### PR TITLE
IG-13225 - Presto/Hive failed to start

### DIFF
--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: MariaDB (MySQL) service
 name: mariadb
-version: 0.2.2
+version: 0.2.3
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2017/09/iguazio_logo_2017_w_c.png
 sources:

--- a/stable/mariadb/templates/mariadb-configmap.yaml
+++ b/stable/mariadb/templates/mariadb-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
 data:
 
   health_check.sh: |
-    mysqladmin status
+    mysqladmin --protocol=TCP -uroot -p$MYSQL_ROOT_PASSWORD status
 
   init-v3io-mariadb.sh: |
     #!/usr/bin/env bash

--- a/stable/mariadb/values.yaml
+++ b/stable/mariadb/values.yaml
@@ -18,14 +18,14 @@ server:
 
   livenessProbe:
     ## Initializing the database could take some time
-    initialDelaySeconds: 10
+    initialDelaySeconds: 60
     ## Try failureThreshold times before giving up.
     failureThreshold: 3
     ## Default Kubernetes values
     periodSeconds: 10
   readinessProbe:
-    initialDelaySeconds: 10
-    failureThreshold: 3
+    initialDelaySeconds: 30
+    failureThreshold: 6
     ## Default Kubernetes values
     periodSeconds: 10
 


### PR DESCRIPTION
- modify health-check - use TCP protocol explicitly to check readiness
- increase initial delay
- increase readiness failure threshold