### PR TITLE
Fix hive custom hive catalog properties file (advanced Presto UI)

### DIFF
--- a/stable/presto/templates/catalog-configmap.yaml
+++ b/stable/presto/templates/catalog-configmap.yaml
@@ -15,7 +15,7 @@ data:
     connector.name=hive-hadoop2
     hive.metastore.uri=thrift://{{ .Values.hive.hostname }}:{{ .Values.hive.port }}
 {{- if hasKey .Values.server.config.catalogs "hive.properties" }}
-{{ print "======== Custom properties =========" | indent 4 }}
+{{ print "# ======== Custom properties =========" | indent 4 }}
 {{ index .Values.server.config.catalogs "hive.properties" | indent 4 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Add missing '#' character at the beginning of the line