### PR TITLE
IG-11976 - Support running Presto on external sources

### DIFF
--- a/stable/presto/Chart.yaml
+++ b/stable/presto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: Distributed SQL query engine for running interactive analytic queries
 name: presto
-version: 0.6.2
+version: 0.6.3
 home: https://prestodb.io
 icon: https://prestodb.io/static/presto.png
 sources:

--- a/stable/presto/templates/catalog-configmap.yaml
+++ b/stable/presto/templates/catalog-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: presto.catalog
+  labels:
+    app: {{ template "presto.name" . }}
+    chart: {{ template "presto.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+{{- range $key, $val := .Values.server.config.catalogs }}
+{{ printf "%s: |" $key | indent 2 }}
+{{ $val | indent 4 }}
+{{- end }}

--- a/stable/presto/templates/coordinator-configmap.yaml
+++ b/stable/presto/templates/coordinator-configmap.yaml
@@ -10,10 +10,23 @@ metadata:
     component: coordinator
 data:
   node.properties: |
+{{- if (eq .Values.server.node.properties.override true) }}
+{{ printf "#============= Custom node properties (override) ==========" | indent 4 }}
+{{ .Values.server.node.properties.custom | indent 4 }}
+{{- else }}
     node.environment={{ .Values.server.node.environment }}
     node.data-dir={{ .Values.server.node.dataDir }}
+{{- if .Values.server.node.properties.custom }}
+{{ printf "#============= Custom node properties ==========" | indent 4 }}
+{{ .Values.server.node.properties.custom | indent 4 }}
+{{- end }}
+{{- end }}
 
   jvm.config: |
+{{- if (eq .Values.server.jvm.properties.override true) }}
+{{ printf "#============= Custom jvm properties (override) ==========" | indent 4 }}
+{{ .Values.server.jvm.properties.custom | indent 4 }}
+{{- else }}
     -server
     -Xmx{{ .Values.server.jvm.maxHeapSize }}
     -XX:+{{ .Values.server.jvm.gcMethod.type }}
@@ -22,8 +35,18 @@ data:
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+HeapDumpOnOutOfMemoryError
     -XX:+ExitOnOutOfMemoryError
+{{- if .Values.server.jvm.properties.custom }}
+{{ printf "#============= Custom jvm properties ==========" | indent 4 }}
+{{ .Values.server.jvm.properties.custom | indent 4 }}
+{{- end }}
+{{- end }}
 
   config.properties: |
+{{- if (eq .Values.server.config.properties.override true) }}
+{{ printf "#============= Custom config properties (override) ==========" | indent 4 }}
+{{ .Values.server.config.properties.custom | indent 4 }}
+{{- println "coordinator=true" }}
+{{- else }}
     coordinator=true
 {{- if gt (int .Values.server.workers) 0 }}
     node-scheduler.include-coordinator=false
@@ -43,6 +66,11 @@ data:
     discovery-server.enabled=true
     discovery.uri=http://{{ template "presto.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.config.http.port }}
     node.internal-address={{ template "presto.fullname" . }}.{{ .Release.Namespace }}.svc
+{{- if .Values.server.config.properties.custom }}
+{{ printf "#============= Custom config properties ==========" | indent 4 }}
+{{ .Values.server.config.properties.custom | indent 4 }}
+{{- end }}
+{{- end }}
 
 {{ if .Values.server.config.https }}
   password-authenticator.properties: |
@@ -51,14 +79,32 @@ data:
 
 {{ if .Values.server.log }}
   log.properties: |
-{{- range $key, $val := .Values.server.log }}
+{{- if (eq .Values.server.log.properties.override true) }}
+{{ printf "#============= Custom log properties (override) ==========" | indent 4 }}
+{{ .Values.server.log.properties.custom | indent 4 }}
+{{- else }}
+{{- range $key, $val := .Values.server.log.categories }}
 {{ printf "%s=%s" $key $val | indent 4}}
+{{- end }}
+{{- if .Values.server.log.properties.custom }}
+{{ println }}
+{{- printf "#============= Custom log properties ==========" | indent 4 }}
+{{ .Values.server.log.properties.custom | indent 4 }}
+{{- end }}
 {{- end }}
 {{ end -}}
 
 {{- range $key, $val := .Values.server.config.extra }}
 {{ printf "%s: |" $key | indent 2 }}
 {{ $val | indent 4 }}
+{{- end }}
+
+{{- if .Values.server.files }}
+{{- range $elem := .Values.server.files }}
+{{ printf "" }}
+{{ printf "%s: |" $elem.name | indent 2}}
+{{ printf "%s" $elem.contents | indent 4 }}
+{{- end }}
 {{- end }}
 
 {{- if .Values.server.config.https }}
@@ -86,35 +132,8 @@ data:
     #!/bin/bash
     cp {{ .Values.server.config.mapPath }}/*.properties $PRESTO_CONF_DIR
     cp {{ .Values.server.config.mapPath }}/*.config $PRESTO_CONF_DIR
-
-{{- if .Values.server.files }}
-
-    # Start creating custom configuration files
-{{- range $elem := .Values.server.files }}
-{{- if hasPrefix "/" $elem.path }}
-{{- if ( hasKey $elem "override" ) }}
-{{- if ( eq $elem.override true ) }}
-{{ printf "echo -n '%s' | base64 --decode > %s" $elem.contents $elem.path | indent 4 }}
-{{- end }}
-{{ else }}
-{{ printf "echo '' >> %s" $elem.path | indent 4 }}
-{{ printf "echo '# ------- Custom --------' >> %s" $elem.path | indent 4 }}
-{{ printf "echo -n '%s' | base64 --decode >> %s" $elem.contents $elem.path | indent 4 }}
-{{- end }}
-{{ else }}
-{{- if ( hasKey $elem "override" ) }}
-{{- if ( eq $elem.override true ) }}
-{{ printf "echo -n '%s' | base64 --decode > ${PRESTO_CONF_DIR}/%s" $elem.contents $elem.path | indent 4 }}
-{{- end }}
-{{ else }}
-{{ printf "echo '' >> %s" $elem.path | indent 4 }}
-{{ printf "echo '# ------- Custom --------' >> ${PRESTO_CONF_DIR}/%s" $elem.path | indent 4 }}
-{{ printf "echo -n '%s' | base64 --decode >> ${PRESTO_CONF_DIR}/%s" $elem.contents $elem.path | indent 4 }}
-{{- end }}
-{{- end }}
-{{- end }}
-    # Finish creating custom configuration files
-{{- end }}
+    cp {{ .Values.server.config.mapPath }}/*.json $PRESTO_CONF_DIR
+    cp {{ .Values.server.config.catalogMapPath }}/*.properties $PRESTO_CONF_DIR/catalog
 
 {{- if .Values.hive }}
 

--- a/stable/presto/templates/coordinator-configmap.yaml
+++ b/stable/presto/templates/coordinator-configmap.yaml
@@ -10,23 +10,10 @@ metadata:
     component: coordinator
 data:
   node.properties: |
-{{- if (eq .Values.server.node.properties.override true) }}
-    # ============= Custom node properties ==========
-    {{- .Values.server.node.properties.custom | b64dec | toYaml | indent 2 }}
-{{- else }}
     node.environment={{ .Values.server.node.environment }}
     node.data-dir={{ .Values.server.node.dataDir }}
-{{- if .Values.server.node.properties.custom }}
-    # ============= Custom node properties ==========
-    {{- .Values.server.node.properties.custom | b64dec | toYaml | indent 2 }}
-{{- end }}
-{{- end }}
 
   jvm.config: |
-{{- if (eq .Values.server.jvm.properties.override true) }}
-    # ============= Custom jvm properties ==========
-    {{- .Values.server.jvm.properties.custom | b64dec | toYaml | indent 2 }}
-{{- else }}
     -server
     -Xmx{{ .Values.server.jvm.maxHeapSize }}
     -XX:+{{ .Values.server.jvm.gcMethod.type }}
@@ -35,18 +22,8 @@ data:
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+HeapDumpOnOutOfMemoryError
     -XX:+ExitOnOutOfMemoryError
-{{- if .Values.server.jvm.properties.custom }}
-    # ============= Custom jvm properties ==========
-    {{- .Values.server.jvm.properties.custom | b64dec | toYaml | indent 2 }}
-{{- end }}
-{{- end }}
 
   config.properties: |
-{{- if (eq .Values.server.config.properties.override true) }}
-    # ============= Custom config properties ==========
-    {{- .Values.server.config.properties.custom | b64dec | toYaml | indent 2 }}
-    coordinator=true
-{{- else }}
     coordinator=true
 {{- if gt (int .Values.server.workers) 0 }}
     node-scheduler.include-coordinator=false
@@ -66,11 +43,6 @@ data:
     discovery-server.enabled=true
     discovery.uri=http://{{ template "presto.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.config.http.port }}
     node.internal-address={{ template "presto.fullname" . }}.{{ .Release.Namespace }}.svc
-{{- if .Values.server.config.properties.custom }}
-    # ============= Custom config properties ==========
-    {{- .Values.server.config.properties.custom | b64dec | toYaml | indent 2 }}
-{{- end }}
-{{- end }}
 
 {{ if .Values.server.config.https }}
   password-authenticator.properties: |
@@ -79,22 +51,13 @@ data:
 
 {{ if .Values.server.log }}
   log.properties: |
-{{- if (eq .Values.server.log.properties.override true) }}
-    # ============= Custom log properties ==========
-    {{- .Values.server.log.properties.custom | b64dec | toYaml | indent 2 }}
-{{- else }}
 {{- range $key, $val := .Values.server.log.categories }}
 {{ printf "%s=%s" $key $val | indent 4}}
 {{- end }}
-{{ end -}}
 
 {{- range $key, $val := .Values.server.config.extra }}
 {{ printf "%s: |" $key | indent 2 }}
 {{ $val | indent 4 }}
-{{- end }}
-{{- if .Values.server.log.properties.custom }}
-    # ============= Custom log properties ==========
-    {{- .Values.server.log.properties.custom | b64dec | toYaml | indent 2 }}
 {{- end }}
 {{- end }}
 
@@ -124,11 +87,27 @@ data:
     cp {{ .Values.server.config.mapPath }}/*.properties $PRESTO_CONF_DIR
     cp {{ .Values.server.config.mapPath }}/*.config $PRESTO_CONF_DIR
 
-{{- if .Values.server.configuration.files }}
+{{- if .Values.server.files }}
 
     # Start creating custom configuration files
-{{- range $name, $content := .Values.server.configuration.files }}
-{{ printf "echo -n '%s' | base64 --decode > $PRESTO_CONF_DIR/%s" $content $name | indent 4 }}
+{{- range $elem := .Values.server.files }}
+{{- if hasPrefix "/" $elem.path }}
+{{- if ( eq $elem.override true ) }}
+{{ printf "echo -n '%s' | base64 --decode > %s" $elem.content $elem.path | indent 4 }}
+{{ else }}
+{{ printf "echo '' >> %s" $elem.path | indent 4 }}
+{{ printf "echo '# ------- Custom --------' >> %s" $elem.path | indent 4 }}
+{{ printf "echo -n '%s' | base64 --decode >> %s" $elem.content $elem.path | indent 4 }}
+{{- end }}
+{{ else }}
+{{- if ( eq $elem.override true ) }}
+{{ printf "echo -n '%s' | base64 --decode > ${PRESTO_CONF_DIR}/%s" $elem.content $elem.path | indent 4 }}
+{{ else }}
+{{ printf "echo '' >> %s" $elem.path | indent 4 }}
+{{ printf "echo '# ------- Custom --------' >> ${PRESTO_CONF_DIR}/%s" $elem.path | indent 4 }}
+{{ printf "echo -n '%s' | base64 --decode >> ${PRESTO_CONF_DIR}/%s" $elem.content $elem.path | indent 4 }}
+{{- end }}
+{{- end }}
 {{- end }}
     # Finish creating custom configuration files
 {{- end }}

--- a/stable/presto/templates/coordinator-configmap.yaml
+++ b/stable/presto/templates/coordinator-configmap.yaml
@@ -94,22 +94,22 @@ data:
 {{- if contains "/" $elem.path }}
 {{- if ( hasKey $elem "override" ) }}
 {{- if ( eq $elem.override true ) }}
-{{ printf "echo -n '%s' | base64 --decode > %s" $elem.content $elem.path | indent 4 }}
+{{ printf "echo -n '%s' | base64 --decode > %s" $elem.contents $elem.path | indent 4 }}
 {{- end }}
 {{ else }}
 {{ printf "echo '' >> %s" $elem.path | indent 4 }}
 {{ printf "echo '# ------- Custom --------' >> %s" $elem.path | indent 4 }}
-{{ printf "echo -n '%s' | base64 --decode >> %s" $elem.content $elem.path | indent 4 }}
+{{ printf "echo -n '%s' | base64 --decode >> %s" $elem.contents $elem.path | indent 4 }}
 {{- end }}
 {{ else }}
 {{- if ( hasKey $elem "override" ) }}
 {{- if ( eq $elem.override true ) }}
-{{ printf "echo -n '%s' | base64 --decode > ${PRESTO_CONF_DIR}/%s" $elem.content $elem.path | indent 4 }}
+{{ printf "echo -n '%s' | base64 --decode > ${PRESTO_CONF_DIR}/%s" $elem.contents $elem.path | indent 4 }}
 {{- end }}
 {{ else }}
 {{ printf "echo '' >> %s" $elem.path | indent 4 }}
 {{ printf "echo '# ------- Custom --------' >> ${PRESTO_CONF_DIR}/%s" $elem.path | indent 4 }}
-{{ printf "echo -n '%s' | base64 --decode >> ${PRESTO_CONF_DIR}/%s" $elem.content $elem.path | indent 4 }}
+{{ printf "echo -n '%s' | base64 --decode >> ${PRESTO_CONF_DIR}/%s" $elem.contents $elem.path | indent 4 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/presto/templates/coordinator-configmap.yaml
+++ b/stable/presto/templates/coordinator-configmap.yaml
@@ -10,10 +10,29 @@ metadata:
     component: coordinator
 data:
   node.properties: |
+{{- if (eq .Values.server.node.properties.override true) }}
+    # ============= Custom node properties ==========
+    {{- range .Values.server.node.properties.custom }}
+    {{ . }}
+    {{- end }}
+{{- else }}
     node.environment={{ .Values.server.node.environment }}
     node.data-dir={{ .Values.server.node.dataDir }}
+{{- if .Values.server.node.properties.custom }}
+    # ============= Custom node properties ==========
+    {{- range .Values.server.node.properties.custom }}
+    {{ . }}
+    {{- end }}
+{{- end }}
+{{- end }}
 
   jvm.config: |
+{{- if (eq .Values.server.jvm.properties.override true) }}
+    # ============= Custom jvm properties ==========
+    {{- range .Values.server.jvm.properties.custom }}
+    {{ . }}
+    {{- end }}
+{{- else }}
     -server
     -Xmx{{ .Values.server.jvm.maxHeapSize }}
     -XX:+{{ .Values.server.jvm.gcMethod.type }}
@@ -22,8 +41,22 @@ data:
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+HeapDumpOnOutOfMemoryError
     -XX:+ExitOnOutOfMemoryError
+{{- if .Values.server.jvm.properties.custom }}
+    # ============= Custom jvm properties ==========
+    {{- range .Values.server.jvm.properties.custom }}
+    {{ . }}
+    {{- end }}
+{{- end }}
+{{- end }}
 
   config.properties: |
+{{- if (eq .Values.server.config.properties.override true) }}
+    # ============= Custom config properties ==========
+    {{- range .Values.server.config.properties.custom }}
+    {{ . }}
+    {{- end }}
+    coordinator=true
+{{- else }}
     coordinator=true
 {{- if gt (int .Values.server.workers) 0 }}
     node-scheduler.include-coordinator=false
@@ -43,14 +76,27 @@ data:
     discovery-server.enabled=true
     discovery.uri=http://{{ template "presto.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.config.http.port }}
     node.internal-address={{ template "presto.fullname" . }}.{{ .Release.Namespace }}.svc
+{{- if .Values.server.config.properties.custom }}
+    # ============= Custom config properties ==========
+    {{- range .Values.server.config.properties.custom }}
+    {{ . }}
+    {{- end }}
+{{- end }}
+{{- end }}
 
-{{- if .Values.server.config.https }}
+{{ if .Values.server.config.https }}
   password-authenticator.properties: |
     password-authenticator.name=v3io
 {{- end }}
 
 {{ if .Values.server.log }}
   log.properties: |
+{{- if (eq .Values.server.log.properties.override true) }}
+    # ============= Custom log properties ==========
+    {{- range .Values.server.log.properties.custom }}
+    {{ . }}
+    {{- end }}
+{{- else }}
 {{- range $key, $val := .Values.server.log }}
 {{ printf "%s=%s" $key $val | indent 4}}
 {{- end }}
@@ -59,6 +105,13 @@ data:
 {{- range $key, $val := .Values.server.config.extra }}
 {{ printf "%s: |" $key | indent 2 }}
 {{ $val | indent 4 }}
+{{- end }}
+{{- if .Values.server.log.properties.custom }}
+    # ============= Custom log properties ==========
+    {{- range .Values.server.log.properties.custom }}
+    {{ . }}
+    {{- end }}
+{{- end }}
 {{- end }}
 
 {{- if .Values.server.config.https }}

--- a/stable/presto/templates/coordinator-configmap.yaml
+++ b/stable/presto/templates/coordinator-configmap.yaml
@@ -91,17 +91,21 @@ data:
 
     # Start creating custom configuration files
 {{- range $elem := .Values.server.files }}
-{{- if hasPrefix "/" $elem.path }}
+{{- if contains "/" $elem.path }}
+{{- if ( hasKey $elem "override" ) }}
 {{- if ( eq $elem.override true ) }}
 {{ printf "echo -n '%s' | base64 --decode > %s" $elem.content $elem.path | indent 4 }}
+{{- end }}
 {{ else }}
 {{ printf "echo '' >> %s" $elem.path | indent 4 }}
 {{ printf "echo '# ------- Custom --------' >> %s" $elem.path | indent 4 }}
 {{ printf "echo -n '%s' | base64 --decode >> %s" $elem.content $elem.path | indent 4 }}
 {{- end }}
 {{ else }}
+{{- if ( hasKey $elem "override" ) }}
 {{- if ( eq $elem.override true ) }}
 {{ printf "echo -n '%s' | base64 --decode > ${PRESTO_CONF_DIR}/%s" $elem.content $elem.path | indent 4 }}
+{{- end }}
 {{ else }}
 {{ printf "echo '' >> %s" $elem.path | indent 4 }}
 {{ printf "echo '# ------- Custom --------' >> ${PRESTO_CONF_DIR}/%s" $elem.path | indent 4 }}

--- a/stable/presto/templates/coordinator-configmap.yaml
+++ b/stable/presto/templates/coordinator-configmap.yaml
@@ -12,26 +12,20 @@ data:
   node.properties: |
 {{- if (eq .Values.server.node.properties.override true) }}
     # ============= Custom node properties ==========
-    {{- range .Values.server.node.properties.custom }}
-    {{ . }}
-    {{- end }}
+    {{- .Values.server.node.properties.custom | b64dec | toYaml | indent 2 }}
 {{- else }}
     node.environment={{ .Values.server.node.environment }}
     node.data-dir={{ .Values.server.node.dataDir }}
 {{- if .Values.server.node.properties.custom }}
     # ============= Custom node properties ==========
-    {{- range .Values.server.node.properties.custom }}
-    {{ . }}
-    {{- end }}
+    {{- .Values.server.node.properties.custom | b64dec | toYaml | indent 2 }}
 {{- end }}
 {{- end }}
 
   jvm.config: |
 {{- if (eq .Values.server.jvm.properties.override true) }}
     # ============= Custom jvm properties ==========
-    {{- range .Values.server.jvm.properties.custom }}
-    {{ . }}
-    {{- end }}
+    {{- .Values.server.jvm.properties.custom | b64dec | toYaml | indent 2 }}
 {{- else }}
     -server
     -Xmx{{ .Values.server.jvm.maxHeapSize }}
@@ -43,18 +37,14 @@ data:
     -XX:+ExitOnOutOfMemoryError
 {{- if .Values.server.jvm.properties.custom }}
     # ============= Custom jvm properties ==========
-    {{- range .Values.server.jvm.properties.custom }}
-    {{ . }}
-    {{- end }}
+    {{- .Values.server.jvm.properties.custom | b64dec | toYaml | indent 2 }}
 {{- end }}
 {{- end }}
 
   config.properties: |
 {{- if (eq .Values.server.config.properties.override true) }}
     # ============= Custom config properties ==========
-    {{- range .Values.server.config.properties.custom }}
-    {{ . }}
-    {{- end }}
+    {{- .Values.server.config.properties.custom | b64dec | toYaml | indent 2 }}
     coordinator=true
 {{- else }}
     coordinator=true
@@ -78,9 +68,7 @@ data:
     node.internal-address={{ template "presto.fullname" . }}.{{ .Release.Namespace }}.svc
 {{- if .Values.server.config.properties.custom }}
     # ============= Custom config properties ==========
-    {{- range .Values.server.config.properties.custom }}
-    {{ . }}
-    {{- end }}
+    {{- .Values.server.config.properties.custom | b64dec | toYaml | indent 2 }}
 {{- end }}
 {{- end }}
 
@@ -93,11 +81,9 @@ data:
   log.properties: |
 {{- if (eq .Values.server.log.properties.override true) }}
     # ============= Custom log properties ==========
-    {{- range .Values.server.log.properties.custom }}
-    {{ . }}
-    {{- end }}
+    {{- .Values.server.log.properties.custom | b64dec | toYaml | indent 2 }}
 {{- else }}
-{{- range $key, $val := .Values.server.log }}
+{{- range $key, $val := .Values.server.log.categories }}
 {{ printf "%s=%s" $key $val | indent 4}}
 {{- end }}
 {{ end -}}
@@ -108,9 +94,7 @@ data:
 {{- end }}
 {{- if .Values.server.log.properties.custom }}
     # ============= Custom log properties ==========
-    {{- range .Values.server.log.properties.custom }}
-    {{ . }}
-    {{- end }}
+    {{- .Values.server.log.properties.custom | b64dec | toYaml | indent 2 }}
 {{- end }}
 {{- end }}
 

--- a/stable/presto/templates/coordinator-configmap.yaml
+++ b/stable/presto/templates/coordinator-configmap.yaml
@@ -91,7 +91,7 @@ data:
 
     # Start creating custom configuration files
 {{- range $elem := .Values.server.files }}
-{{- if contains "/" $elem.path }}
+{{- if hasPrefix "/" $elem.path }}
 {{- if ( hasKey $elem "override" ) }}
 {{- if ( eq $elem.override true ) }}
 {{ printf "echo -n '%s' | base64 --decode > %s" $elem.contents $elem.path | indent 4 }}

--- a/stable/presto/templates/coordinator-configmap.yaml
+++ b/stable/presto/templates/coordinator-configmap.yaml
@@ -140,7 +140,17 @@ data:
     cp {{ .Values.server.config.mapPath }}/*.properties $PRESTO_CONF_DIR
     cp {{ .Values.server.config.mapPath }}/*.config $PRESTO_CONF_DIR
 
+{{- if .Values.server.configuration.files }}
+
+    # Start creating custom configuration files
+{{- range $name, $content := .Values.server.configuration.files }}
+{{ printf "echo -n '%s' | base64 --decode > $PRESTO_CONF_DIR/%s" $content $name | indent 4 }}
+{{- end }}
+    # Finish creating custom configuration files
+{{- end }}
+
 {{- if .Values.hive }}
+
     # Hive configuration
     echo hive.config.resources=${HADOOP_CONF_DIR}/core-site.xml,${HADOOP_CONF_DIR}/hdfs-site.xml >> $PRESTO_CONF_DIR/hive.properties
     mv $PRESTO_CONF_DIR/hive.properties $PRESTO_CONF_DIR/catalog/hive.properties

--- a/stable/presto/templates/coordinator-configmap.yaml
+++ b/stable/presto/templates/coordinator-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     component: coordinator
 data:
   node.properties: |
-{{- if (eq .Values.server.node.properties.override true) }}
+{{- if and .Values.server.node.properties.override (eq .Values.server.node.properties.override true) }}
 {{ printf "#============= Custom node properties (override) ==========" | indent 4 }}
 {{ .Values.server.node.properties.custom | indent 4 }}
 {{- else }}

--- a/stable/presto/templates/coordinator-configmap.yaml
+++ b/stable/presto/templates/coordinator-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
     component: coordinator
 data:
   node.properties: |
-{{- if and .Values.server.node.properties.override (eq .Values.server.node.properties.override true) }}
+{{- if (eq .Values.server.node.properties.override true) }}
 {{ printf "#============= Custom node properties (override) ==========" | indent 4 }}
 {{ .Values.server.node.properties.custom | indent 4 }}
 {{- else }}

--- a/stable/presto/templates/coordinator-configmap.yaml
+++ b/stable/presto/templates/coordinator-configmap.yaml
@@ -51,14 +51,14 @@ data:
 
 {{ if .Values.server.log }}
   log.properties: |
-{{- range $key, $val := .Values.server.log.categories }}
+{{- range $key, $val := .Values.server.log }}
 {{ printf "%s=%s" $key $val | indent 4}}
 {{- end }}
+{{ end -}}
 
 {{- range $key, $val := .Values.server.config.extra }}
 {{ printf "%s: |" $key | indent 2 }}
 {{ $val | indent 4 }}
-{{- end }}
 {{- end }}
 
 {{- if .Values.server.config.https }}

--- a/stable/presto/templates/coordinator-deployment.yaml
+++ b/stable/presto/templates/coordinator-deployment.yaml
@@ -25,6 +25,9 @@ spec:
         - name: config-volume
           configMap:
             name: {{ template "presto.coordinator" . }}
+        - name: catalog-config-volume
+          configMap:
+            name: presto.catalog
         - name: daemon-health
           emptyDir: {}
 {{- if .Values.server.config.https }}
@@ -67,6 +70,8 @@ spec:
           volumeMounts:
             - mountPath: {{ .Values.server.config.mapPath }}
               name: config-volume
+            - mountPath: {{ .Values.server.config.catalogMapPath }}
+              name: catalog-config-volume
             - mountPath: /var/run/iguazio/daemon_health
               name: daemon-health
 {{- if .Values.server.config.https }}

--- a/stable/presto/templates/worker-configmap.yaml
+++ b/stable/presto/templates/worker-configmap.yaml
@@ -144,7 +144,17 @@ data:
     cp {{ .Values.server.config.mapPath }}/*.properties $PRESTO_CONF_DIR
     cp {{ .Values.server.config.mapPath }}/*.config $PRESTO_CONF_DIR
 
+{{- if .Values.server.configuration.files }}
+
+    # Start creating custom configuration files
+{{- range $name, $content := .Values.server.configuration.files }}
+{{ printf "echo -n '%s' | base64 --decode > $PRESTO_CONF_DIR/%s" $content $name | indent 4 }}
+{{- end }}
+    # Finish creating custom configuration files
+{{- end }}
+
 {{- if .Values.hive }}
+
     # Hive configuration
     echo hive.config.resources=${HADOOP_CONF_DIR}/core-site.xml,${HADOOP_CONF_DIR}/hdfs-site.xml >> $PRESTO_CONF_DIR/hive.properties
     mv $PRESTO_CONF_DIR/hive.properties $PRESTO_CONF_DIR/catalog/hive.properties

--- a/stable/presto/templates/worker-configmap.yaml
+++ b/stable/presto/templates/worker-configmap.yaml
@@ -11,10 +11,23 @@ metadata:
     component: worker
 data:
   node.properties: |
+{{- if (eq .Values.server.node.properties.override true) }}
+{{ printf "#============= Custom node properties (override) ==========" | indent 4 }}
+{{ .Values.server.node.properties.custom | indent 4 }}
+{{- else }}
     node.environment={{ .Values.server.node.environment }}
     node.data-dir={{ .Values.server.node.dataDir }}
+{{- if .Values.server.node.properties.custom }}
+{{ printf "#============= Custom node properties ==========" | indent 4 }}
+{{ .Values.server.node.properties.custom | indent 4 }}
+{{- end }}
+{{- end }}
 
   jvm.config: |
+{{- if (eq .Values.server.jvm.properties.override true) }}
+{{ printf "#============= Custom jvm properties (override) ==========" | indent 4 }}
+{{ .Values.server.jvm.properties.custom | indent 4 }}
+{{- else }}
     -server
     -Xmx{{ .Values.server.jvm.maxHeapSize }}
     -XX:+{{ .Values.server.jvm.gcMethod.type }}
@@ -23,8 +36,18 @@ data:
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+HeapDumpOnOutOfMemoryError
     -XX:+ExitOnOutOfMemoryError
+{{- if .Values.server.jvm.properties.custom }}
+{{ printf "#============= Custom jvm properties ==========" | indent 4 }}
+{{ .Values.server.jvm.properties.custom | indent 4 }}
+{{- end }}
+{{- end }}
 
   config.properties: |
+{{- if (eq .Values.server.config.properties.override true) }}
+{{ printf "#============= Custom config properties (override) ==========" | indent 4 }}
+{{ .Values.server.config.properties.custom | indent 4 }}
+{{- println "coordinator=false" }}
+{{- else }}
     coordinator=false
     http-server.http.port={{ .Values.server.config.http.port }}
 {{- if .Values.server.config.https }}
@@ -37,6 +60,11 @@ data:
     query.max-memory={{ .Values.server.config.query.maxMemory }}
     query.max-memory-per-node={{ .Values.server.config.query.maxMemoryPerNode }}
     discovery.uri=http://{{ template "presto.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.config.http.port }}
+{{- if .Values.server.config.properties.custom }}
+{{ printf "#============= Custom config properties ==========" | indent 4 }}
+{{ .Values.server.config.properties.custom | indent 4 }}
+{{- end }}
+{{- end }}
 
 {{ if .Values.server.config.https }}
   password-authenticator.properties: |
@@ -45,8 +73,18 @@ data:
 
 {{ if .Values.server.log }}
   log.properties: |
-{{- range $key, $val := .Values.server.log }}
+{{- if (eq .Values.server.log.properties.override true) }}
+{{ printf "#============= Custom log properties (override) ==========" | indent 4 }}
+{{ .Values.server.log.properties.custom | indent 4 }}
+{{- else }}
+{{- range $key, $val := .Values.server.log.categories }}
 {{ printf "%s=%s" $key $val | indent 4}}
+{{- end }}
+{{- if .Values.server.log.properties.custom }}
+{{ println }}
+{{- printf "#============= Custom log properties ==========" | indent 4 }}
+{{ .Values.server.log.properties.custom | indent 4 }}
+{{- end }}
 {{- end }}
 {{ end -}}
 
@@ -90,35 +128,8 @@ data:
     #!/bin/bash
     cp {{ .Values.server.config.mapPath }}/*.properties $PRESTO_CONF_DIR
     cp {{ .Values.server.config.mapPath }}/*.config $PRESTO_CONF_DIR
-
-{{- if .Values.server.files }}
-
-    # Start creating custom configuration files
-{{- range $elem := .Values.server.files }}
-{{- if hasPrefix "/" $elem.path }}
-{{- if ( hasKey $elem "override" ) }}
-{{- if ( eq $elem.override true ) }}
-{{ printf "echo -n '%s' | base64 --decode > %s" $elem.contents $elem.path | indent 4 }}
-{{- end }}
-{{ else }}
-{{ printf "echo '' >> %s" $elem.path | indent 4 }}
-{{ printf "echo '# ------- Custom --------' >> %s" $elem.path | indent 4 }}
-{{ printf "echo -n '%s' | base64 --decode >> %s" $elem.contents $elem.path | indent 4 }}
-{{- end }}
-{{ else }}
-{{- if ( hasKey $elem "override" ) }}
-{{- if ( eq $elem.override true ) }}
-{{ printf "echo -n '%s' | base64 --decode > ${PRESTO_CONF_DIR}/%s" $elem.contents $elem.path | indent 4 }}
-{{- end }}
-{{ else }}
-{{ printf "echo '' >> %s" $elem.path | indent 4 }}
-{{ printf "echo '# ------- Custom --------' >> ${PRESTO_CONF_DIR}/%s" $elem.path | indent 4 }}
-{{ printf "echo -n '%s' | base64 --decode >> ${PRESTO_CONF_DIR}/%s" $elem.contents $elem.path | indent 4 }}
-{{- end }}
-{{- end }}
-{{- end }}
-    # Finish creating custom configuration files
-{{- end }}
+    cp {{ .Values.server.config.mapPath }}/*.json $PRESTO_CONF_DIR
+    cp {{ .Values.server.config.catalogMapPath }}/*.properties $PRESTO_CONF_DIR/catalog
 
 {{- if .Values.hive }}
 

--- a/stable/presto/templates/worker-configmap.yaml
+++ b/stable/presto/templates/worker-configmap.yaml
@@ -11,10 +11,29 @@ metadata:
     component: worker
 data:
   node.properties: |
+{{- if (eq .Values.server.node.properties.override true) }}
+    # ============= Custom node properties ==========
+    {{- range .Values.server.node.properties.custom }}
+    {{ . }}
+    {{- end }}
+{{- else }}
     node.environment={{ .Values.server.node.environment }}
     node.data-dir={{ .Values.server.node.dataDir }}
+{{- if .Values.server.node.properties.custom }}
+    # ============= Custom node properties ==========
+    {{- range .Values.server.node.properties.custom }}
+    {{ . }}
+    {{- end }}
+{{- end }}
+{{- end }}
 
   jvm.config: |
+{{- if (eq .Values.server.jvm.properties.override true) }}
+    # ============= Custom jvm properties ==========
+    {{- range .Values.server.jvm.properties.custom }}
+    {{ . }}
+    {{- end }}
+{{- else }}
     -server
     -Xmx{{ .Values.server.jvm.maxHeapSize }}
     -XX:+{{ .Values.server.jvm.gcMethod.type }}
@@ -23,8 +42,22 @@ data:
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+HeapDumpOnOutOfMemoryError
     -XX:+ExitOnOutOfMemoryError
+{{- if .Values.server.jvm.properties.custom }}
+    # ============= Custom jvm properties ==========
+    {{- range .Values.server.jvm.properties.custom }}
+    {{ . }}
+    {{- end }}
+{{- end }}
+{{- end }}
 
   config.properties: |
+{{- if (eq .Values.server.config.properties.override true) }}
+    # ============= Custom config properties ==========
+    {{- range .Values.server.config.properties.custom }}
+    {{ . }}
+    {{- end }}
+    coordinator=false
+{{- else }}
     coordinator=false
     http-server.http.port={{ .Values.server.config.http.port }}
 {{- if .Values.server.config.https }}
@@ -37,14 +70,27 @@ data:
     query.max-memory={{ .Values.server.config.query.maxMemory }}
     query.max-memory-per-node={{ .Values.server.config.query.maxMemoryPerNode }}
     discovery.uri=http://{{ template "presto.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.config.http.port }}
+{{- if .Values.server.config.properties.custom }}
+    # ============= Custom config properties ==========
+    {{- range .Values.server.config.properties.custom }}
+    {{ . }}
+    {{- end }}
+{{- end }}
+{{- end }}
 
-{{- if .Values.server.config.https }}
+{{ if .Values.server.config.https }}
   password-authenticator.properties: |
     password-authenticator.name=v3io
 {{- end }}
 
 {{ if .Values.server.log }}
   log.properties: |
+{{- if (eq .Values.server.log.properties.override true) }}
+    # ============= Custom log properties ==========
+    {{- range .Values.server.log.properties.custom }}
+    {{ . }}
+    {{- end }}
+{{- else }}
 {{- range $key, $val := .Values.server.log }}
 {{ printf "%s=%s" $key $val | indent 4}}
 {{- end }}
@@ -53,6 +99,13 @@ data:
 {{- range $key, $val := .Values.server.config.extra }}
 {{ printf "%s: |" $key | indent 2 }}
 {{ $val | indent 4 }}
+{{- end }}
+{{- if .Values.server.log.properties.custom }}
+    # ============= Custom log properties ==========
+    {{- range .Values.server.log.properties.custom }}
+    {{ . }}
+    {{- end }}
+{{- end }}
 {{- end }}
 
   health_check.sh: |

--- a/stable/presto/templates/worker-configmap.yaml
+++ b/stable/presto/templates/worker-configmap.yaml
@@ -45,14 +45,14 @@ data:
 
 {{ if .Values.server.log }}
   log.properties: |
-{{- range $key, $val := .Values.server.log.categories }}
+{{- range $key, $val := .Values.server.log }}
 {{ printf "%s=%s" $key $val | indent 4}}
 {{- end }}
+{{ end -}}
 
 {{- range $key, $val := .Values.server.config.extra }}
 {{ printf "%s: |" $key | indent 2 }}
 {{ $val | indent 4 }}
-{{- end }}
 {{- end }}
 
   health_check.sh: |

--- a/stable/presto/templates/worker-configmap.yaml
+++ b/stable/presto/templates/worker-configmap.yaml
@@ -95,7 +95,7 @@ data:
 
     # Start creating custom configuration files
 {{- range $elem := .Values.server.files }}
-{{- if contains "/" $elem.path }}
+{{- if hasPrefix "/" $elem.path }}
 {{- if ( hasKey $elem "override" ) }}
 {{- if ( eq $elem.override true ) }}
 {{ printf "echo -n '%s' | base64 --decode > %s" $elem.contents $elem.path | indent 4 }}

--- a/stable/presto/templates/worker-configmap.yaml
+++ b/stable/presto/templates/worker-configmap.yaml
@@ -98,22 +98,22 @@ data:
 {{- if contains "/" $elem.path }}
 {{- if ( hasKey $elem "override" ) }}
 {{- if ( eq $elem.override true ) }}
-{{ printf "echo -n '%s' | base64 --decode > %s" $elem.content $elem.path | indent 4 }}
+{{ printf "echo -n '%s' | base64 --decode > %s" $elem.contents $elem.path | indent 4 }}
 {{- end }}
 {{ else }}
 {{ printf "echo '' >> %s" $elem.path | indent 4 }}
 {{ printf "echo '# ------- Custom --------' >> %s" $elem.path | indent 4 }}
-{{ printf "echo -n '%s' | base64 --decode >> %s" $elem.content $elem.path | indent 4 }}
+{{ printf "echo -n '%s' | base64 --decode >> %s" $elem.contents $elem.path | indent 4 }}
 {{- end }}
 {{ else }}
 {{- if ( hasKey $elem "override" ) }}
 {{- if ( eq $elem.override true ) }}
-{{ printf "echo -n '%s' | base64 --decode > ${PRESTO_CONF_DIR}/%s" $elem.content $elem.path | indent 4 }}
+{{ printf "echo -n '%s' | base64 --decode > ${PRESTO_CONF_DIR}/%s" $elem.contents $elem.path | indent 4 }}
 {{- end }}
 {{ else }}
 {{ printf "echo '' >> %s" $elem.path | indent 4 }}
 {{ printf "echo '# ------- Custom --------' >> ${PRESTO_CONF_DIR}/%s" $elem.path | indent 4 }}
-{{ printf "echo -n '%s' | base64 --decode >> ${PRESTO_CONF_DIR}/%s" $elem.content $elem.path | indent 4 }}
+{{ printf "echo -n '%s' | base64 --decode >> ${PRESTO_CONF_DIR}/%s" $elem.contents $elem.path | indent 4 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/presto/templates/worker-configmap.yaml
+++ b/stable/presto/templates/worker-configmap.yaml
@@ -13,26 +13,20 @@ data:
   node.properties: |
 {{- if (eq .Values.server.node.properties.override true) }}
     # ============= Custom node properties ==========
-    {{- range .Values.server.node.properties.custom }}
-    {{ . }}
-    {{- end }}
+    {{- .Values.server.node.properties.custom | b64dec | toYaml | indent 2 }}
 {{- else }}
     node.environment={{ .Values.server.node.environment }}
     node.data-dir={{ .Values.server.node.dataDir }}
 {{- if .Values.server.node.properties.custom }}
     # ============= Custom node properties ==========
-    {{- range .Values.server.node.properties.custom }}
-    {{ . }}
-    {{- end }}
+    {{- .Values.server.node.properties.custom | b64dec | toYaml | indent 2 }}
 {{- end }}
 {{- end }}
 
   jvm.config: |
 {{- if (eq .Values.server.jvm.properties.override true) }}
     # ============= Custom jvm properties ==========
-    {{- range .Values.server.jvm.properties.custom }}
-    {{ . }}
-    {{- end }}
+    {{- .Values.server.jvm.properties.custom | b64dec | toYaml | indent 2 }}
 {{- else }}
     -server
     -Xmx{{ .Values.server.jvm.maxHeapSize }}
@@ -44,18 +38,14 @@ data:
     -XX:+ExitOnOutOfMemoryError
 {{- if .Values.server.jvm.properties.custom }}
     # ============= Custom jvm properties ==========
-    {{- range .Values.server.jvm.properties.custom }}
-    {{ . }}
-    {{- end }}
+    {{- .Values.server.jvm.properties.custom | b64dec | toYaml | indent 2 }}
 {{- end }}
 {{- end }}
 
   config.properties: |
 {{- if (eq .Values.server.config.properties.override true) }}
     # ============= Custom config properties ==========
-    {{- range .Values.server.config.properties.custom }}
-    {{ . }}
-    {{- end }}
+    {{- .Values.server.config.properties.custom | b64dec | toYaml | indent 2 }}
     coordinator=false
 {{- else }}
     coordinator=false
@@ -72,9 +62,7 @@ data:
     discovery.uri=http://{{ template "presto.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.config.http.port }}
 {{- if .Values.server.config.properties.custom }}
     # ============= Custom config properties ==========
-    {{- range .Values.server.config.properties.custom }}
-    {{ . }}
-    {{- end }}
+    {{- .Values.server.config.properties.custom | b64dec | toYaml | indent 2 }}
 {{- end }}
 {{- end }}
 
@@ -87,11 +75,9 @@ data:
   log.properties: |
 {{- if (eq .Values.server.log.properties.override true) }}
     # ============= Custom log properties ==========
-    {{- range .Values.server.log.properties.custom }}
-    {{ . }}
-    {{- end }}
+    {{- .Values.server.log.properties.custom | b64dec | toYaml | indent 2 }}
 {{- else }}
-{{- range $key, $val := .Values.server.log }}
+{{- range $key, $val := .Values.server.log.categories }}
 {{ printf "%s=%s" $key $val | indent 4}}
 {{- end }}
 {{ end -}}
@@ -102,9 +88,7 @@ data:
 {{- end }}
 {{- if .Values.server.log.properties.custom }}
     # ============= Custom log properties ==========
-    {{- range .Values.server.log.properties.custom }}
-    {{ . }}
-    {{- end }}
+    {{- .Values.server.log.properties.custom | b64dec | toYaml | indent 2 }}
 {{- end }}
 {{- end }}
 

--- a/stable/presto/templates/worker-configmap.yaml
+++ b/stable/presto/templates/worker-configmap.yaml
@@ -96,16 +96,20 @@ data:
     # Start creating custom configuration files
 {{- range $elem := .Values.server.files }}
 {{- if contains "/" $elem.path }}
+{{- if ( hasKey $elem "override" ) }}
 {{- if ( eq $elem.override true ) }}
 {{ printf "echo -n '%s' | base64 --decode > %s" $elem.content $elem.path | indent 4 }}
+{{- end }}
 {{ else }}
 {{ printf "echo '' >> %s" $elem.path | indent 4 }}
 {{ printf "echo '# ------- Custom --------' >> %s" $elem.path | indent 4 }}
 {{ printf "echo -n '%s' | base64 --decode >> %s" $elem.content $elem.path | indent 4 }}
 {{- end }}
 {{ else }}
+{{- if ( hasKey $elem "override" ) }}
 {{- if ( eq $elem.override true ) }}
 {{ printf "echo -n '%s' | base64 --decode > ${PRESTO_CONF_DIR}/%s" $elem.content $elem.path | indent 4 }}
+{{- end }}
 {{ else }}
 {{ printf "echo '' >> %s" $elem.path | indent 4 }}
 {{ printf "echo '# ------- Custom --------' >> ${PRESTO_CONF_DIR}/%s" $elem.path | indent 4 }}

--- a/stable/presto/templates/worker-configmap.yaml
+++ b/stable/presto/templates/worker-configmap.yaml
@@ -11,23 +11,10 @@ metadata:
     component: worker
 data:
   node.properties: |
-{{- if (eq .Values.server.node.properties.override true) }}
-    # ============= Custom node properties ==========
-    {{- .Values.server.node.properties.custom | b64dec | toYaml | indent 2 }}
-{{- else }}
     node.environment={{ .Values.server.node.environment }}
     node.data-dir={{ .Values.server.node.dataDir }}
-{{- if .Values.server.node.properties.custom }}
-    # ============= Custom node properties ==========
-    {{- .Values.server.node.properties.custom | b64dec | toYaml | indent 2 }}
-{{- end }}
-{{- end }}
 
   jvm.config: |
-{{- if (eq .Values.server.jvm.properties.override true) }}
-    # ============= Custom jvm properties ==========
-    {{- .Values.server.jvm.properties.custom | b64dec | toYaml | indent 2 }}
-{{- else }}
     -server
     -Xmx{{ .Values.server.jvm.maxHeapSize }}
     -XX:+{{ .Values.server.jvm.gcMethod.type }}
@@ -36,18 +23,8 @@ data:
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+HeapDumpOnOutOfMemoryError
     -XX:+ExitOnOutOfMemoryError
-{{- if .Values.server.jvm.properties.custom }}
-    # ============= Custom jvm properties ==========
-    {{- .Values.server.jvm.properties.custom | b64dec | toYaml | indent 2 }}
-{{- end }}
-{{- end }}
 
   config.properties: |
-{{- if (eq .Values.server.config.properties.override true) }}
-    # ============= Custom config properties ==========
-    {{- .Values.server.config.properties.custom | b64dec | toYaml | indent 2 }}
-    coordinator=false
-{{- else }}
     coordinator=false
     http-server.http.port={{ .Values.server.config.http.port }}
 {{- if .Values.server.config.https }}
@@ -60,11 +37,6 @@ data:
     query.max-memory={{ .Values.server.config.query.maxMemory }}
     query.max-memory-per-node={{ .Values.server.config.query.maxMemoryPerNode }}
     discovery.uri=http://{{ template "presto.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.config.http.port }}
-{{- if .Values.server.config.properties.custom }}
-    # ============= Custom config properties ==========
-    {{- .Values.server.config.properties.custom | b64dec | toYaml | indent 2 }}
-{{- end }}
-{{- end }}
 
 {{ if .Values.server.config.https }}
   password-authenticator.properties: |
@@ -73,22 +45,13 @@ data:
 
 {{ if .Values.server.log }}
   log.properties: |
-{{- if (eq .Values.server.log.properties.override true) }}
-    # ============= Custom log properties ==========
-    {{- .Values.server.log.properties.custom | b64dec | toYaml | indent 2 }}
-{{- else }}
 {{- range $key, $val := .Values.server.log.categories }}
 {{ printf "%s=%s" $key $val | indent 4}}
 {{- end }}
-{{ end -}}
 
 {{- range $key, $val := .Values.server.config.extra }}
 {{ printf "%s: |" $key | indent 2 }}
 {{ $val | indent 4 }}
-{{- end }}
-{{- if .Values.server.log.properties.custom }}
-    # ============= Custom log properties ==========
-    {{- .Values.server.log.properties.custom | b64dec | toYaml | indent 2 }}
 {{- end }}
 {{- end }}
 
@@ -128,11 +91,27 @@ data:
     cp {{ .Values.server.config.mapPath }}/*.properties $PRESTO_CONF_DIR
     cp {{ .Values.server.config.mapPath }}/*.config $PRESTO_CONF_DIR
 
-{{- if .Values.server.configuration.files }}
+{{- if .Values.server.files }}
 
     # Start creating custom configuration files
-{{- range $name, $content := .Values.server.configuration.files }}
-{{ printf "echo -n '%s' | base64 --decode > $PRESTO_CONF_DIR/%s" $content $name | indent 4 }}
+{{- range $elem := .Values.server.files }}
+{{- if contains "/" $elem.path }}
+{{- if ( eq $elem.override true ) }}
+{{ printf "echo -n '%s' | base64 --decode > %s" $elem.content $elem.path | indent 4 }}
+{{ else }}
+{{ printf "echo '' >> %s" $elem.path | indent 4 }}
+{{ printf "echo '# ------- Custom --------' >> %s" $elem.path | indent 4 }}
+{{ printf "echo -n '%s' | base64 --decode >> %s" $elem.content $elem.path | indent 4 }}
+{{- end }}
+{{ else }}
+{{- if ( eq $elem.override true ) }}
+{{ printf "echo -n '%s' | base64 --decode > ${PRESTO_CONF_DIR}/%s" $elem.content $elem.path | indent 4 }}
+{{ else }}
+{{ printf "echo '' >> %s" $elem.path | indent 4 }}
+{{ printf "echo '# ------- Custom --------' >> ${PRESTO_CONF_DIR}/%s" $elem.path | indent 4 }}
+{{ printf "echo -n '%s' | base64 --decode >> ${PRESTO_CONF_DIR}/%s" $elem.content $elem.path | indent 4 }}
+{{- end }}
+{{- end }}
 {{- end }}
     # Finish creating custom configuration files
 {{- end }}

--- a/stable/presto/templates/worker-deployment.yaml
+++ b/stable/presto/templates/worker-deployment.yaml
@@ -27,6 +27,9 @@ spec:
         - name: config-volume
           configMap:
             name: {{ template "presto.worker" . }}
+        - name: catalog-config-volume
+          configMap:
+            name: presto.catalog
         - name: daemon-health
           emptyDir: {}
 {{- if .Values.server.config.https }}
@@ -71,6 +74,8 @@ spec:
           volumeMounts:
             - mountPath: {{ .Values.server.config.mapPath }}
               name: config-volume
+            - mountPath: {{ .Values.server.config.catalogMapPath }}
+              name: catalog-config-volume
             - mountPath: /var/run/iguazio/daemon_health
               name: daemon-health
 {{- if .Values.server.config.https }}

--- a/stable/presto/values.yaml
+++ b/stable/presto/values.yaml
@@ -3,12 +3,18 @@ server:
   node:
     environment: production
     dataDir: /presto/etc/data
+    properties:
+        override: false
   log:
+    properties:
+      override: false
     categories:
       com.facebook.presto: INFO
       io.iguaz.v3io: INFO
       io.iguaz.v3io.daemon: INFO
   config:
+    properties:
+      override: false
     mapPath: /etc/config/presto
     catalogMapPath: /etc/config/presto/catalog
     path: /presto/etc
@@ -29,6 +35,8 @@ server:
     extra: {}
 
   jvm:
+    properties:
+      override: false
     maxHeapSize: "8G"
     gcMethod:
       type: "UseG1GC"

--- a/stable/presto/values.yaml
+++ b/stable/presto/values.yaml
@@ -4,11 +4,13 @@ server:
     environment: production
     dataDir: /presto/etc/data
   log:
-    com.facebook.presto: INFO
-    io.iguaz.v3io: INFO
-    io.iguaz.v3io.daemon: INFO
+    categories:
+      com.facebook.presto: INFO
+      io.iguaz.v3io: INFO
+      io.iguaz.v3io.daemon: INFO
   config:
     mapPath: /etc/config/presto
+    catalogMapPath: /etc/config/presto/catalog
     path: /presto/etc
     http:
       port: 8080


### PR DESCRIPTION
Custom contents can be added to desired files. Note, contents should be encoded with Base64
Example 1: using **values** file
```
helm update <...> --values ./values-presto.yaml
```
Here is example of the values file contents (partial)
```server:
  workers: 1
  node:
    properties:
      override: true
      custom: |
        node.environment=production
        node.data-dir=/presto/etc/data
  log:
    properties:
      override: false
      custom: |
        com.iguazio.test.log.properties=INFO
  jvm:
    properties:
      override: false
      custom: |
        -XX:NewSize=512M
...
    extra:
      filename.properties: |
        Plain text
        multi
        line
        file
        contents

      resource-groups.properties: |
        resource-groups.configuration-manager=file
        resource-groups.config-file=etc/resource_groups.json

      resource_groups.json: |
        {
          "rootGroups": [
            {
              "name": "global",
              "softMemoryLimit": "80%",
              "hardConcurrencyLimit": 100,
....
```