### PR TITLE
Update metrics server exporter version

### DIFF
--- a/stable/metrics-server-exporter/Chart.yaml
+++ b/stable/metrics-server-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: K8s metrics exporter in prometheus format
 name: metrics-server-exporter
-version: 0.1.2
+version: 0.1.3
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2017/09/iguazio_logo_2017_w_c.png
 sources:

--- a/stable/metrics-server-exporter/values.yaml
+++ b/stable/metrics-server-exporter/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: iguaziodocker/metrics-server-exporter
-  tag: 0.1.2
+  tag: 0.1.3
   pullPolicy: IfNotPresent
 
 container:


### PR DESCRIPTION
Metrics server exporter now exports namespace's pod labels as a metric with a constant value 1.