### PR TITLE
Bumping minor chart versions for 3.0.0

### DIFF
--- a/demo/netops-demo/Chart.yaml
+++ b/demo/netops-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: V3IO NetOps demo
 name: netops-demo
-version: 0.0.15
+version: 0.1.0
 appVersion: 0.0.14
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://iguazio.com

--- a/demo/taxi-demo/Chart.yaml
+++ b/demo/taxi-demo/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.2.9
+version: 0.3.0
 name: taxi-demo
 description: V3IO Taxi Demo
 home: https://iguazio.com

--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 4.5.0
+version: 4.6.0
 appVersion: 6.5.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/requirements.lock
+++ b/stable/grafana/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: v3io-configs
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.7.2
-digest: sha256:b71bfc14333504a9f5e55588d9e4a04c32578dadf4b6157f6b61fe7f6302836b
-generated: 2020-01-27T16:37:27.581697+02:00
+  version: 0.8.0
+digest: sha256:3db8c5a6fd73a17a59ceea85bdcc4e35dcc5b8a9d914a9d1d7efa2e8d413a2c7
+generated: "2020-04-03T22:50:08.784013+03:00"

--- a/stable/grafana/requirements.yaml
+++ b/stable/grafana/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.2"
+  version: "0.8.0"
   repository: https://v3io.github.io/helm-charts/stable

--- a/stable/hive/Chart.yaml
+++ b/stable/hive/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: Hive metastore service
 name: hive
-version: 0.2.2
+version: 0.3.0
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2017/09/iguazio_logo_2017_w_c.png
 sources:

--- a/stable/hive/requirements.lock
+++ b/stable/hive/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: v3io-configs
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.7.2
-digest: sha256:b71bfc14333504a9f5e55588d9e4a04c32578dadf4b6157f6b61fe7f6302836b
-generated: 2019-07-14T11:28:28.377669+03:00
+  version: 0.8.0
+digest: sha256:3db8c5a6fd73a17a59ceea85bdcc4e35dcc5b8a9d914a9d1d7efa2e8d413a2c7
+generated: "2020-04-03T22:56:14.099553+03:00"

--- a/stable/hive/requirements.yaml
+++ b/stable/hive/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.2"
+  version: "0.8.0"
   repository: https://v3io.github.io/helm-charts/stable

--- a/stable/iguazio-system/Chart.yaml
+++ b/stable/iguazio-system/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for creating iguazio-system namespace and jobs
 name: iguazio-system
-version: 0.4.8
+version: 0.5.0
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2017/09/iguazio_logo_2017_w_c.png
 sources:

--- a/stable/iguazio-system/requirements.lock
+++ b/stable/iguazio-system/requirements.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 0.16.1
 - name: tenant
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.2.3
-digest: sha256:0e03fa59878481317794ab3516d1f383489ae00eff38f2ff5bbbd91ac66e5785
-generated: 2019-12-15T17:16:17.296289+02:00
+  version: 0.3.0
+digest: sha256:bb07c56b9fd39a2ac41f6cc105a905a2f6b6af3fc5b095e7e790919db46c16ca
+generated: "2020-04-03T22:56:23.646766+03:00"

--- a/stable/iguazio-system/requirements.yaml
+++ b/stable/iguazio-system/requirements.yaml
@@ -13,5 +13,5 @@ dependencies:
   condition: fluent.enabled
   repository: https://kubernetes-charts.storage.googleapis.com/
 - name: tenant
-  version: "0.2.3"
+  version: "0.3.0"
   repository: https://v3io.github.io/helm-charts/stable

--- a/stable/jupyter/Chart.yaml
+++ b/stable/jupyter/Chart.yaml
@@ -1,4 +1,4 @@
-version: 0.7.17
+version: 0.8.0
 apiVersion: v1
 appVersion: ">=2.0.0"
 name: jupyter

--- a/stable/jupyter/requirements.lock
+++ b/stable/jupyter/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: v3io-configs
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.7.4
+  version: 0.8.0
 - name: pvc
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.0.1
-digest: sha256:df6ad29a198cfadaa16e7719020c2d69c0a0607bbe2c990590ec53fe60f14341
-generated: "2020-02-17T12:25:46.329748267+02:00"
+  version: 0.1.0
+digest: sha256:3ee3bc21f90533380f2c3d7decb0093afaf0e527924fd79872db1b9c555abeef
+generated: "2020-04-03T22:56:33.781206+03:00"

