### PR TITLE
Pipelines helm additions and changes

### DIFF
--- a/stable/pipelines/Chart.yaml
+++ b/stable/pipelines/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=0.1.40"
 description: Kubeflow pipelines framework for machine learning
 name: pipelines
-version: 0.2.1
+version: 0.3.0
 home: https://www.kubeflow.org/
 icon: https://github.com/kubeflow/marketing-materials/blob/master/logos/Raster/Kubeflow-Logo-RGB.png
 sources:

--- a/stable/pipelines/templates/metadata/deployment.yaml
+++ b/stable/pipelines/templates/metadata/deployment.yaml
@@ -60,7 +60,7 @@ spec:
         ]
         ports:
         - containerPort: 8080
-          name:
+          name: md-backendapi
       initContainers:
       - name: metadata-init
         command: [

--- a/stable/pipelines/templates/metadata/deployment.yaml
+++ b/stable/pipelines/templates/metadata/deployment.yaml
@@ -20,8 +20,9 @@ spec:
 {{ include "pipelines.commonLabels" . | indent 8 }}
     spec:
       containers:
-      - name: container
-        image: {{ .Values.images.metadata.repository }}:{{ .Values.images.metadata.tag }}
+      - name: metadata-container
+        image: {{ .Values.images.metadata.container.repository }}:{{ .Values.images.metadata.container.tag }}
+        imagePullPolicy: {{ .Values.images.imagePullPolicy }}
         env:
 #        - name: DBCONFIG_USER
 #          valueFrom:
@@ -49,16 +50,25 @@ spec:
               name: metadata-mysql-configmap
               key: MYSQL_PORT
         command: ["/bin/metadata_store_server"]
-        args: ["--grpc_port=8080",
-               "--mysql_config_database=$(MYSQL_DATABASE)",
-               "--mysql_config_host=$(MYSQL_HOST)",
-               "--mysql_config_port=$(MYSQL_PORT)",
-#               "--mysql_config_user=$(DBCONFIG_USER)",
-#               "--mysql_config_password=$(DBCONFIG_PASSWORD)"
+        args: [
+          "--grpc_port=8080",
+          "--mysql_config_database=$(MYSQL_DATABASE)",
+          "--mysql_config_host=$(MYSQL_HOST)",
+          "--mysql_config_port=$(MYSQL_PORT)",
+          #               "--mysql_config_user=$(DBCONFIG_USER)",
+          #               "--mysql_config_password=$(DBCONFIG_PASSWORD)"
         ]
         ports:
         - containerPort: 8080
-          name: md-backendapi
+          name:
+      initContainers:
+      - name: metadata-init
+        command: [
+          'sh',
+          '-c',
+          'until nslookup myservice; do echo waiting for myservice; sleep 2; done; echo mysql found;']
+        image: {{ .Values.images.metadata.init.repository }}:{{ .Values.images.metadata.init.tag }}
+        imagePullPolicy: {{ .Values.images.imagePullPolicy }}
       resources:
 {{ toYaml .Values.resources | indent 8 }}
 {{- end }}

--- a/stable/pipelines/templates/metadata/envoy-deployment.yaml
+++ b/stable/pipelines/templates/metadata/envoy-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: container
-        image: {{ .Values.images.metadata-envoy.repository }}:{{ .Values.images.metadata-envoy.tag }}
+        image: {{ .Values.images.metadataEnvoy.repository }}:{{ .Values.images.metadataEnvoy.tag }}
         imagePullPolicy: {{ .Values.images.imagePullPolicy }}
         ports:
         - name: md-envoy

--- a/stable/pipelines/templates/metadata/envoy-deployment.yaml
+++ b/stable/pipelines/templates/metadata/envoy-deployment.yaml
@@ -19,7 +19,8 @@ spec:
     spec:
       containers:
       - name: container
-        image: gcr.io/ml-pipeline/envoy:initial
+        image: {{ .Values.images.metadata-envoy.repository }}:{{ .Values.images.metadata-envoy.tag }}
+        imagePullPolicy: {{ .Values.images.imagePullPolicy }}
         ports:
         - name: md-envoy
           containerPort: 9090

--- a/stable/pipelines/templates/ml-pipeline/pipeline-runner/role.yaml
+++ b/stable/pipelines/templates/ml-pipeline/pipeline-runner/role.yaml
@@ -83,4 +83,11 @@ rules:
   - seldondeployments
   verbs:
   - '*'
+- apiGroups:
+  - sparkoperator.k8s.io
+  resources:
+  - sparkapplications
+  - scheduledsparkapplications
+  verbs:
+  - '*'
 {{- end }}

--- a/stable/pipelines/values.yaml
+++ b/stable/pipelines/values.yaml
@@ -78,7 +78,7 @@ images:
     init:
       repository: gcr.io/tfx-oss-public/ml_metadata_store_server
       tag: 0.14.0
-  metadata-envoy:
+  metadataEnvoy:
     repository: gcr.io/ml-pipeline/envoy
     tag: initial
   mysql:

--- a/stable/pipelines/values.yaml
+++ b/stable/pipelines/values.yaml
@@ -76,8 +76,8 @@ images:
       repository: gcr.io/tfx-oss-public/ml_metadata_store_server
       tag: 0.14.0
     init:
-      repository: gcr.io/tfx-oss-public/ml_metadata_store_server
-      tag: 0.14.0
+      repository: quay.io/iguazio/busybox
+      tag: latest
   metadataEnvoy:
     repository: gcr.io/ml-pipeline/envoy
     tag: initial

--- a/stable/pipelines/values.yaml
+++ b/stable/pipelines/values.yaml
@@ -72,8 +72,15 @@ images:
     repository: gcr.io/ml-pipeline/visualization-server
     tag: 0.1.27
   metadata:
-    repository: gcr.io/tfx-oss-public/ml_metadata_store_server
-    tag: 0.14.0
+    container:
+      repository: gcr.io/tfx-oss-public/ml_metadata_store_server
+      tag: 0.14.0
+    init:
+      repository: gcr.io/tfx-oss-public/ml_metadata_store_server
+      tag: 0.14.0
+  metadata-envoy:
+    repository: gcr.io/ml-pipeline/envoy
+    tag: initial
   mysql:
     repository: mysql
     tag: 5.6

--- a/stable/pipelines/values.yaml
+++ b/stable/pipelines/values.yaml
@@ -76,7 +76,7 @@ images:
       repository: gcr.io/tfx-oss-public/ml_metadata_store_server
       tag: 0.14.0
     init:
-      repository: quay.io/iguazio/busybox
+      repository: busybox
       tag: latest
   metadataEnvoy:
     repository: gcr.io/ml-pipeline/envoy


### PR DESCRIPTION
- Adding metadata init container to avoid ml_metada core dump when mysql is not ready yet
- Slight change of values metada images because of the above (breaking)
- Adding values for metada-envoy image
- Adding sparkapplications (sparkoperator's resources) perms to pipeline-runner role