### PR TITLE
IG-10883 - add new health check for dayman

### DIFF
--- a/stable/shell/Chart.yaml
+++ b/stable/shell/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: Shell access to data services
 name: shell
-version: 0.7.11
+version: 0.7.12
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2017/09/iguazio_logo_2017_w_c.png
 sources:

--- a/stable/shell/templates/shell-deployment.yaml
+++ b/stable/shell/templates/shell-deployment.yaml
@@ -63,15 +63,15 @@ spec:
               command:
               - /bin/bash
               - {{ .Values.global.v3io.configMountPath }}/health_check.sh
-              initialDelaySeconds: 5
-              periodSeconds: 1
+              initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+              periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           readinessProbe:
             exec:
               command:
               - /bin/bash
               - {{ .Values.global.v3io.configMountPath }}/health_check.sh
-              initialDelaySeconds: 5
-              periodSeconds: 1
+              initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+              periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
 {{- if .Values.environment }}
           env:
 {{ include .Values.environment.template . | indent 12 }}

--- a/stable/shell/templates/v3io-config-configmap.yaml
+++ b/stable/shell/templates/v3io-config-configmap.yaml
@@ -12,3 +12,5 @@ data:
 
   health_check.sh: |
 {{ include "v3io-configs.script.javaHealthCheck" . | indent 4 }}
+    # Test that dayman is alive and accessible
+    hadoop fs -test -e /

--- a/stable/shell/values.yaml
+++ b/stable/shell/values.yaml
@@ -63,7 +63,7 @@ global:
 
 livenessProbe:
   initialDelaySeconds: 5
-  periodSeconds: 10
+  periodSeconds: 5
 readinessProbe:
   initialDelaySeconds: 5
-  periodSeconds: 10
+  periodSeconds: 5

--- a/stable/shell/values.yaml
+++ b/stable/shell/values.yaml
@@ -60,3 +60,10 @@ volumes:
 global:
   v3io:
     configMountPath: /etc/config/v3io
+
+livenessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 10
+readinessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 10

--- a/stable/spark/Chart.yaml
+++ b/stable/spark/Chart.yaml
@@ -1,5 +1,5 @@
 name: spark
-version: 0.7.2
+version: 0.7.3
 appVersion: ">=2.0.0"
 description: Fast and general-purpose cluster computing system.
 home: http://spark.apache.org

--- a/stable/spark/templates/spark-master-configmap.yaml
+++ b/stable/spark/templates/spark-master-configmap.yaml
@@ -10,6 +10,8 @@ metadata:
 data:
   health_check.sh: |
 {{ include "v3io-configs.script.httpHealthCheckWithJava" . | indent 4 }}
+    # Test that dayman is alive and accessible
+    hadoop fs -test -e /
 
   run.sh: |
     #!/usr/bin/env bash

--- a/stable/spark/templates/spark-master-deployment.yaml
+++ b/stable/spark/templates/spark-master-deployment.yaml
@@ -51,16 +51,16 @@ spec:
               - /bin/bash
               - /etc/config/spark/health_check.sh
               - --port={{ .Values.master.webAdmin.containerPort }}
-              initialDelaySeconds: 90
-              periodSeconds: 1
+              initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+              periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           readinessProbe:
             exec:
               command:
               - /bin/bash
               - /etc/config/spark/health_check.sh
               - --port={{ .Values.master.webAdmin.containerPort }}
-              initialDelaySeconds: 5
-              periodSeconds: 1
+              initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+              periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           resources:
 {{ toYaml .Values.master.resources | indent 12 }}
 {{- if .Values.environment }}

--- a/stable/spark/templates/spark-worker-configmap.yaml
+++ b/stable/spark/templates/spark-worker-configmap.yaml
@@ -10,6 +10,8 @@ metadata:
 data:
   health_check.sh: |
 {{ include "v3io-configs.script.httpHealthCheckWithJava" . | indent 4 }}
+    # Test that dayman is alive and accessible
+    hadoop fs -test -e /
 
   run.sh: |
     #!/usr/bin/env bash

--- a/stable/spark/templates/spark-worker-deployment.yaml
+++ b/stable/spark/templates/spark-worker-deployment.yaml
@@ -50,16 +50,16 @@ spec:
               - /bin/bash
               - /etc/config/spark/health_check.sh
               - --port={{ .Values.master.webAdmin.containerPort }}
-              initialDelaySeconds: 90
-              periodSeconds: 1
+              initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+              periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           readinessProbe:
             exec:
               command:
               - /bin/bash
               - /etc/config/spark/health_check.sh
               - --port={{ .Values.master.webAdmin.containerPort }}
-              initialDelaySeconds: 5
-              periodSeconds: 1
+              initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+              periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           resources:
 {{ toYaml .Values.worker.resources | indent 12 }}
 {{- if .Values.environment }}

--- a/stable/spark/values.yaml
+++ b/stable/spark/values.yaml
@@ -7,7 +7,7 @@ master:
   replicas: 1
   servicePort: 7077
   containerPort: 7077
-  
+
   resources: {}
     # limits:
       # cpu: 1
@@ -15,7 +15,7 @@ master:
     # requests:
       # cpu: 1
       # memory: "3Gi"
-  
+
   webAdmin:
     servicePort: 8080
     containerPort: 8080
@@ -29,7 +29,7 @@ worker:
   replicas: 1
   containerPort: 8081
   executorMemory: "1g"
-  
+
   resources: {}
     # limits:
       # cpu: 1
@@ -59,3 +59,11 @@ global:
     configMountPath: /etc/config/v3io
 
 v3io: {}
+
+livenessProbe:
+  initialDelaySeconds: 90
+  periodSeconds: 10
+
+readinessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 10

--- a/stable/spark/values.yaml
+++ b/stable/spark/values.yaml
@@ -62,8 +62,8 @@ v3io: {}
 
 livenessProbe:
   initialDelaySeconds: 90
-  periodSeconds: 10
+  periodSeconds: 5
 
 readinessProbe:
   initialDelaySeconds: 5
-  periodSeconds: 10
+  periodSeconds: 5


### PR DESCRIPTION
New health check is needed to monitor state of v3io-dayman pod since in case of restart it gets new IP and dependant pods need to be restarted in order to be operational