--- a/stable/jupyter/requirements.yaml
+++ b/stable/jupyter/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.4"
+  version: "0.8.0"
   repository: https://v3io.github.io/helm-charts/stable
 - name: pvc
-  version: "0.0.1"
+  version: "0.1.0"
   repository: https://v3io.github.io/helm-charts/stable

--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: MariaDB (MySQL) service
 name: mariadb
-version: 0.2.3
+version: 0.3.0
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2017/09/iguazio_logo_2017_w_c.png
 sources:

--- a/stable/mariadb/requirements.lock
+++ b/stable/mariadb/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: v3io-configs
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.7.2
-digest: sha256:b71bfc14333504a9f5e55588d9e4a04c32578dadf4b6157f6b61fe7f6302836b
-generated: 2019-07-14T11:28:42.261617+03:00
+  version: 0.8.0
+digest: sha256:3db8c5a6fd73a17a59ceea85bdcc4e35dcc5b8a9d914a9d1d7efa2e8d413a2c7
+generated: "2020-04-03T22:56:46.666259+03:00"

--- a/stable/mariadb/requirements.yaml
+++ b/stable/mariadb/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.2"
+  version: "0.8.0"
   repository: https://v3io.github.io/helm-charts/stable

--- a/stable/metrics-server-exporter/Chart.yaml
+++ b/stable/metrics-server-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: K8s metrics exporter in prometheus format
 name: metrics-server-exporter
-version: 0.2.1
+version: 0.3.0
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2017/09/iguazio_logo_2017_w_c.png
 sources:

--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 name: mlrun
-version: 0.2.0
+version: 0.3.0
+appVersion: 0.4.3
 description: Machine Learning automation and tracking
 type: application
 sources:
@@ -9,4 +10,4 @@ maintainers:
   - name: hedingber
     email: hedii@iguazio.com
 icon: https://di5r923elu32w2e633ofbxj9-wpengine.netdna-ssl.com/wp-content/uploads/2019/10/Iguazio-Logo.png
-appVersion: 0.4.3
+

--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -10,4 +10,3 @@ maintainers:
   - name: hedingber
     email: hedii@iguazio.com
 icon: https://di5r923elu32w2e633ofbxj9-wpengine.netdna-ssl.com/wp-content/uploads/2019/10/Iguazio-Logo.png
-

--- a/stable/mlrun/requirements.lock
+++ b/stable/mlrun/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: v3io-configs
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.7.2
-digest: sha256:b71bfc14333504a9f5e55588d9e4a04c32578dadf4b6157f6b61fe7f6302836b
-generated: 2020-02-25T20:28:23.803042+02:00
+  version: 0.8.0
+digest: sha256:3db8c5a6fd73a17a59ceea85bdcc4e35dcc5b8a9d914a9d1d7efa2e8d413a2c7
+generated: "2020-04-03T22:56:51.997058+03:00"

--- a/stable/mlrun/requirements.yaml
+++ b/stable/mlrun/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.2"
+  version: "0.8.0"
   repository: https://v3io.github.io/helm-charts/stable

--- a/stable/mpi-operator/Chart.yaml
+++ b/stable/mpi-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "==0.2.0"
 description: Kubeflow MPI job operator
 name: mpi-operator
-version: 0.0.3
+version: 0.1.0
 home: https://www.kubeflow.org/
 icon: https://github.com/kubeflow/marketing-materials/blob/master/logos/Raster/Kubeflow-Logo-RGB.png
 sources:

--- a/stable/pipelines/Chart.yaml
+++ b/stable/pipelines/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=0.2.5"
 description: Kubeflow pipelines framework for machine learning
 name: pipelines
-version: 0.3.9
+version: 0.4.0
 home: https://www.kubeflow.org/
 icon: https://github.com/kubeflow/marketing-materials/blob/master/logos/Raster/Kubeflow-Logo-RGB.png
 sources:

--- a/stable/pod-gpu-metrics-exporter/Chart.yaml
+++ b/stable/pod-gpu-metrics-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.0.0-alpha"
 description: Pod GPU metrics exporter
 name: pod-gpu-metrics-exporter
-version: 0.2.1
+version: 0.3.0
 sources:
   - https://github.com/NVIDIA/gpu-monitoring-tools/tree/master/exporters/prometheus-dcgm/k8s/pod-gpu-metrics-exporter
 maintainers:

