### PR TITLE
IG-13178: change default of hive.parquet.use-column-names to true

### DIFF
--- a/stable/presto/templates/catalog-configmap.yaml
+++ b/stable/presto/templates/catalog-configmap.yaml
@@ -14,6 +14,7 @@ data:
   hive.properties: |
     connector.name=hive-hadoop2
     hive.metastore.uri=thrift://{{ .Values.hive.hostname }}:{{ .Values.hive.port }}
+    hive.parquet.use-column-names=true
 {{- if hasKey .Values.server.config.catalogs "hive.properties" }}
 {{ print "======== Custom properties =========" | indent 4 }}
 {{ index .Values.server.config.catalogs "hive.properties" | indent 4 }}


### PR DESCRIPTION
- [x] change default of **hive.parquet.use-column-names** to **true**

NOTE: this PR depends on decision regarding the default value. See discussion in Jira.