### PR TITLE
Jupyter: Change log level to WARN

### DIFF
--- a/stable/jupyter/Chart.yaml
+++ b/stable/jupyter/Chart.yaml
@@ -1,5 +1,5 @@
 name: jupyter
-version: 0.6.0
+version: 0.6.1
 appVersion: ">=2.0.0"
 description: Jupyter
 home: https://jupyter.org/

--- a/stable/jupyter/templates/jupyter-deployment.yaml
+++ b/stable/jupyter/templates/jupyter-deployment.yaml
@@ -57,6 +57,7 @@ spec:
             - --NotebookApp.password=''
             - --notebook-dir="/User"
             - --NotebookApp.default_url="/lab"
+            - --Application.log_level="WARN"
 {{- if .Values.debug.enabled }}
             - --debug
 {{- end }}


### PR DESCRIPTION
For some reason it crashed while executing a specific test on my machine (probably has nothing to do with my change).
It crashed on daemon not responding to 3 heartbeat attempts (after trying file-access test).
@bivas - Is there anything special I have to do when replacing jupyter's helm chart?