### PR TITLE
Longer readiness timeout for Nuclio functions

### DIFF
--- a/demo/taxi-demo/Chart.yaml
+++ b/demo/taxi-demo/Chart.yaml
@@ -1,5 +1,5 @@
 name: taxi-demo
-version: 0.2.7
+version: 0.2.8
 description: V3IO Taxi Demo
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2017/09/iguazio_logo_2017_w_c.png

--- a/demo/taxi-demo/templates/demo-function.yaml
+++ b/demo/taxi-demo/templates/demo-function.yaml
@@ -15,6 +15,7 @@ spec:
   maxReplicas: 1
   minReplicas: 1
   runtime: {{ $val.runtime }}
+  readinessTimeoutSeconds: {{ $val.readinessTimeoutSeconds }}
   build:
     commands: 
     {{- range $val := $val.commands }}

--- a/demo/taxi-demo/values.yaml
+++ b/demo/taxi-demo/values.yaml
@@ -15,6 +15,7 @@ v3io:
       url: generate-data:8080
       handler: "functions.generate_data.generate_data:handler"
       runtime: "python:3.6"
+      readinessTimeoutSeconds: 180
       projectName: "taxi-demo"
       commands:
         - pip install requests==2.19.1
@@ -29,6 +30,7 @@ v3io:
       url: ingest:8080
       handler: "functions.ingest.ingest:handler"
       runtime: "python:3.6"
+      readinessTimeoutSeconds: 180
       projectName: "taxi-demo"
       commands:
         - pip install requests==2.19.1


### PR DESCRIPTION
Allow 3 minutes for nuclio functions to become ready, rather than the default 30 seconds