### PR TITLE
Lint fixes for helm 2.15.1

### DIFF
--- a/stable/jupyter/Chart.yaml
+++ b/stable/jupyter/Chart.yaml
@@ -1,6 +1,7 @@
-name: jupyter
-version: 0.7.8
+version: 0.7.9
+apiVersion: v1
 appVersion: ">=2.0.0"
+name: jupyter
 description: Jupyter
 home: https://jupyter.org/
 icon: https://jupyter.org/assets/nav_logo.svg

--- a/stable/jupyterhub/Chart.yaml
+++ b/stable/jupyterhub/Chart.yaml
@@ -1,6 +1,7 @@
-name: jupyterhub
-version: 0.7.7
+apiVersion: v1
+version: 0.7.8
 appVersion: 0.9.2
+name: jupyterhub
 description: Multi-user Jupyter installation
 home: https://z2jh.jupyter.org
 sources:

--- a/stable/spark/Chart.yaml
+++ b/stable/spark/Chart.yaml
@@ -1,6 +1,7 @@
-name: spark
-version: 0.9.2
+apiVersion: v1
+version: 0.9.3
 appVersion: ">=2.0.0"
+name: spark
 description: Fast and general-purpose cluster computing system.
 home: http://spark.apache.org
 icon: http://spark.apache.org/images/spark-logo-trademark.png

--- a/stable/sparkoperator/requirements.lock
+++ b/stable/sparkoperator/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: v3io-configs
+  repository: https://v3io.github.io/helm-charts/stable
+  version: 0.7.2
+digest: sha256:b71bfc14333504a9f5e55588d9e4a04c32578dadf4b6157f6b61fe7f6302836b
+generated: "2020-01-19T16:23:00.877675+02:00"

--- a/stable/tsdb-functions/Chart.yaml
+++ b/stable/tsdb-functions/Chart.yaml
@@ -1,6 +1,7 @@
-name: tsdb-functions
-version: 0.2.0
+apiVersion: v1
+version: 0.2.1
 appVersion: 0.0.12
+name: tsdb-functions
 description: V3IO TSDB nuclio functions
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2017/09/iguazio_logo_2017_w_c.png

--- a/stable/v3io-webapi/Chart.yaml
+++ b/stable/v3io-webapi/Chart.yaml
@@ -1,6 +1,7 @@
-name: v3io-webapi
-version: 0.7.7
+apiVersion: v1
+version: 0.7.8
 appVersion: "~1.7.0"
+name: v3io-webapi
 description: v3io WebAPI
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2017/09/iguazio_logo_2017_w_c.png

--- a/stable/v3iod/Chart.yaml
+++ b/stable/v3iod/Chart.yaml
@@ -1,6 +1,7 @@
-name: v3iod
-version: 0.11.2
+apiVersion: v1
+version: 0.11.3
 appVersion: ">=1.9.4"
+name: v3iod
 description: v3io daemon
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2017/09/iguazio_logo_2017_w_c.png

--- a/stable/zeppelin/Chart.yaml
+++ b/stable/zeppelin/Chart.yaml
@@ -1,6 +1,7 @@
-name: zeppelin
+apiVersion: v1
 version: 0.3.5
 appVersion: ">=2.0.0"
+name: zeppelin
 description: Zeppelin
 home: https://zeppelin.apache.org/
 icon: https://zeppelin.apache.org/assets/themes/zeppelin/img/zeppelin_logo.png


### PR DESCRIPTION
- Adding `apiVersion` to `Chart.yaml` and bumping patch versions all around
- Adding missing `requirements.lock` in `sparkoperator`