### PR TITLE
Enabling to configure jupyter's sidecar-proxy metric names

### DIFF
--- a/stable/jupyter/Chart.yaml
+++ b/stable/jupyter/Chart.yaml
@@ -1,5 +1,5 @@
 name: jupyter
-version: 0.6.10
+version: 0.7.0
 appVersion: ">=2.0.0"
 description: Jupyter
 home: https://jupyter.org/

--- a/stable/jupyter/Chart.yaml
+++ b/stable/jupyter/Chart.yaml
@@ -1,5 +1,5 @@
 name: jupyter
-version: 0.6.9
+version: 0.6.10
 appVersion: ">=2.0.0"
 description: Jupyter
 home: https://jupyter.org/

--- a/stable/jupyter/templates/jupyter-deployment.yaml
+++ b/stable/jupyter/templates/jupyter-deployment.yaml
@@ -149,6 +149,11 @@ spec:
           - --namespace={{ .Release.Namespace }}
           - --service-name={{ .Release.Name }}
           - --instance-name={{ template "jupyter.fullname" . }}
+{{- if .Values.proxy.metricNames }}
+{{- range $val := .Values.proxy.metricNames }}
+          - --metric-names={{ $val }}
+{{ end -}}
+{{- end }}
           ports:
             - containerPort: {{ .Values.proxy.servicePort }}
               name: sidecar-proxy

--- a/stable/jupyter/templates/jupyter-deployment.yaml
+++ b/stable/jupyter/templates/jupyter-deployment.yaml
@@ -151,7 +151,7 @@ spec:
           - --instance-name={{ template "jupyter.fullname" . }}
 {{- if .Values.proxy.metricNames }}
 {{- range $val := .Values.proxy.metricNames }}
-          - --metric-names={{ $val }}
+          - --metric-name={{ $val }}
 {{ end -}}
 {{- end }}
           ports:

--- a/stable/jupyter/values.yaml
+++ b/stable/jupyter/values.yaml
@@ -91,6 +91,7 @@ proxy:
   logLevel: info
   metricNames:
     - 'num_of_requests'
+    - 'jupyter_kernel_busyness'
 
 daemon:
   image:

--- a/stable/jupyter/values.yaml
+++ b/stable/jupyter/values.yaml
@@ -89,6 +89,8 @@ proxy:
     tag: 0.1.1
   servicePort: 8080
   logLevel: info
+  metricNames:
+    - 'num_of_requests'
 
 daemon:
   image:


### PR DESCRIPTION
Should be merged after https://github.com/v3io/sidecar-proxy/pull/16 (which adds the new metric-names flag)