--- a/stable/pod-gpu-metrics-exporter/requirements.lock
+++ b/stable/pod-gpu-metrics-exporter/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: node-feature-discovery
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.1.0
+  version: 0.2.0
 - name: gpu-feature-discovery
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.1.0
-digest: sha256:619463abf822689c2857db3b18707403284b6d892e83168e14660bad646be12b
-generated: "2019-12-31T11:53:33.804319+02:00"
+  version: 0.2.0
+digest: sha256:30f0826f8008684b6eb6cae31825275a892102c29b210ece416fac3d48e53906
+generated: "2020-04-03T22:56:57.6829+03:00"

--- a/stable/pod-gpu-metrics-exporter/requirements.yaml
+++ b/stable/pod-gpu-metrics-exporter/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
 
 - name: node-feature-discovery
-  version: 0.1.0
+  version: 0.2.0
   repository: https://v3io.github.io/helm-charts/stable
 
 - name: gpu-feature-discovery
-  version: 0.1.0
+  version: 0.2.0
   repository: https://v3io.github.io/helm-charts/stable

--- a/stable/prebaked-registry/Chart.yaml
+++ b/stable/prebaked-registry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry with prebaked images and without persistency
 name: prebaked-registry
-version: 1.8.3
+version: 1.9.0
 appVersion: 2.7.1
 home: https://hub.docker.com/_/registry/
 icon: https://hub.docker.com/public/images/logos/mini-logo.svg

--- a/stable/presto/Chart.yaml
+++ b/stable/presto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: Presto is a distributed SQL query engine for big data
 name: presto
-version: 0.9.0
+version: 0.10.0
 home: https://prestosql.io/
 icon: https://prestosql.io/assets/presto.png
 sources:

--- a/stable/presto/requirements.lock
+++ b/stable/presto/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: v3io-configs
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.7.2
-digest: sha256:b71bfc14333504a9f5e55588d9e4a04c32578dadf4b6157f6b61fe7f6302836b
-generated: 2019-07-14T11:28:56.640106+03:00
+  version: 0.8.0
+digest: sha256:3db8c5a6fd73a17a59ceea85bdcc4e35dcc5b8a9d914a9d1d7efa2e8d413a2c7
+generated: "2020-04-03T22:57:04.512416+03:00"

--- a/stable/presto/requirements.yaml
+++ b/stable/presto/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.2"
+  version: "0.8.0"
   repository: https://v3io.github.io/helm-charts/stable

--- a/stable/provazio/Chart.yaml
+++ b/stable/provazio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Iguazio provisioner
 name: provazio
-version: 0.3.6
+version: 0.4.0
 appVersion: 0.10.11
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://iguazio.com

--- a/stable/scaler/Chart.yaml
+++ b/stable/scaler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for creating scaler - dlx
 name: scaler
-version: 0.4.0
+version: 0.5.0
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2017/09/iguazio_logo_2017_w_c.png
 sources:

--- a/stable/shell/Chart.yaml
+++ b/stable/shell/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: Shell access to data services
 name: shell
-version: 0.9.12
+version: 0.10.0
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2017/09/iguazio_logo_2017_w_c.png
 sources:

--- a/stable/shell/requirements.lock
+++ b/stable/shell/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: v3io-configs
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.7.4
-digest: sha256:d782ad797e3fd156f637a03c788cccb022047dcb7d3952cefb7c70de1c3ac623
-generated: "2020-02-17T12:25:27.102537912+02:00"
+  version: 0.8.0
+digest: sha256:3db8c5a6fd73a17a59ceea85bdcc4e35dcc5b8a9d914a9d1d7efa2e8d413a2c7
+generated: "2020-04-03T22:57:10.052434+03:00"

--- a/stable/shell/requirements.yaml
+++ b/stable/shell/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.4"
+  version: "0.8.0"
   repository: https://v3io.github.io/helm-charts/stable

--- a/stable/spark/Chart.yaml
+++ b/stable/spark/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.9.3
+version: 0.10.0
 appVersion: ">=2.0.0"
 name: spark
 description: Fast and general-purpose cluster computing system.

--- a/stable/spark/requirements.lock
+++ b/stable/spark/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: v3io-configs
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.7.2
-digest: sha256:b71bfc14333504a9f5e55588d9e4a04c32578dadf4b6157f6b61fe7f6302836b
-generated: 2019-07-14T11:29:11.356896+03:00
+  version: 0.8.0
+digest: sha256:3db8c5a6fd73a17a59ceea85bdcc4e35dcc5b8a9d914a9d1d7efa2e8d413a2c7
+generated: "2020-04-03T22:57:17.555203+03:00"

