### PR TITLE
IG-10645: update dayman default configuration

### DIFF
--- a/stable/v3iod/Chart.yaml
+++ b/stable/v3iod/Chart.yaml
@@ -1,5 +1,5 @@
 name: v3iod
-version: 0.9.3
+version: 0.9.4
 appVersion: ">=1.9.4"
 description: v3io daemon
 home: https://iguazio.com

--- a/stable/v3iod/values.yaml
+++ b/stable/v3iod/values.yaml
@@ -26,7 +26,7 @@ v3iod:
   maxInFlightRequests: 4096
   maxChannelInactivitySeconds: 180
   numHugePages: 3000
-  numOfWorkers: 2
+  numOfWorkers: 1
   boostSizeInBytes: 536870912
   disableRDMA: false
   heaps: |

--- a/stable/v3iod/values.yaml
+++ b/stable/v3iod/values.yaml
@@ -21,39 +21,49 @@ v3iod:
     # requests:
       # cpu: 1
       # memory: "3Gi"
-    
+
   cdiPort: 1967
-  maxInFlightRequests: 1024
+  maxInFlightRequests: 4096
   maxChannelInactivitySeconds: 180
   numHugePages: 3000
-  numOfWorkers: 1
-  boostSizeInBytes: 10000000
+  numOfWorkers: 2
+  boostSizeInBytes: 536870912
   disableRDMA: false
   heaps: |
     {
       "kind": "mempool",
-      "block_size_bytes": 4096,
-      "num_blocks": 10000
+      "block_size_bytes": 5120,
+      "num_blocks": 5000
     },
     {
       "kind": "mempool",
-      "block_size_bytes": 9296,
-      "num_blocks": 10000
+      "block_size_bytes": 20480,
+      "num_blocks": 2000
     },
     {
       "kind": "mempool",
-      "block_size_bytes": 16384,
-      "num_blocks": 10000
+      "block_size_bytes": 73728,
+      "num_blocks": 5000
     },
     {
       "kind": "mempool",
-      "block_size_bytes": 1228800,
+      "block_size_bytes": 286720,
       "num_blocks": 500
     },
     {
       "kind": "mempool",
-      "block_size_bytes": 2228800,
-      "num_blocks": 200
+      "block_size_bytes": 563200,
+      "num_blocks": 500
+    },
+    {
+      "kind": "mempool",
+      "block_size_bytes": 1126400,
+      "num_blocks": 500
+    },
+    {
+      "kind": "mempool",
+      "block_size_bytes": 2150400,
+      "num_blocks": 500
     }
 
   datanodes:


### PR DESCRIPTION
Make the default configuration same as in kompton 
See also: [kompton](https://github.com/iguazio/kompton/blob/development/deploy/roles/hadoop/templates/dayman_config.j2)

Note, in default configuration number of  workers is `2` which means it will claim 2 x 3 Gb of RAM on startup. I would recommend to use single worker on small setups in cloud