### PR TITLE
Supporting special character in jupyter env vars

### DIFF
--- a/stable/jupyter/Chart.yaml
+++ b/stable/jupyter/Chart.yaml
@@ -1,5 +1,5 @@
 name: jupyter
-version: 0.6.2
+version: 0.6.3
 appVersion: ">=2.0.0"
 description: Jupyter
 home: https://jupyter.org/

--- a/stable/jupyter/templates/jupyter-deployment.yaml
+++ b/stable/jupyter/templates/jupyter-deployment.yaml
@@ -116,7 +116,7 @@ spec:
 {{- if .Values.environment }}
 {{- range $name, $val := .Values.environment.extra }}
             - name: {{ $name }}
-              value: {{ $val }}
+              value: '{{ $val }}'
 {{ end -}}
 {{- if .Values.environment.template }}
 {{ include .Values.environment.template . | indent 12 }}

--- a/stable/jupyter/templates/jupyter-deployment.yaml
+++ b/stable/jupyter/templates/jupyter-deployment.yaml
@@ -116,7 +116,7 @@ spec:
 {{- if .Values.environment }}
 {{- range $name, $val := .Values.environment.extra }}
             - name: {{ $name }}
-              value: '{{ $val }}'
+              value: {{ $val | quote }}
 {{ end -}}
 {{- if .Values.environment.template }}
 {{ include .Values.environment.template . | indent 12 }}


### PR DESCRIPTION
`helm install` with `--set environment.extra.key='@#%45ef'` was throwing 
```
Error: YAML parse error on jupyter/templates/jupyter-deployment.yaml: error converting YAML to JSON: yaml: line 89: found character that cannot start any token
```

adding the single quotes to solve this