### PR TITLE
Update metrics-server-exporter helm chart

### DIFF
--- a/stable/metrics-server-exporter/Chart.yaml
+++ b/stable/metrics-server-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: K8s metrics exporter in prometheus format
 name: metrics-server-exporter
-version: 0.1.0
+version: 0.1.1
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2017/09/iguazio_logo_2017_w_c.png
 sources:

--- a/stable/metrics-server-exporter/templates/metrics-server-exporter-deployment.yaml
+++ b/stable/metrics-server-exporter/templates/metrics-server-exporter-deployment.yaml
@@ -17,6 +17,8 @@ spec:
     metadata:
       labels:
         app: {{ template "metrics-server-exporter.name" . }}
+        chart: {{ template "metrics-server-exporter.chart" . }}
+        release: {{ .Release.Name }}
     spec:
       serviceAccountName: metrics-server-exporter
       containers:

--- a/stable/metrics-server-exporter/templates/metrics-server-exporter-service-account.yaml
+++ b/stable/metrics-server-exporter/templates/metrics-server-exporter-service-account.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: metrics-server-exporter
+  name: {{ template "metrics-server-exporter.name" . }}
   labels:
-    app: metrics-server-exporter
+    app: {{ template "metrics-server-exporter.name" . }}
+    chart: {{ template "metrics-server-exporter.chart" . }}
+    release: {{ .Release.Name }}

--- a/stable/metrics-server-exporter/templates/metrics-server-exporter-service.yaml
+++ b/stable/metrics-server-exporter/templates/metrics-server-exporter-service.yaml
@@ -7,7 +7,9 @@ metadata:
     prometheus.io/scrape: "true"
   name: metrics-server-exporter
   labels:
-    app: metrics-server-exporter
+    app: {{ template "metrics-server-exporter.name" . }}
+    chart: {{ template "metrics-server-exporter.chart" . }}
+    release: {{ .Release.Name }}
 spec:
   ports:
   - port: {{ .Values.service.port }}

--- a/stable/metrics-server-exporter/values.yaml
+++ b/stable/metrics-server-exporter/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: iguaziodocker/metrics-server-exporter
-  tag: 0.1.0
+  tag: 0.1.1
   pullPolicy: IfNotPresent
 
 container:


### PR DESCRIPTION
* Added a "release" label to metrics-server-exporter deployment.
* A new image that reads the "release" label of the pod and publishes it as a prometheus metric label.