### PR TITLE
Fix hive default catalog creation

### DIFF
--- a/stable/presto/Chart.yaml
+++ b/stable/presto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: Distributed SQL query engine for running interactive analytic queries
 name: presto
-version: 0.6.4
+version: 0.6.5
 home: https://prestodb.io
 icon: https://prestodb.io/static/presto.png
 sources:

--- a/stable/presto/Chart.yaml
+++ b/stable/presto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: Distributed SQL query engine for running interactive analytic queries
 name: presto
-version: 0.6.5
+version: 0.6.6
 home: https://prestodb.io
 icon: https://prestodb.io/static/presto.png
 sources:

--- a/stable/presto/templates/catalog-configmap.yaml
+++ b/stable/presto/templates/catalog-configmap.yaml
@@ -10,11 +10,14 @@ metadata:
 data:
 {{- $overrideHiveProperties := .Values.server.catalog.hive.override -}}
 {{- if .Values.hive }}
-{{- if and (hasKey .Values.server.config.catalogs "hive.properties") (not ($overrideHiveProperties)) }}
+{{- if not ($overrideHiveProperties) }}
   hive.properties: |
     connector.name=hive-hadoop2
     hive.metastore.uri=thrift://{{ .Values.hive.hostname }}:{{ .Values.hive.port }}
+{{- if hasKey .Values.server.config.catalogs "hive.properties" }}
+{{ print "======== Custom properties =========" | indent 4 }}
 {{ index .Values.server.config.catalogs "hive.properties" | indent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/stable/presto/templates/catalog-configmap.yaml
+++ b/stable/presto/templates/catalog-configmap.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-{{- $overrideHiveProperties := .Values.hive.properties.override -}}
+{{- $overrideHiveProperties := .Values.server.catalog.hive.override -}}
 {{- if .Values.hive }}
 {{- if and (hasKey .Values.server.config.catalogs "hive.properties") (not ($overrideHiveProperties)) }}
   hive.properties: |

--- a/stable/presto/values.yaml
+++ b/stable/presto/values.yaml
@@ -43,9 +43,11 @@ server:
       type: "UseG1GC"
       g1:
         heapRegionSize: "32M"
+
+  catalog:
+    hive:
+        override: false
 hive:
-  properties:
-    override: false
   hostname: hive
   port: 9083
 

--- a/stable/presto/values.yaml
+++ b/stable/presto/values.yaml
@@ -46,7 +46,7 @@ server:
 
   catalog:
     hive:
-        override: false
+      override: false
 hive:
   hostname: hive
   port: 9083


### PR DESCRIPTION
 - fix issue introduced by recent update - hive default catalog should be created if no custom `hive.properties` have been provided