### PR TITLE
mpi-operator fix (0.0.2)

### DIFF
--- a/stable/mpi-operator/Chart.yaml
+++ b/stable/mpi-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=0.2.1"
 description: Kubeflow MPI job operator
 name: mpi-operator
-version: 0.0.1
+version: 0.0.2
 home: https://www.kubeflow.org/
 icon: https://github.com/kubeflow/marketing-materials/blob/master/logos/Raster/Kubeflow-Logo-RGB.png
 sources:

--- a/stable/mpi-operator/templates/mpi-operator-deployment.yaml
+++ b/stable/mpi-operator/templates/mpi-operator-deployment.yaml
@@ -33,6 +33,9 @@ spec:
           "--kubectl-delivery-image",
           "{{ .Values.image.kubectlDelivery.repository }}:{{ .Values.image.kubectlDelivery.tag }}"
         ]
+        env:
+        - name: KUBEFLOW_NAMESPACE
+          value: {{ .Release.Namespace }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
 {{- end }}

--- a/stable/mpi-operator/templates/mpi-operator-deployment.yaml
+++ b/stable/mpi-operator/templates/mpi-operator-deployment.yaml
@@ -31,7 +31,9 @@ spec:
         args: [
           "-alsologtostderr",
           "--kubectl-delivery-image",
-          "{{ .Values.image.kubectlDelivery.repository }}:{{ .Values.image.kubectlDelivery.tag }}"
+          "{{ .Values.image.kubectlDelivery.repository }}:{{ .Values.image.kubectlDelivery.tag }}",
+          "--namespace",
+          "{{ .Release.Namespace }}"
         ]
         env:
         - name: KUBEFLOW_NAMESPACE


### PR DESCRIPTION
- Passing in namespace arg to pod
- Adding namespace env var to pod


Note, this still works only with a custom image `https://quay.io/repository/iguazio/mpi-operator?tab=tags` which includes a code fix