### PR TITLE
Provazio (0.2.3) - CRDs fix - removing invalid description field

### DIFF
--- a/stable/provazio/Chart.yaml
+++ b/stable/provazio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Iguazio provisioner
 name: provazio
-version: 0.2.2
+version: 0.2.3
 appVersion: 0.3.0
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://iguazio.com

--- a/stable/provazio/templates/appcluster-crd.yaml
+++ b/stable/provazio/templates/appcluster-crd.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.controller.crd.create }}
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Iguazio AppCluster resource
 kind: CustomResourceDefinition
 metadata:
   name: iguazioappclusters.iguazio.com

--- a/stable/provazio/templates/tenant-appserviceset-crd.yaml
+++ b/stable/provazio/templates/tenant-appserviceset-crd.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.controller.crd.create }}
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Iguazio Tenant AppServiceSet resource
 kind: CustomResourceDefinition
 metadata:
   name: iguaziotenantappservicesets.iguazio.com

--- a/stable/provazio/templates/tenant-crd.yaml
+++ b/stable/provazio/templates/tenant-crd.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.controller.crd.create }}
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Iguazio Tenant resource
 kind: CustomResourceDefinition
 metadata:
   name: iguaziotenants.iguazio.com


### PR DESCRIPTION
Failed validation after bumping helm version
Caused: IG-12355
Since a new helm version bump brought in a (soon to be reverted) helm feature of schema validation