### PR TITLE
Fix helm chart - make it agnostic to empty hive section

### DIFF
--- a/stable/presto/Chart.yaml
+++ b/stable/presto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: Distributed SQL query engine for running interactive analytic queries
 name: presto
-version: 0.6.4
+version: 0.6.5
 home: https://prestodb.io
 icon: https://prestodb.io/static/presto.png
 sources:

--- a/stable/presto/templates/catalog-configmap.yaml
+++ b/stable/presto/templates/catalog-configmap.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-{{- $overrideHiveProperties := .Values.hive.properties.override -}}
+{{- $overrideHiveProperties := .Values.server.catalog.hive.override -}}
 {{- if .Values.hive }}
 {{- if and (hasKey .Values.server.config.catalogs "hive.properties") (not ($overrideHiveProperties)) }}
   hive.properties: |

--- a/stable/presto/values.yaml
+++ b/stable/presto/values.yaml
@@ -43,9 +43,11 @@ server:
       type: "UseG1GC"
       g1:
         heapRegionSize: "32M"
+
+  catalog:
+    hive:
+        override: false
 hive:
-  properties:
-    override: false
   hostname: hive
   port: 9083
 


### PR DESCRIPTION
- move `override` from `hive` to different location to avoid crash if `hive` is set to empty value