### PR TITLE
Allowing kubectl top pods in shell and jupyter (role update)

### DIFF
--- a/stable/jupyter/Chart.yaml
+++ b/stable/jupyter/Chart.yaml
@@ -1,5 +1,5 @@
 name: jupyter
-version: 0.6.8
+version: 0.6.9
 appVersion: ">=2.0.0"
 description: Jupyter
 home: https://jupyter.org/

--- a/stable/jupyter/templates/jupyter-mpi-job-executor-role.yaml
+++ b/stable/jupyter/templates/jupyter-mpi-job-executor-role.yaml
@@ -20,4 +20,3 @@ rules:
 - apiGroups: ["metrics.k8s.io"]
   resources: ["pods"]
   verbs: ["list", "get"]
-

--- a/stable/jupyter/templates/jupyter-mpi-job-executor-role.yaml
+++ b/stable/jupyter/templates/jupyter-mpi-job-executor-role.yaml
@@ -17,3 +17,7 @@ rules:
 - apiGroups: [""]
   resources: ["pods/log"]
   verbs: ["get", "list"]
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods"]
+  verbs: ["list", "get"]
+

--- a/stable/shell/Chart.yaml
+++ b/stable/shell/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: Shell access to data services
 name: shell
-version: 0.9.4
+version: 0.9.5
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2017/09/iguazio_logo_2017_w_c.png
 sources:

--- a/stable/shell/templates/shell-service-admin-role.yaml
+++ b/stable/shell/templates/shell-service-admin-role.yaml
@@ -14,3 +14,6 @@ rules:
 - apiGroups: ["", "batch"]
   resources: ["jobs", "cronjobs"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods"]
+  verbs: ["list", "get"]


### PR DESCRIPTION
- in jupyter - for job executor executor
- in shell - only for service admin role