--- a/stable/spark/requirements.yaml
+++ b/stable/spark/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.2"
+  version: "0.8.0"
   repository: https://v3io.github.io/helm-charts/stable

--- a/stable/sparkoperator/Chart.yaml
+++ b/stable/sparkoperator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.0.1
+version: 1.1.0
 appVersion: v1beta2-1.0.1-2.4.4
 keywords:
   - spark

--- a/stable/sparkoperator/requirements.lock
+++ b/stable/sparkoperator/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: v3io-configs
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.7.2
-digest: sha256:b71bfc14333504a9f5e55588d9e4a04c32578dadf4b6157f6b61fe7f6302836b
-generated: "2020-01-19T16:49:41.66051+02:00"
+  version: 0.8.0
+digest: sha256:3db8c5a6fd73a17a59ceea85bdcc4e35dcc5b8a9d914a9d1d7efa2e8d413a2c7
+generated: "2020-04-03T22:57:25.575872+03:00"

--- a/stable/sparkoperator/requirements.yaml
+++ b/stable/sparkoperator/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.2"
+  version: "0.8.0"
   repository: https://v3io.github.io/helm-charts/stable
 

--- a/stable/tenant-creator/Chart.yaml
+++ b/stable/tenant-creator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for creating tenant creator
 name: tenant-creator
-version: 0.1.4
+version: 0.2.0
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2017/09/iguazio_logo_2017_w_c.png
 sources:

--- a/stable/tsdb-functions/Chart.yaml
+++ b/stable/tsdb-functions/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.2.1
+version: 0.3.0
 appVersion: 0.0.12
 name: tsdb-functions
 description: V3IO TSDB nuclio functions

--- a/stable/v3io-framesd/Chart.yaml
+++ b/stable/v3io-framesd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: V3IO frames daemon
 name: v3io-framesd
-version: 0.2.2
+version: 0.3.0
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2017/09/iguazio_logo_2017_w_c.png
 sources:

--- a/stable/v3io-webapi/Chart.yaml
+++ b/stable/v3io-webapi/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.7.9
+version: 0.8.0
 appVersion: "~1.7.0"
 name: v3io-webapi
 description: v3io WebAPI

--- a/stable/v3io-webapi/requirements.lock
+++ b/stable/v3io-webapi/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: v3io-configs
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.7.2
-digest: sha256:b71bfc14333504a9f5e55588d9e4a04c32578dadf4b6157f6b61fe7f6302836b
-generated: 2019-07-14T11:29:26.505053+03:00
+  version: 0.8.0
+digest: sha256:3db8c5a6fd73a17a59ceea85bdcc4e35dcc5b8a9d914a9d1d7efa2e8d413a2c7
+generated: "2020-04-03T22:57:33.462144+03:00"

--- a/stable/v3io-webapi/requirements.yaml
+++ b/stable/v3io-webapi/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.2"
+  version: "0.8.0"
   repository: https://v3io.github.io/helm-charts/stable

--- a/stable/v3iod/Chart.yaml
+++ b/stable/v3iod/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.11.6
+version: 0.12.0
 appVersion: ">=1.9.4"
 name: v3iod
 description: v3io daemon

--- a/stable/zeppelin/Chart.yaml
+++ b/stable/zeppelin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.3.8
+version: 0.4.0
 appVersion: ">=2.0.0"
 name: zeppelin
 description: Zeppelin

--- a/stable/zeppelin/requirements.lock
+++ b/stable/zeppelin/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: v3io-configs
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.7.4
-digest: sha256:d782ad797e3fd156f637a03c788cccb022047dcb7d3952cefb7c70de1c3ac623
-generated: "2020-02-17T12:25:38.87281561+02:00"
+  version: 0.8.0
+digest: sha256:3db8c5a6fd73a17a59ceea85bdcc4e35dcc5b8a9d914a9d1d7efa2e8d413a2c7
+generated: "2020-04-03T22:57:39.597608+03:00"

--- a/stable/zeppelin/requirements.yaml
+++ b/stable/zeppelin/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: v3io-configs
-  version: "0.7.4"
+  version: "0.8.0"
   repository: https://v3io.github.io/helm-charts/stable


### PR DESCRIPTION
### In preparation of 2.8.0 release:
Bumping minor version on primary helm charts (dependencies have been bumped and will now be consumed from their new bumped version)
