### PR TITLE
Allow advanced users to make changes to Java V3IO configuration

### DIFF
--- a/stable/grafana/requirements.yaml
+++ b/stable/grafana/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.2"
+  version: "0.7.5"
   repository: https://v3io.github.io/helm-charts/stable

--- a/stable/hive/requirements.yaml
+++ b/stable/hive/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.2"
+  version: "0.7.5"
   repository: https://v3io.github.io/helm-charts/stable

--- a/stable/jupyter/requirements.yaml
+++ b/stable/jupyter/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.4"
+  version: "0.7.5"
   repository: https://v3io.github.io/helm-charts/stable
 - name: pvc
   version: "0.0.1"

--- a/stable/jupyterhub/requirements.yaml
+++ b/stable/jupyterhub/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: v3io-configs
-  version: "0.5.2"
+  version: "0.7.5"
   repository: https://v3io.github.io/helm-charts/stable

--- a/stable/mariadb/requirements.yaml
+++ b/stable/mariadb/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.2"
+  version: "0.7.5"
   repository: https://v3io.github.io/helm-charts/stable

--- a/stable/mlrun/requirements.yaml
+++ b/stable/mlrun/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.2"
+  version: "0.7.5"
   repository: https://v3io.github.io/helm-charts/stable

--- a/stable/presto/requirements.yaml
+++ b/stable/presto/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.2"
+  version: "0.7.5"
   repository: https://v3io.github.io/helm-charts/stable

--- a/stable/shell/requirements.yaml
+++ b/stable/shell/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.4"
+  version: "0.7.5"
   repository: https://v3io.github.io/helm-charts/stable

--- a/stable/spark/requirements.yaml
+++ b/stable/spark/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.2"
+  version: "0.7.5"
   repository: https://v3io.github.io/helm-charts/stable

--- a/stable/sparkoperator/requirements.yaml
+++ b/stable/sparkoperator/requirements.yaml
@@ -1,5 +1,4 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.2"
+  version: "0.7.5"
   repository: https://v3io.github.io/helm-charts/stable
-

--- a/stable/v3io-configs/Chart.yaml
+++ b/stable/v3io-configs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: V3IO configuration templates
 name: v3io-configs
-version: 0.7.4
+version: 0.7.5
 icon: https://www.iguazio.com/wp-content/uploads/2017/09/iguazio_logo_2017_w_c.png
 sources:
   - https://github.com/iguazio/kubeops/

--- a/stable/v3io-configs/templates/_java.conf.tpl
+++ b/stable/v3io-configs/templates/_java.conf.tpl
@@ -10,6 +10,20 @@ v3io.client {
 }
 v3io.config.auth.file={{ default "/igz/java/auth" .Values.global.v3io.authPath }}/{{ default ".java" .Values.global.v3io.authFileName }}
 new-daemon=true
+
+{{- if .Values.java }}
+{{- if .Values.java.v3io }}
+{{- if .Values.java.v3io.conf }}
+{{- if .Values.java.v3io.conf.properties }}
+{{ print }}
+    {{- range $key, $val := .Values.java.v3io.conf.properties }}
+{{ printf "%s=%s" $key $val }}
+    {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{- end -}}
 
 {{- define "v3io-configs.java.configMap" -}}

--- a/stable/v3io-webapi/requirements.yaml
+++ b/stable/v3io-webapi/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.2"
+  version: "0.7.5"
   repository: https://v3io.github.io/helm-charts/stable

--- a/stable/zeppelin/requirements.yaml
+++ b/stable/zeppelin/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.4"
+  version: "0.7.5"
   repository: https://v3io.github.io/helm-charts/stable


### PR DESCRIPTION
Allow advanced users to make changes to Java V3IO configuration by providing custom values
For example: 
adding following **values** to **shell** spec
```
java:
  v3io:
    conf:
      properties:
        v3io.kv.find.payload-size: "1 MiB"
        v3io.kv.find.payload-size.find-by-key.payload-size: "256 KiB"
```
will create the following entry in shell's config-map:
```
data:
  v3io.conf: |
    v3io.client {
        socket.host=CURRENT_NODE_IP
        session.use-system-user=false
        on-failure.state.path=/igz/java/crash/.crash
    }
    v3io.config.auth.file=/igz/java/auth/.java
    new-daemon=true

    v3io.kv.find.payload-size=1 MiB
    v3io.kv.find.payload-size.find-by-key.payload-size=256 KiB
```