### PR TITLE
Added Zeppelin Iguazio Example

### DIFF
--- a/stable/spark/Chart.yaml
+++ b/stable/spark/Chart.yaml
@@ -1,5 +1,5 @@
 name: spark
-version: 0.5.5
+version: 0.5.6
 appVersion: "2.1.2-1.7.0"
 description: Fast and general-purpose cluster computing system.
 home: http://spark.apache.org

--- a/stable/spark/templates/spark-zeppelin-notebook-configmap.yaml
+++ b/stable/spark/templates/spark-zeppelin-notebook-configmap.yaml
@@ -11,7 +11,7 @@ metadata:
   name: {{ template "spark.zeppelin-name" . }}-notebooks
 data:
 {{- range $i, $notebook := .Values.zeppelin.preloadNotebooks.notebooks }}
-{{- with randAlphaNum 7 }}
+{{- with randAlphaNum 9 }}
 {{ default . $notebook.id | indent 2 }}: |
     {
     "paragraphs": [

--- a/stable/spark/templates/spark-zeppelin-notebook-configmap.yaml
+++ b/stable/spark/templates/spark-zeppelin-notebook-configmap.yaml
@@ -11,39 +11,10 @@ metadata:
   name: {{ template "spark.zeppelin-name" . }}-notebooks
 data:
 {{- range $i, $notebook := .Values.zeppelin.preloadNotebooks.notebooks }}
-{{- with randAlphaNum 9 }}
-{{ . | indent 2 }}: |
+{{- with randAlphaNum 7 }}
+{{ default . $notebook.id | indent 2 }}: |
     {
     "paragraphs": [
-{{- if (ne "" $notebook.documentation) -}}
-        {
-        "text": {{ printf "%%md\n%s" $notebook.documentation | quote }},
-        "user": "anonymous",
-        "config": {
-            "colWidth": 12,
-            "enabled": true,
-            "results": {},
-            "editorSetting": {
-            "language": "markdown"
-            },
-            "editorMode": "ace/mode/markdown"
-        },
-        "settings": {
-            "params": {},
-            "forms": {}
-        },
-        "apps": [],
-        "jobName": "paragraph_{{ randNumeric 13 }}_{{ randNumeric 9 }}",
-        "id": "{{ date "20060102-150405" now }}_{{ randNumeric 9 }}",
-        "dateCreated": "{{ date "2006-01-02 15:04:05.999" now }}",
-        "dateUpdated": "{{ date "2006-01-02 15:04:05.999" now }}",
-        "dateStarted": "{{ date "2006-01-02 15:04:05.999" now }}",
-        "dateFinished": "{{ date "2006-01-02 15:04:05.999" now }}",
-        "status": "FINISHED",
-        "errorMessage": "",
-        "progressUpdateIntervalMs": 500
-        }{{ if (gt (len $notebook.sections) 0) }},{{ end }}
-{{- end -}}
 {{- range $j, $section := $notebook.sections }}
         {
 {{- if $section.title -}}
@@ -61,7 +32,8 @@ data:
             "editorSetting": {
             "language": "{{ $section.language }}"
             },
-            "editorMode": "ace/mode/{{ $section.language }}"
+            "editorMode": "ace/mode/{{ $section.language }}",
+            "editorHide": {{ default false $section.editorHide }}
         },
         "settings": {
             "params": {},
@@ -76,12 +48,23 @@ data:
         "dateFinished": "{{ date "2006-01-02 15:04:05.999" now }}",
         "status": "FINISHED",
         "errorMessage": "",
+{{- if $section.result}}
+        "results": {
+            "code": "SUCCESS",
+            "msg": [
+               {
+                   "type": {{ $section.result.type | quote }},
+                   "data": {{ $section.result.data | quote }}
+               }
+            ]
+        },
+{{- end}}
         "progressUpdateIntervalMs": 500
         }{{ if (lt $j (sub (len $notebook.sections) 1)) }},{{ end }}
 {{- end }}
     ],
     "name": "{{ $notebook.title }}",
-    "id": "{{ . }}",
+    "id": "{{ default . $notebook.id }}",
     "config": {
         "looknfeel": "default",
         "personalizedMode": "false"

--- a/stable/spark/values.yaml
+++ b/stable/spark/values.yaml
@@ -60,171 +60,203 @@ zeppelin:
   preloadNotebooks:
     enabled: true
     notebooks: 
-       - title: Iguazio Getting Started Example
-         documentation: |-
-             This note contains code examples for performing common tasks to help you get started with the Iguazio Continous Data Platform ("the platform").
-             Follow the tutorial by running the note paragraphs in order of appearance.
+      - id: getting-started
+        title: Iguazio Getting Started Example
+        sections:
 
-             > **Tip:** You can also browse the files and directories that you write to the "bigdata" container in this tutorial from the platform dashboard: in the side navigation menu, select **Data**, and then select the **bigdata** container from the table. On the container data page, select the **Browse** tab, and then use the side directory-navigation tree to browse the directories. Selecting a file or directory in the browse table displays its metadata.
+        - language: md
+          content: |-
+            %md
 
-             For more information about the platform including tutorial, demos, and code examples &; read [the platform documentation](https://www.iguazio.com/docs/).
-             For technical questions and assistance, don't hestistate to contact support@iguazio.com.
+            This note contains code examples for performing common tasks to help you get started with the Iguazio Continous Data Platform ("the platform").
+            Follow the tutorial by running the note paragraphs in order of appearance.
 
-         sections:
+            > **Tip:** You can also browse the files and directories that you write to the "bigdata" container in this tutorial from the platform dashboard: in the side navigation menu, select **Data**, and then select the **bigdata** container from the table. On the container data page, select the **Browse** tab, and then use the side directory-navigation tree to browse the directories. Selecting a file or directory in the browse table displays its metadata.
 
-         - language: md
-           title: Step 1  Ingest a sample CSV file into the platform
-           content: |-
-             %md
+            For more information about the platform including tutorial, demos, and code examples &; read [the platform documentation](https://www.iguazio.com/docs/).
+            For technical questions and assistance, don't hestistate to contact support@iguazio.com.
+          editorHide: true
+          result:
+            type: HTML
+            data: "<div class=\"markdown-body\">\n<p>This note contains code examples for performing common tasks to help you get started with the Iguazio Continous Data Platform (&ldquo;the platform&rdquo;).<br/>Follow the tutorial by running the note paragraphs in order of appearance.</p>\n<blockquote>\n  <p><strong>Tip:</strong> You can also browse the files and directories that you write to the &ldquo;bigdata&rdquo; container in this tutorial from the platform dashboard: in the side navigation menu, select <strong>Data</strong>, and then select the <strong>bigdata</strong> container from the table. On the container data page, select the <strong>Browse</strong> tab, and then use the side directory-navigation tree to browse the directories. Selecting a file or directory in the browse table displays its metadata.</p>\n</blockquote>\n<p>For more information about the platform including tutorial, demos, and code examples &amp;; read <a href=\"https://www.iguazio.com/docs/\">the platform documentation</a>.<br/>For technical questions and assistance, don&rsquo;t hestistate to contact <a href=\"mailto:&#115;u&#112;&#x70;&#x6f;&#x72;&#x74;&#64;&#x69;&#x67;u&#97;&#x7a;&#105;o&#46;&#99;&#111;m\">&#115;u&#112;&#x70;&#x6f;&#x72;&#x74;&#64;&#x69;&#x67;u&#97;&#x7a;&#105;o&#46;&#99;&#111;m</a>.</p>\n</div>"
 
-             Use `curl` to download the sample **bank.csv** file that is used in Zeppelin's getting-started tutorial from [the Amazon S3 website](https://s3.amazonaws.com/apache-zeppelin/tutorial/bank/bank.csv) to the **/tmp** directory in the local file system of your platform. Then, use `hadoop fs` to move the file from the local file system to a new **zeppelin_getting_started_example** directory in the platform's "bigdata" data container.  
+        - language: md
+          title: "Step 1: Ingest a sample CSV file into the platform"
+          content: |-
+            %md
 
-         - language: sh
-           content: |-
-             %sh 
+            Use `curl` to download the sample **bank.csv** file that is used in Zeppelin's getting-started tutorial from [the Amazon S3 website](https://s3.amazonaws.com/apache-zeppelin/tutorial/bank/bank.csv) to the **/tmp** directory in the local file system of your platform. Then, use `hadoop fs` to move the file from the local file system to a new **zeppelin_getting_started_example** directory in the platform's "bigdata" data container.  
+          editorHide: true
+          result:
+            type: HTML
+            data: "<div class=\"markdown-body\">\n<p>Use <code>curl</code> to download the sample <strong>bank.csv</strong> file that is used in Zeppelin&rsquo;s getting-started tutorial from <a href=\"https://s3.amazonaws.com/apache-zeppelin/tutorial/bank/bank.csv\">the Amazon S3 website</a> to the <strong>/tmp</strong> directory in the local file system of your platform. Then, use <code>hadoop fs</code> to move the file from the local file system to a new <strong>zeppelin_getting_started_example</strong> directory in the platform&rsquo;s &ldquo;bigdata&rdquo; data container.</p>\n</div>"
 
-             # Download the sample bank.csv file that is used in the basic Zeppelin Tutorial from the AWS S3 web site to the local /tmp directory
-             curl "https://s3.amazonaws.com/apache-zeppelin/tutorial/bank/bank.csv" > /tmp/bank.csv
+        - language: sh
+          content: |-
+            %sh 
 
-             # Create a zeppelin_getting_started_example directory in the "bigdata" container of your platform cluster
-             hadoop fs -mkdir v3io://bigdata/zeppelin_getting_started_example
+            # Download the sample bank.csv file that is used in the basic Zeppelin Tutorial from the AWS S3 web site to the local /tmp directory
+            curl "https://s3.amazonaws.com/apache-zeppelin/tutorial/bank/bank.csv" > /tmp/bank.csv
 
-             # Move the CSV file from the local file-system /tmp directory to the new zeppelin_getting_started_example directory in the "bigdata" container
-             hadoop fs -moveFromLocal /tmp/bank.csv v3io://bigdata/zeppelin_getting_started_example/
+            # Create a zeppelin_getting_started_example directory in the "bigdata" container of your platform cluster
+            hadoop fs -mkdir v3io://bigdata/zeppelin_getting_started_example
 
-             # Verify that the "bigdata" container now has a zeppelin_getting_started_example directory with the bank.csv file
-             hadoop fs -ls v3io://bigdata/zeppelin_getting_started_example/
+            # Move the CSV file from the local file-system /tmp directory to the new zeppelin_getting_started_example directory in the "bigdata" container
+            hadoop fs -moveFromLocal /tmp/bank.csv v3io://bigdata/zeppelin_getting_started_example/
 
-         - language: md
-           title: Step 2 Convert the sample CSV file to a NoSQL table
-           content: |-
-             %md
+            # Verify that the "bigdata" container now has a zeppelin_getting_started_example directory with the bank.csv file
+            hadoop fs -ls v3io://bigdata/zeppelin_getting_started_example/
 
-             Read the sample **bank.csv** file that you downloaded in Step 1 into a Spark DataFrame, and write the data in NoSQL format to a new **bank_nosql** table in the **zeppelin_getting_started_example** directory that you created in the "bigdata" container.
-             Before writing the CSV file to the NoSQL table, add an `"id"` column with unique values to the DataFrame. This column will serve as the table's primary-key attribute, which uniquely identifies the table items.
-             > **Note:** To use the Iguazio Spark Connector to read and write data in the platform, set the data-source format in the call to the Spark DataFrame `format` method to the platform's custom NoSQL data source `"io.iguaz.v3io.spark.sql.kv"`.
+        - language: md
+          title: "Step 2: Convert the sample CSV file to a NoSQL table"
+          content: |-
+            %md
 
-         - language: spark
-           content: |-
-             %spark
+            Read the sample **bank.csv** file that you downloaded in Step 1 into a Spark DataFrame, and write the data in NoSQL format to a new **bank_nosql** table in the **zeppelin_getting_started_example** directory that you created in the "bigdata" container.
+            Before writing the CSV file to the NoSQL table, add an `"id"` column with unique values to the DataFrame. This column will serve as the table's primary-key attribute, which uniquely identifies the table items.
+            > **Note:** To use the Iguazio Spark Connector to read and write data in the platform, set the data-source format in the call to the Spark DataFrame `format` method to the platform's custom NoSQL data source `"io.iguaz.v3io.spark.sql.kv"`.
+          editorHide: true
+          result:
+            type: HTML
+            data: "<div class=\"markdown-body\">\n<p>Read the sample <strong>bank.csv</strong> file that you downloaded in Step 1 into a Spark DataFrame, and write the data in NoSQL format to a new <strong>bank_nosql</strong> table in the <strong>zeppelin_getting_started_example</strong> directory that you created in the &ldquo;bigdata&rdquo; container.<br/>Before writing the CSV file to the NoSQL table, add an <code>&quot;id&quot;</code> column with unique values to the DataFrame. This column will serve as the table&rsquo;s primary-key attribute, which uniquely identifies the table items.</p>\n<blockquote>\n  <p><strong>Note:</strong> To use the Iguazio Spark Connector to read and write data in the platform, set the data-source format in the call to the Spark DataFrame <code>format</code> method to the platform&rsquo;s custom NoSQL data source <code>&quot;io.iguaz.v3io.spark.sql.kv&quot;</code>.</p>\n</blockquote>\n</div>"
 
-             import org.apache.spark.sql.SparkSession
+        - language: spark
+          content: |-
+            %spark
 
-             // Read the sample bank.csv file from the zeppelin_getting_started_example "bigdata" container into a Spark DataFrame, and let Spark infer the schema of the CSV file
-             val myDF = spark.read.option("header", "true").option("delimiter", ";").option("inferSchema", "true").csv("v3io://bigdata/zeppelin_getting_started_example/bank.csv")
+            import org.apache.spark.sql.SparkSession
 
-             // Add an "id" column with unique auto-generated sequential values
-             val nosqlDF = myDF.withColumn("id", monotonically_increasing_id+1)
+            // Read the sample bank.csv file from the zeppelin_getting_started_example "bigdata" container into a Spark DataFrame, and let Spark infer the schema of the CSV file
+            val myDF = spark.read.option("header", "true").option("delimiter", ";").option("inferSchema", "true").csv("v3io://bigdata/zeppelin_getting_started_example/bank.csv")
 
-             // Show the DataFrame data
-             nosqlDF.show()
+            // Add an "id" column with unique auto-generated sequential values
+            val nosqlDF = myDF.withColumn("id", monotonically_increasing_id+1)
 
-             // Write the DataFrame data to a zeppelin_example/bank_nosql NoSQL table in the platform's "bigdata" container.
-             // The data source is set in the format call to "io.iguaz.v3io.spark.sql.kv" - the platform's custom NoSQL data source.
-             // The "id" column (attribute) is defined as the table's primary-key attribute, which uniquely identifies table items.
-             nosqlDF.write.format("io.iguaz.v3io.spark.sql.kv").mode("append").option("key", "id").save("v3io://bigdata/zeppelin_getting_started_example/bank_nosql/")
+            // Show the DataFrame data
+            nosqlDF.show()
 
-             // Show the schema of of the DataFrame data
-             nosqlDF.printSchema()
+            // Write the DataFrame data to a zeppelin_example/bank_nosql NoSQL table in the platform's "bigdata" container.
+            // The data source is set in the format call to "io.iguaz.v3io.spark.sql.kv" - the platform's custom NoSQL data source.
+            // The "id" column (attribute) is defined as the table's primary-key attribute, which uniquely identifies table items.
+            nosqlDF.write.format("io.iguaz.v3io.spark.sql.kv").mode("append").option("key", "id").save("v3io://bigdata/zeppelin_getting_started_example/bank_nosql/")
 
-             // Create a temporay view named "bank" for quering the DataFrame data using Spark SQL
-             nosqlDF.createOrReplaceTempView("bank")
+            // Show the schema of of the DataFrame data
+            nosqlDF.printSchema()
 
-
-         - language: md
-           title: Step 3 Query the data with the Scala Spark interpreter
-
-           content: |-
-             %md
-
-             Use the Scala Spark interpreter (`%spark`) to query the temporary `bank` view for the average bank balance for each age. 
-
-
-         - language: spark
-           content: |-
-             %spark
-
-             // Use Spark SQL to query the temporary "bank" view 
-             val sqlDF = spark.sql("select age, round(avg(balance)) from bank group by age order by age asc")
-
-             // Show the first 10 lines of the query result
-             sqlDF.show(10)
-
-         - language: md
-           title: Step 4 Query the data with the SQL interpreter
-
-           content: |-
-             %md
-
-             Use the SQL interpreter (`%sql`) to query the temporary `bank` view for the number customers in each age under 30 and visualize the results graphically.
+            // Create a temporay view named "bank" for quering the DataFrame data using Spark SQL
+            nosqlDF.createOrReplaceTempView("bank")
 
 
-         - language: sql
-           content: |-
-             %sql
+        - language: md
+          title: "Step 3: Query the data with the Scala Spark interpreter"
 
-             select age, count(1) value
-             from bank 
-             where age < 30 
-             group by age 
-             order by age
+          content: |-
+            %md
 
-         - language: md
-           title: Step 5 Convert the NoSQL table to a Parquet table
+            Use the Scala Spark interpreter (`%spark`) to query the temporary `bank` view for the average bank balance for each age. 
+          editorHide: true
+          result:
+            type: HTML
+            data: "<div class=\"markdown-body\">\n<p>Use the Scala Spark interpreter (<code>%spark</code>) to query the temporary <code>bank</code> view for the average bank balance for each age.</p>\n</div>"
 
-           content: |-
-             %md
+        - language: spark
+          content: |-
+            %spark
 
-             Read the **zeppelin_getting_started_example/bank_nosql** table from the "bigdata" container into a Spark DataFrame, and write the data in Parquet format to a new **zeppelin_getting_started_example/bank_prqt** table in the "bigdata" container.
+            // Use Spark SQL to query the temporary "bank" view 
+            val sqlDF = spark.sql("select age, round(avg(balance)) from bank group by age order by age asc")
+
+            // Show the first 10 lines of the query result
+            sqlDF.show(10)
+
+        - language: md
+          title: "Step 4: Query the data with the SQL interpreter"
+
+          content: |-
+            %md
+
+            Use the SQL interpreter (`%sql`) to query the temporary `bank` view for the number customers in each age under 30 and visualize the results graphically.
+          editorHide: true
+          result:
+            type: HTML
+            data: "<div class=\"markdown-body\">\n<p>Use the SQL interpreter (<code>%sql</code>) to query the temporary <code>bank</code> view for the number customers in each age under 30 and visualize the results graphically.</p>\n</div>"
+
+        - language: sql
+          content: |-
+            %sql
+
+            select age, count(1) value
+            from bank 
+            where age < 30 
+            group by age 
+            order by age
+
+        - language: md
+          title: "Step 5: Convert the NoSQL table to a Parquet table"
+
+          content: |-
+            %md
+
+            Read the **zeppelin_getting_started_example/bank_nosql** table from the "bigdata" container into a Spark DataFrame, and write the data in Parquet format to a new **zeppelin_getting_started_example/bank_prqt** table in the "bigdata" container.
+          editorHide: true
+          result:
+            type: HTML
+            data: "<div class=\"markdown-body\">\n<p>Read the <strong>zeppelin_getting_started_example/bank_nosql</strong> table from the &ldquo;bigdata&rdquo; container into a Spark DataFrame, and write the data in Parquet format to a new <strong>zeppelin_getting_started_example/bank_prqt</strong> table in the &ldquo;bigdata&rdquo; container.</p>\n</div>"
+
+        - language: spark
+          content: |-
+            %spark
+
+            // Read the contents of the zeppelin_getting_started_example/bank_nosql NoSQL table in the platform's "bigdata" container into a Spark DataFrame
+            val prqtDF = spark.read.format("io.iguaz.v3io.spark.sql.kv").load("v3io://bigdata/zeppelin_getting_started_example/bank_nosql/")
+
+            // Write the DataFrame data in Parquet format to a zeppelin_getting_started_example/bank_prqt table in the "bigdata" container
+            prqtDF.write.format("parquet").mode("append").save("v3io://bigdata/zeppelin_getting_started_example/bank_prqt/")
 
 
-         - language: spark
-           content: |-
-             %spark
+        - language: md
+          title: "Step 6: Display the contents of the example container directory"
 
-             // Read the contents of the zeppelin_getting_started_example/bank_nosql NoSQL table in the platform's "bigdata" container into a Spark DataFrame
-             val prqtDF = spark.read.format("io.iguaz.v3io.spark.sql.kv").load("v3io://bigdata/zeppelin_getting_started_example/bank_nosql/")
+          content: |-
+            %md
 
-             // Write the DataFrame data in Parquet format to a zeppelin_getting_started_example/bank_prqt table in the "bigdata" container
-             prqtDF.write.format("parquet").mode("append").save("v3io://bigdata/zeppelin_getting_started_example/bank_prqt/")
+            Use `hadoop fs` to list the contents of the **zeppelin_getting_started_example** directory in the platform's "bigdata" container.
+            You should see in this directory the **bank.csv** file and the **bank_nosql** and **bank_prqt** table directories.
+          editorHide: true
+          result:
+            type: HTML
+            data: "<div class=\"markdown-body\">\n<p>Use <code>hadoop fs</code> to list the contents of the <strong>zeppelin_getting_started_example</strong> directory in the platform&rsquo;s &ldquo;bigdata&rdquo; container.<br/>You should see in this directory the <strong>bank.csv</strong> file and the <strong>bank_nosql</strong> and <strong>bank_prqt</strong> table directories.</p>\n</div>"
 
+        - language: sh
+          content: |-
+            %sh
 
-         - language: md
-           title: Step 6 Display the contents of the example container directory
+            # List the files and directories in the "zeppelin_getting_started_example" directory in the "bigdata" container
+            hadoop fs -ls v3io://bigdata/zeppelin_getting_started_example
 
-           content: |-
-             %md
+        - language: md
+          title: "Step 7: Cleanup"
 
-             Use `hadoop fs` to list the contents of the **zeppelin_getting_started_example** directory in the platform's "bigdata" container.
-             You should see in this directory the **bank.csv** file and the **bank_nosql** and **bank_prqt** table directories.
+          content: |-
+            %md
 
+            When you are done, you can optionally delete the files and directories created in this tutorial.
+            The clean up is done with the `hadoop fs -rm -r` command.
+          editorHide: true
+          result:
+            type: HTML
+            data: "<div class=\"markdown-body\">\n<p>When you are done, you can optionally delete the files and directories created in this tutorial.<br/>The clean up is done with the <code>hadoop fs -rm -r</code> command.</p>\n</div>"
 
-         - language: sh
-           content: |-
-             %sh
+        - language: sh
+          content: |-
+            %spark
+            %sh
 
-             # List the files and directories in the "zeppelin_getting_started_example" directory in the "bigdata" container
-             hadoop fs -ls v3io://bigdata/zeppelin_getting_started_example
+            # Delete the zeppelin_getting_started_example directory in the "bigdata" container
+            hadoop fs -rm -r v3io://bigdata/zeppelin_getting_started_example/
 
-         - language: md
-           title: Step 7 Cleanup
-
-           content: |-
-             %md
-
-             When you are done, you can optionally delete the files and directories created in this tutorial.
-             The clean up is done with the `hadoop fs -rm -r` command.
-
-         - language: sh
-           content: |-
-             %spark
-             %sh
-
-             # Delete the zeppelin_getting_started_example directory in the "bigdata" container
-             hadoop fs -rm -r v3io://bigdata/zeppelin_getting_started_example/
-
-             # Verfiy that the "bigdata" container no longer has a zeppelin_getting_started_example directory
-             hadoop fs -ls v3io://bigdata/
+            # Verfiy that the "bigdata" container no longer has a zeppelin_getting_started_example directory
+            hadoop fs -ls v3io://bigdata/
 
 
 environment:

--- a/stable/spark/values.yaml
+++ b/stable/spark/values.yaml
@@ -59,25 +59,173 @@ zeppelin:
 
   preloadNotebooks:
     enabled: true
-    notebooks: {}
-    # - title: "Demo Notebook"
-    #   documentation: |-
-    #     ## Title ##
-    #     This section actually supports Markdown syntax!
-    #   sections:
-    #   - language: scala (python, sh, sql, etc.)
-    #     title: my section title
-    #     content: |-
-    #       import org.apache.spark.sql.types._
-    #       import org.apache.spark.sql.functions._
-    #       val schema = StructType(List(
-    #               StructField("__name", StringType),
-    #               StructField("count", LongType)
-    #           ))
-    #       val df = sqlContext.read
-    #                   .schema(schema)
-    #                   .load("/data")
-    #       df.where($"count" > 10).orderBy(desc("count")).show()
+    notebooks: 
+       - title: Iguazio Getting Started Example
+         documentation: |-
+             This note contains code examples for performing common tasks to help you get started with the Iguazio Continous Data Platform ("the platform").
+             Follow the tutorial by running the note paragraphs in order of appearance.
+
+             > **Tip:** You can also browse the files and directories that you write to the "bigdata" container in this tutorial from the platform dashboard: in the side navigation menu, select **Data**, and then select the **bigdata** container from the table. On the container data page, select the **Browse** tab, and then use the side directory-navigation tree to browse the directories. Selecting a file or directory in the browse table displays its metadata.
+
+             For more information about the platform including tutorial, demos, and code examples &; read [the platform documentation](https://www.iguazio.com/docs/).
+             For technical questions and assistance, don't hestistate to contact support@iguazio.com.
+
+         sections:
+
+         - language: md
+           title: Step 1  Ingest a sample CSV file into the platform
+           content: |-
+             %md
+
+             Use `curl` to download the sample **bank.csv** file that is used in Zeppelin's getting-started tutorial from [the Amazon S3 website](https://s3.amazonaws.com/apache-zeppelin/tutorial/bank/bank.csv) to the **/tmp** directory in the local file system of your platform. Then, use `hadoop fs` to move the file from the local file system to a new **zeppelin_getting_started_example** directory in the platform's "bigdata" data container.  
+
+         - language: sh
+           content: |-
+             %sh 
+
+             # Download the sample bank.csv file that is used in the basic Zeppelin Tutorial from the AWS S3 web site to the local /tmp directory
+             curl "https://s3.amazonaws.com/apache-zeppelin/tutorial/bank/bank.csv" > /tmp/bank.csv
+
+             # Create a zeppelin_getting_started_example directory in the "bigdata" container of your platform cluster
+             hadoop fs -mkdir v3io://bigdata/zeppelin_getting_started_example
+
+             # Move the CSV file from the local file-system /tmp directory to the new zeppelin_getting_started_example directory in the "bigdata" container
+             hadoop fs -moveFromLocal /tmp/bank.csv v3io://bigdata/zeppelin_getting_started_example/
+
+             # Verify that the "bigdata" container now has a zeppelin_getting_started_example directory with the bank.csv file
+             hadoop fs -ls v3io://bigdata/zeppelin_getting_started_example/
+
+         - language: md
+           title: Step 2 Convert the sample CSV file to a NoSQL table
+           content: |-
+             %md
+
+             Read the sample **bank.csv** file that you downloaded in Step 1 into a Spark DataFrame, and write the data in NoSQL format to a new **bank_nosql** table in the **zeppelin_getting_started_example** directory that you created in the "bigdata" container.
+             Before writing the CSV file to the NoSQL table, add an `"id"` column with unique values to the DataFrame. This column will serve as the table's primary-key attribute, which uniquely identifies the table items.
+             > **Note:** To use the Iguazio Spark Connector to read and write data in the platform, set the data-source format in the call to the Spark DataFrame `format` method to the platform's custom NoSQL data source `"io.iguaz.v3io.spark.sql.kv"`.
+
+         - language: spark
+           content: |-
+             %spark
+
+             import org.apache.spark.sql.SparkSession
+
+             // Read the sample bank.csv file from the zeppelin_getting_started_example "bigdata" container into a Spark DataFrame, and let Spark infer the schema of the CSV file
+             val myDF = spark.read.option("header", "true").option("delimiter", ";").option("inferSchema", "true").csv("v3io://bigdata/zeppelin_getting_started_example/bank.csv")
+
+             // Add an "id" column with unique auto-generated sequential values
+             val nosqlDF = myDF.withColumn("id", monotonically_increasing_id+1)
+
+             // Show the DataFrame data
+             nosqlDF.show()
+
+             // Write the DataFrame data to a zeppelin_example/bank_nosql NoSQL table in the platform's "bigdata" container.
+             // The data source is set in the format call to "io.iguaz.v3io.spark.sql.kv" - the platform's custom NoSQL data source.
+             // The "id" column (attribute) is defined as the table's primary-key attribute, which uniquely identifies table items.
+             nosqlDF.write.format("io.iguaz.v3io.spark.sql.kv").mode("append").option("key", "id").save("v3io://bigdata/zeppelin_getting_started_example/bank_nosql/")
+
+             // Show the schema of of the DataFrame data
+             nosqlDF.printSchema()
+
+             // Create a temporay view named "bank" for quering the DataFrame data using Spark SQL
+             nosqlDF.createOrReplaceTempView("bank")
+
+
+         - language: md
+           title: Step 3 Query the data with the Scala Spark interpreter
+
+           content: |-
+             %md
+
+             Use the Scala Spark interpreter (`%spark`) to query the temporary `bank` view for the average bank balance for each age. 
+
+
+         - language: spark
+           content: |-
+             %spark
+
+             // Use Spark SQL to query the temporary "bank" view 
+             val sqlDF = spark.sql("select age, round(avg(balance)) from bank group by age order by age asc")
+
+             // Show the first 10 lines of the query result
+             sqlDF.show(10)
+
+         - language: md
+           title: Step 4 Query the data with the SQL interpreter
+
+           content: |-
+             %md
+
+             Use the SQL interpreter (`%sql`) to query the temporary `bank` view for the number customers in each age under 30 and visualize the results graphically.
+
+
+         - language: sql
+           content: |-
+             %sql
+
+             select age, count(1) value
+             from bank 
+             where age < 30 
+             group by age 
+             order by age
+
+         - language: md
+           title: Step 5 Convert the NoSQL table to a Parquet table
+
+           content: |-
+             %md
+
+             Read the **zeppelin_getting_started_example/bank_nosql** table from the "bigdata" container into a Spark DataFrame, and write the data in Parquet format to a new **zeppelin_getting_started_example/bank_prqt** table in the "bigdata" container.
+
+
+         - language: spark
+           content: |-
+             %spark
+
+             // Read the contents of the zeppelin_getting_started_example/bank_nosql NoSQL table in the platform's "bigdata" container into a Spark DataFrame
+             val prqtDF = spark.read.format("io.iguaz.v3io.spark.sql.kv").load("v3io://bigdata/zeppelin_getting_started_example/bank_nosql/")
+
+             // Write the DataFrame data in Parquet format to a zeppelin_getting_started_example/bank_prqt table in the "bigdata" container
+             prqtDF.write.format("parquet").mode("append").save("v3io://bigdata/zeppelin_getting_started_example/bank_prqt/")
+
+
+         - language: md
+           title: Step 6 Display the contents of the example container directory
+
+           content: |-
+             %md
+
+             Use `hadoop fs` to list the contents of the **zeppelin_getting_started_example** directory in the platform's "bigdata" container.
+             You should see in this directory the **bank.csv** file and the **bank_nosql** and **bank_prqt** table directories.
+
+
+         - language: sh
+           content: |-
+             %sh
+
+             # List the files and directories in the "zeppelin_getting_started_example" directory in the "bigdata" container
+             hadoop fs -ls v3io://bigdata/zeppelin_getting_started_example
+
+         - language: md
+           title: Step 7 Cleanup
+
+           content: |-
+             %md
+
+             When you are done, you can optionally delete the files and directories created in this tutorial.
+             The clean up is done with the `hadoop fs -rm -r` command.
+
+         - language: sh
+           content: |-
+             %spark
+             %sh
+
+             # Delete the zeppelin_getting_started_example directory in the "bigdata" container
+             hadoop fs -rm -r v3io://bigdata/zeppelin_getting_started_example/
+
+             # Verfiy that the "bigdata" container no longer has a zeppelin_getting_started_example directory
+             hadoop fs -ls v3io://bigdata/
+
 
 environment:
   template: v3io-configs.deployment.env
@@ -90,8 +238,8 @@ volumes:
     volumesTemplate: v3io-configs.deployment.mount
     volumeMountsTemplate: v3io-configs.deployment.volumeMounts
   zeppelin:
-    volumesTemplate: v3io-configs.deployment.mount-with-fuse
-    volumeMountsTemplate: v3io-configs.deployment.volumeMounts-with-fuse
+    volumesTemplate: v3io-configs.deployment.mount
+    volumeMountsTemplate: v3io-configs.deployment.volumeMounts
 
 debug:
   enabled: false

--- a/stable/spark/values.yaml
+++ b/stable/spark/values.yaml
@@ -48,8 +48,8 @@ zeppelin:
   servicePort: 8080
   containerPort: 8080
   # nodePort: 32100
-  storage:
-    path: /v3io/bigdata/.services/zeppelin/notebook
+  storage: {}
+  #   path: /v3io/bigdata/.services/zeppelin/notebook
 
   resources: {}
     # limits:
@@ -271,8 +271,8 @@ volumes:
     volumesTemplate: v3io-configs.deployment.mount
     volumeMountsTemplate: v3io-configs.deployment.volumeMounts
   zeppelin:
-    volumesTemplate: v3io-configs.deployment.mount
-    volumeMountsTemplate: v3io-configs.deployment.volumeMounts
+    volumesTemplate: v3io-configs.deployment.mount-with-fuse
+    volumeMountsTemplate: v3io-configs.deployment.volumeMounts-with-fuse
 
 debug:
   enabled: false

--- a/stable/spark/values.yaml
+++ b/stable/spark/values.yaml
@@ -87,27 +87,21 @@ zeppelin:
           content: |-
             %md
 
-            Use `curl` to download the sample **bank.csv** file that is used in Zeppelin's getting-started tutorial from [the Amazon S3 website](https://s3.amazonaws.com/apache-zeppelin/tutorial/bank/bank.csv) to the **/tmp** directory in the local file system of your platform. Then, use `hadoop fs` to move the file from the local file system to a new **zeppelin_getting_started_example** directory in the platform's "bigdata" data container.  
+            Use `curl` to download the sample **bank.csv** file that is used in Zeppelin's getting-started tutorial from [the Amazon S3 website](https://s3.amazonaws.com/apache-zeppelin/tutorial/bank/bank.csv) to the **zeppelin_getting_started_example** directory in the platform's "bigdata" data container. 
           editorHide: true
           result:
             type: HTML
-            data: "<div class=\"markdown-body\">\n<p>Use <code>curl</code> to download the sample <strong>bank.csv</strong> file that is used in Zeppelin&rsquo;s getting-started tutorial from <a href=\"https://s3.amazonaws.com/apache-zeppelin/tutorial/bank/bank.csv\">the Amazon S3 website</a> to the <strong>/tmp</strong> directory in the local file system of your platform. Then, use <code>hadoop fs</code> to move the file from the local file system to a new <strong>zeppelin_getting_started_example</strong> directory in the platform&rsquo;s &ldquo;bigdata&rdquo; data container.</p>\n</div>"
+            data: "<div class=\"markdown-body\">\n<p>Use <code>curl</code> to download the sample <strong>bank.csv</strong> file that is used in Zeppelin&rsquo;s getting-started tutorial from <a href=\"https://s3.amazonaws.com/apache-zeppelin/tutorial/bank/bank.csv\">the Amazon S3 website</a> to the <strong>zeppelin_getting_started_example</strong> directory in the platform&rsquo;s &ldquo;bigdata&rdquo; data container.</p>\n</div>"
 
         - language: sh
           content: |-
             %sh 
 
-            # Download the sample bank.csv file that is used in the basic Zeppelin Tutorial from the AWS S3 web site to the local /tmp directory
-            curl "https://s3.amazonaws.com/apache-zeppelin/tutorial/bank/bank.csv" > /tmp/bank.csv
-
             # Create a zeppelin_getting_started_example directory in the "bigdata" container of your platform cluster
-            hadoop fs -mkdir v3io://bigdata/zeppelin_getting_started_example
+            mkdir -p /v3io/bigdata/zeppelin_getting_started_example
 
-            # Move the CSV file from the local file-system /tmp directory to the new zeppelin_getting_started_example directory in the "bigdata" container
-            hadoop fs -moveFromLocal /tmp/bank.csv v3io://bigdata/zeppelin_getting_started_example/
-
-            # Verify that the "bigdata" container now has a zeppelin_getting_started_example directory with the bank.csv file
-            hadoop fs -ls v3io://bigdata/zeppelin_getting_started_example/
+            # Download the sample bank.csv file that is used in the basic Zeppelin Tutorial from the AWS S3 web site to the local /tmp directory
+            curl -L "https://s3.amazonaws.com/apache-zeppelin/tutorial/bank/bank.csv" > /v3io/bigdata/zeppelin_getting_started_example/bank.csv
 
         - language: md
           title: "Step 2: Convert the sample CSV file to a NoSQL table"


### PR DESCRIPTION
NirSe:
- Added getting started preloaded notebook

EranD:
- Supported specifying ID in preloaded notebook to allow static link (e.g. `#/notebook/getting-started`)
- Added support for "editorHide" for documentation sections - user doesn't need to see markdown, only resulting HTML
- Added support for results for things like markdown sections
- Removed "documentation" portion in preloaded notebook as documentation is commonly a repeating number of sections
