### PR TITLE
[stable/provazio] - Add configs checksum to deployments

### DIFF
--- a/stable/provazio/Chart.yaml
+++ b/stable/provazio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Iguazio provisioner
 name: provazio
-version: 0.3.5
+version: 0.3.6
 appVersion: 0.10.11
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://iguazio.com

--- a/stable/provazio/templates/controller-deployment.yaml
+++ b/stable/provazio/templates/controller-deployment.yaml
@@ -24,6 +24,9 @@ spec:
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
         component: controller
+      annotations:
+        checksum/system-config: {{ include (print $.Template.BasePath "/controller-system-config-configmap.yaml") . | sha256sum }}
+        checksum/artifact-version-manifest: {{ include (print $.Template.BasePath "/controller-artifact-version-manifest-configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "provazio.controller.name" . }}
       containers:

--- a/stable/provazio/templates/dashboard-deployment.yaml
+++ b/stable/provazio/templates/dashboard-deployment.yaml
@@ -24,6 +24,9 @@ spec:
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
         component: dashboard
+      annotations:
+        checksum/env-spec: {{ include (print $.Template.BasePath "/dashboard-env-spec-configmap.yaml") . | sha256sum }}
+        checksum/artifact-version-manifest: {{ include (print $.Template.BasePath "/dashboard-artifact-version-manifest-configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "provazio.dashboard.name" . }}
       containers:

--- a/stable/provazio/templates/vault-deployment.yaml
+++ b/stable/provazio/templates/vault-deployment.yaml
@@ -24,6 +24,8 @@ spec:
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
         component: vault
+      annotations:
+        checksum/env-spec: {{ include (print $.Template.BasePath "/vault-env-spec-configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ template "provazio.vault.name" . }}
       containers:


### PR DESCRIPTION
This checksum will make the pod template to change when something was changed in the config - meaning the deployment will recreate the pod - meaning we don't need to use `--recreate-pods` anymore