### PR TITLE
IG-15006: Total block size should not exceed max integer (2G)

### DIFF
--- a/stable/v3iod/Chart.yaml
+++ b/stable/v3iod/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.11.4
+version: 0.11.5
 appVersion: ">=1.9.4"
 name: v3iod
 description: v3io daemon

--- a/stable/v3iod/values.yaml
+++ b/stable/v3iod/values.yaml
@@ -63,7 +63,7 @@ v3iod:
     {
       "kind": "mempool",
       "block_size_bytes": 2150400,
-      "num_blocks": 1000
+      "num_blocks": 998
     }
   coefficients: |
         "on_v3io_event_num_read_v3io_response_repetitions": 1,


### PR DESCRIPTION
Formula: num_blocks = 2147483647 / block_size_bytes
Note, ByteBuffer in Java has limit of 2G (Integer.MAX_VALUE) therefore total pool size should not exceed that limit