### PR TITLE
mpi-operator - back to v1alpha1 and 0.2.0

### DIFF
--- a/stable/mpi-operator/Chart.yaml
+++ b/stable/mpi-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: ">=0.2.1"
+appVersion: "==0.2.0"
 description: Kubeflow MPI job operator
 name: mpi-operator
-version: 0.0.2
+version: 0.0.3
 home: https://www.kubeflow.org/
 icon: https://github.com/kubeflow/marketing-materials/blob/master/logos/Raster/Kubeflow-Logo-RGB.png
 sources:

--- a/stable/mpi-operator/templates/mpi-operator-clusterrole.yaml
+++ b/stable/mpi-operator/templates/mpi-operator-clusterrole.yaml
@@ -35,14 +35,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - endpoints
-  verbs:
-  - create
-  - get
-  - update
-- apiGroups:
-  - ""
-  resources:
   - events
   verbs:
   - create
@@ -94,7 +86,6 @@ rules:
   - kubeflow.org
   resources:
   - mpijobs
-  - mpijobs/status
   verbs:
   - "*"
 {{- end }}

--- a/stable/mpi-operator/templates/mpi-operator-deployment.yaml
+++ b/stable/mpi-operator/templates/mpi-operator-deployment.yaml
@@ -30,6 +30,8 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args: [
           "-alsologtostderr",
+          "--gpus-per-node",
+          "{{ .Values.deployment.gpusPerNode }}",
           "--kubectl-delivery-image",
           "{{ .Values.image.kubectlDelivery.repository }}:{{ .Values.image.kubectlDelivery.tag }}",
           "--namespace",

--- a/stable/mpi-operator/templates/mpijob-crd.yaml
+++ b/stable/mpi-operator/templates/mpijob-crd.yaml
@@ -11,7 +11,7 @@ metadata:
     component: crd
 spec:
   group: kubeflow.org
-  version: v1alpha2
+  version: v1alpha1
   scope: Namespaced
   names:
     plural: mpijobs
@@ -20,27 +20,88 @@ spec:
     shortNames:
     - mj
     - mpij
-  subresources:
-    status: {}
   validation:
     openAPIV3Schema:
       properties:
         spec:
-          properties:
-            slotsPerWorker:
-              type: integer
-              minimum: 1
-            mpiReplicaSpecs:
-              properties:
-                Launcher:
-                  properties:
-                    replicas:
-                      type: integer
-                      minimum: 1
-                      maximum: 1
-                Worker:
-                  properties:
-                    replicas:
-                      type: integer
-                      minimum: 1
+          title: The MPIJob spec
+          description: Only one of `gpus`, `processingUnits`, or `replicas` should be specified
+          oneOf:
+          - properties:
+              gpus:
+                title: Total number of GPUs
+                description: Valid values are 1, 2, 4, or any multiple of 8
+                oneOf:
+                - type: integer
+                  enum:
+                  - 1
+                  - 2
+                  - 4
+                - type: integer
+                  multipleOf: 8
+                  minimum: 8
+              slotsPerWorker:
+                title: The number of slots per worker used in hostfile
+                description: Defaults to the number of processing units per worker
+                type: integer
+                minimum: 1
+              gpusPerNode:
+                title: The maximum number of GPUs available per node
+                description: Defaults to the number of GPUs per worker
+                type: integer
+                minimum: 1
+            required:
+            - gpus
+          - properties:
+              processingUnits:
+                title: Total number of processing units
+                description: Valid values are 1, 2, 4, or any multiple of 8
+                oneOf:
+                - type: integer
+                  enum:
+                  - 1
+                  - 2
+                  - 4
+                - type: integer
+                  multipleOf: 8
+                  minimum: 8
+              slotsPerWorker:
+                title: The number of slots per worker used in hostfile
+                description: Defaults to the number of processing units per worker
+                type: integer
+                minimum: 1
+              processingUnitsPerNode:
+                title: The maximum number of processing units available per node
+                description: Defaults to the number of processing units per worker
+                type: integer
+                minimum: 1
+              processingResourceType:
+                title: The processing resource type, e.g. 'nvidia.com/gpu' or 'cpu'
+                description: Defaults to 'nvidia.com/gpu'
+                type: string
+                enum:
+                  - nvidia.com/gpu
+                  - cpu
+            required:
+            - processingUnits
+          - properties:
+              replicas:
+                title: Total number of replicas
+                description: The processing resource limit should be specified for each replica
+                type: integer
+                minimum: 1
+              slotsPerWorker:
+                title: The number of slots per worker used in hostfile
+                description: Defaults to the number of processing units per worker
+                type: integer
+                minimum: 1
+              processingResourceType:
+                title: The processing resource type, e.g. 'nvidia.com/gpu' or 'cpu'
+                description: Defaults to 'nvidia.com/gpu'
+                type: string
+                enum:
+                  - nvidia.com/gpu
+                  - cpu
+            required:
+            - replicas
 {{- end }}

--- a/stable/mpi-operator/values.yaml
+++ b/stable/mpi-operator/values.yaml
@@ -11,12 +11,13 @@ rbac:
 
 deployment:
   create: true
+  gpusPerNode: 1  # for mpioperator 0.2.0
 
 image:
   deployment:
     replicas: 1
     repository: mpioperator/mpi-operator
-    tag: 0.2.1
+    tag: 0.2.0
     pullPolicy: IfNotPresent
   kubectlDelivery:
     repository: mpioperator/kubectl-delivery


### PR DESCRIPTION
Rolling back to first iteration due to stability issues (hmm, more like broken af)
- New deployment arg demanding same gpu number per node 👎 
- Resource changes (rolebinding rules, crd, deployment)
- Image back to 0.2.0