### PR TITLE
[stable/mlrun] - Fixing component label

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.1.0
+version: 0.2.0
 description: Machine Learning automation and tracking
 type: application
 sources:

--- a/stable/mlrun/templates/_helpers.tpl
+++ b/stable/mlrun/templates/_helpers.tpl
@@ -97,7 +97,7 @@ API selector labels
 */}}
 {{- define "mlrun.api.selectorLabels" -}}
 {{ include "mlrun.common.selectorLabels" . }}
-helm.sh/component: {{ .Values.api.name | quote }}
+app.kubernetes.io/component: {{ .Values.api.name | quote }}
 {{- end -}}
 
 {{/*
@@ -113,7 +113,7 @@ UI selector labels
 */}}
 {{- define "mlrun.ui.selectorLabels" -}}
 {{ include "mlrun.common.selectorLabels" . }}
-helm.sh/component: {{ .Values.ui.name | quote }}
+app.kubernetes.io/component: {{ .Values.ui.name | quote }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
mistakenly was `helm.sh/component`,  should be `app.kubernetes.io/component`