### PR TITLE
Move v3io connector configuration from docker file to configMap

### DIFF
--- a/stable/presto/Chart.yaml
+++ b/stable/presto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: Distributed SQL query engine for running interactive analytic queries
 name: presto
-version: 0.6.7
+version: 0.6.8
 home: https://prestodb.io
 icon: https://prestodb.io/static/presto.png
 sources:

--- a/stable/presto/templates/_helpers.tpl
+++ b/stable/presto/templates/_helpers.tpl
@@ -50,6 +50,20 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 
+
+{{- define "presto.catalog" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-catalog" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-catalog" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/stable/presto/templates/catalog-configmap.yaml
+++ b/stable/presto/templates/catalog-configmap.yaml
@@ -8,6 +8,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
+  v3io.properties: |
+    connector.name=v3io
+
 {{- $overrideHiveProperties := .Values.server.catalog.hive.override -}}
 {{- if .Values.hive }}
 {{- if not ($overrideHiveProperties) }}

--- a/stable/presto/templates/catalog-configmap.yaml
+++ b/stable/presto/templates/catalog-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: presto.catalog
+  name: {{ template "presto.catalog" . }}
   labels:
     app: {{ template "presto.name" . }}
     chart: {{ template "presto.chart" . }}

--- a/stable/presto/templates/catalog-configmap.yaml
+++ b/stable/presto/templates/catalog-configmap.yaml
@@ -33,7 +33,7 @@ data:
 {{- end }}
 
 {{- range $key, $val := .Values.server.config.catalogs }}
-{{- if and ( (or (ne $key "hive.properties") $overrideHiveProperties) (or (ne $key "v3io.properties") $overrideV3ioProperties)) }}
+{{- if or (or ( (and (eq $key "hive.properties") $overrideHiveProperties) (and (eq $key "v3io.properties") $overrideV3ioProperties)) (and (ne $key "hive.properties") (ne $key "v3io.properties")) )}}
 {{ printf "%s: |" $key | indent 2 }}
 {{ print "# ======== Custom catalog =========" | indent 4 }}
 {{ $val | indent 4 }}

--- a/stable/presto/templates/catalog-configmap.yaml
+++ b/stable/presto/templates/catalog-configmap.yaml
@@ -9,30 +9,23 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
 {{- $overrideV3ioProperties := .Values.server.catalog.v3io.override -}}
+{{- if hasKey .Values.server.config.catalogs "v3io.properties" }}
 {{- if not ($overrideV3ioProperties) }}
   v3io.properties: |
     connector.name=v3io
-{{- if hasKey .Values.server.config.catalogs "v3io.properties" }}
 {{ print "# ======== Custom properties =========" | indent 4 }}
 {{ index .Values.server.config.catalogs "v3io.properties" | indent 4 }}
 {{- end }}
 {{- end }}
 
-{{- range $key, $val := .Values.server.config.catalogs }}
-{{- if or (ne $key "v3io.properties") $overrideV3ioProperties }}
-{{ printf "%s: |" $key | indent 2 }}
-{{ $val | indent 4 }}
-{{- end }}
-{{- end }}
-
 {{- $overrideHiveProperties := .Values.server.catalog.hive.override -}}
 {{- if .Values.hive }}
+{{- if hasKey .Values.server.config.catalogs "hive.properties" }}
 {{- if not ($overrideHiveProperties) }}
   hive.properties: |
     connector.name=hive-hadoop2
     hive.metastore.uri=thrift://{{ .Values.hive.hostname }}:{{ .Values.hive.port }}
     hive.parquet.use-column-names=true
-{{- if hasKey .Values.server.config.catalogs "hive.properties" }}
 {{ print "# ======== Custom properties =========" | indent 4 }}
 {{ index .Values.server.config.catalogs "hive.properties" | indent 4 }}
 {{- end }}
@@ -40,8 +33,9 @@ data:
 {{- end }}
 
 {{- range $key, $val := .Values.server.config.catalogs }}
-{{- if or (ne $key "hive.properties") $overrideHiveProperties }}
+{{- if and ( (or (ne $key "hive.properties") $overrideHiveProperties) (or (ne $key "v3io.properties") $overrideV3ioProperties)) }}
 {{ printf "%s: |" $key | indent 2 }}
+{{ print "# ======== Custom catalog =========" | indent 4 }}
 {{ $val | indent 4 }}
 {{- end }}
 {{- end }}

--- a/stable/presto/templates/catalog-configmap.yaml
+++ b/stable/presto/templates/catalog-configmap.yaml
@@ -8,34 +8,56 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
+{{- $v3ioCatalogKey := "v3io.properties" -}}
 {{- $overrideV3ioProperties := .Values.server.catalog.v3io.override -}}
-{{- if hasKey .Values.server.config.catalogs "v3io.properties" }}
-{{- if not ($overrideV3ioProperties) }}
-  v3io.properties: |
+{{- if hasKey .Values.server.config.catalogs $v3ioCatalogKey }}
+{{- if ($overrideV3ioProperties) }}
+{{ printf "%s: |" $v3ioCatalogKey | indent 2 }}
+{{ printf "# ======== Content of %s has been overriden by user =========" $v3ioCatalogKey | indent 4 }}
+{{ index .Values.server.config.catalogs $v3ioCatalogKey | indent 4 }}
+{{- else }}
+  # append custom properties to v3io connector
+{{ printf "%s: |" $v3ioCatalogKey | indent 2 }}
     connector.name=v3io
-{{ print "# ======== Custom properties =========" | indent 4 }}
-{{ index .Values.server.config.catalogs "v3io.properties" | indent 4 }}
+{{ print "# ======== Custom properties (added by user) =========" | indent 4 }}
+{{ index .Values.server.config.catalogs $v3ioCatalogKey | indent 4 }}
 {{- end }}
+{{- else }}
+  # no custom v3io conector present - create default v3io connector settings
+{{ printf "%s: |" $v3ioCatalogKey | indent 2 }}
+    connector.name=v3io
 {{- end }}
 
+{{- $hiveCatalogKey := "hive.properties" -}}
 {{- $overrideHiveProperties := .Values.server.catalog.hive.override -}}
 {{- if .Values.hive }}
-{{- if hasKey .Values.server.config.catalogs "hive.properties" }}
-{{- if not ($overrideHiveProperties) }}
-  hive.properties: |
+{{- if hasKey .Values.server.config.catalogs $hiveCatalogKey }}
+{{- if ($overrideHiveProperties) }}
+{{ printf "%s: |" $hiveCatalogKey | indent 2 }}
+{{ printf "# ======== Content of %s has been overriden by user =========" $hiveCatalogKey | indent 4 }}
+{{ index .Values.server.config.catalogs $hiveCatalogKey | indent 4 }}
+{{- else }}
+  # append custom properties to hive connector
+{{ printf "%s: |" $hiveCatalogKey | indent 2 }}
     connector.name=hive-hadoop2
     hive.metastore.uri=thrift://{{ .Values.hive.hostname }}:{{ .Values.hive.port }}
     hive.parquet.use-column-names=true
-{{ print "# ======== Custom properties =========" | indent 4 }}
-{{ index .Values.server.config.catalogs "hive.properties" | indent 4 }}
+{{ print "# ======== Custom properties (added by user) =========" | indent 4 }}
+{{ index .Values.server.config.catalogs $hiveCatalogKey | indent 4 }}
 {{- end }}
+{{- else }}
+  # no custom hive connector present - use default hive connector settings
+{{ printf "%s: |" $hiveCatalogKey | indent 2 }}
+    connector.name=hive-hadoop2
+    hive.metastore.uri=thrift://{{ .Values.hive.hostname }}:{{ .Values.hive.port }}
+    hive.parquet.use-column-names=true
 {{- end }}
 {{- end }}
 
 {{- range $key, $val := .Values.server.config.catalogs }}
-{{- if or (or ( (and (eq $key "hive.properties") $overrideHiveProperties) (and (eq $key "v3io.properties") $overrideV3ioProperties)) (and (ne $key "hive.properties") (ne $key "v3io.properties")) )}}
+{{- if (and (ne $key "hive.properties") (ne $key "v3io.properties"))}}
 {{ printf "%s: |" $key | indent 2 }}
-{{ print "# ======== Custom catalog =========" | indent 4 }}
+{{ printf "# ======== Connector %s has been created by user =========" $key | indent 4 }}
 {{ $val | indent 4 }}
 {{- end }}
 {{- end }}

--- a/stable/presto/templates/catalog-configmap.yaml
+++ b/stable/presto/templates/catalog-configmap.yaml
@@ -8,8 +8,22 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
+{{- $overrideV3ioProperties := .Values.server.catalog.v3io.override -}}
+{{- if not ($overrideV3ioProperties) }}
   v3io.properties: |
     connector.name=v3io
+{{- if hasKey .Values.server.config.catalogs "v3io.properties" }}
+{{ print "# ======== Custom properties =========" | indent 4 }}
+{{ index .Values.server.config.catalogs "v3io.properties" | indent 4 }}
+{{- end }}
+{{- end }}
+
+{{- range $key, $val := .Values.server.config.catalogs }}
+{{- if or (ne $key "v3io.properties") $overrideV3ioProperties }}
+{{ printf "%s: |" $key | indent 2 }}
+{{ $val | indent 4 }}
+{{- end }}
+{{- end }}
 
 {{- $overrideHiveProperties := .Values.server.catalog.hive.override -}}
 {{- if .Values.hive }}

--- a/stable/presto/templates/catalog-configmap.yaml
+++ b/stable/presto/templates/catalog-configmap.yaml
@@ -55,7 +55,7 @@ data:
 {{- end }}
 
 {{- range $key, $val := .Values.server.config.catalogs }}
-{{- if (and (ne $key "hive.properties") (ne $key "v3io.properties"))}}
+{{- if (and (ne $key $hiveCatalogKey) (ne $key $v3ioCatalogKey))}}
 {{ printf "%s: |" $key | indent 2 }}
 {{ printf "# ======== Connector %s has been created by user =========" $key | indent 4 }}
 {{ $val | indent 4 }}

--- a/stable/presto/templates/coordinator-deployment.yaml
+++ b/stable/presto/templates/coordinator-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             name: {{ template "presto.coordinator" . }}
         - name: catalog-config-volume
           configMap:
-            name: presto.catalog
+            name: presto-catalog
         - name: daemon-health
           emptyDir: {}
 {{- if .Values.server.config.https }}

--- a/stable/presto/templates/worker-deployment.yaml
+++ b/stable/presto/templates/worker-deployment.yaml
@@ -29,7 +29,7 @@ spec:
             name: {{ template "presto.worker" . }}
         - name: catalog-config-volume
           configMap:
-            name: presto.catalog
+            name: presto-catalog
         - name: daemon-health
           emptyDir: {}
 {{- if .Values.server.config.https }}

--- a/stable/presto/values.yaml
+++ b/stable/presto/values.yaml
@@ -45,6 +45,8 @@ server:
         heapRegionSize: "32M"
 
   catalog:
+    v3io:
+      override: false
     hive:
       override: false
 hive:


### PR DESCRIPTION
Moving all connector descriptors (v3io + hive) to ConfigMap (see presto helm-chart) to provide more control and flexibility.
This change will also allow fetching contents of the "built-in" connector descriptors and displaying it in UI (after 2.5)

Related:
1. https://github.com/iguazio/provazio/pull/809
2. https://github.com/iguazio/zeta/pull/1243