### PR TITLE
Support overriding chart version when packaging it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,10 +189,10 @@ package-all:
 
 .PHONY: package-specific
 package-specific:
-	echo "Packing chart"
-	cd $(WORKDIR); \
+	@echo "Packing chart"
+	@cd $(WORKDIR); \
 	if [ "$(CHART_VERSION_OVERRIDE)" != "none" ]; then \
-	    cp $(CHART_NAME)/Chart.yaml $(CHART_NAME)/oldChart.yaml; \
+	    cp $(CHART_NAME)/Chart.yaml $(CHART_NAME)/Chart.yaml.old; \
         awk '{if ($$1=="version:") {$$2="$(CHART_VERSION_OVERRIDE)"; print $$0} else print $$0}' $(CHART_NAME)/Chart.yaml > $(CHART_NAME)/tmp; \
         mv $(CHART_NAME)/tmp $(CHART_NAME)/Chart.yaml; \
     fi ; \
@@ -206,7 +206,7 @@ package-specific:
         exit 103 ; \
     fi ; \
     if [ "$(CHART_VERSION_OVERRIDE)" != "none" ]; then \
-        mv $(CHART_NAME)/oldChart.yaml $(CHART_NAME)/Chart.yaml; \
+        mv $(CHART_NAME)/Chart.yaml.old $(CHART_NAME)/Chart.yaml; \
     fi ; \
 
 .PHONY: index

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,6 @@ package-specific:
 	@echo "Packing chart"
 	@cd $(WORKDIR); \
 	if [ "$(CHART_VERSION_OVERRIDE)" != "none" ]; then \
-	    cp $(CHART_NAME)/Chart.yaml $(CHART_NAME)/Chart.yaml.old; \
         awk '{if ($$1=="version:") {$$2="$(CHART_VERSION_OVERRIDE)"; print $$0} else print $$0}' $(CHART_NAME)/Chart.yaml > $(CHART_NAME)/tmp; \
         mv $(CHART_NAME)/tmp $(CHART_NAME)/Chart.yaml; \
     fi ; \

--- a/Makefile
+++ b/Makefile
@@ -199,10 +199,16 @@ package-specific:
 	$(HELM) lint $(CHART_NAME); \
 	if [ "$$?" != "0" ]; then \
         echo "Chart $(CHART_NAME) failed lint" ; \
+        if [ "$(CHART_VERSION_OVERRIDE)" != "none" ]; then \
+            mv $(CHART_NAME)/Chart.yaml.old $(CHART_NAME)/Chart.yaml; \
+        fi ; \
         exit 103 ; \
     fi ; \
     $(HELM) package $(CHART_NAME) && if [ "$$?" != "0" ]; then \
         echo "Chart $(CHART_NAME) failed package" ; \
+        if [ "$(CHART_VERSION_OVERRIDE)" != "none" ]; then \
+            mv $(CHART_NAME)/Chart.yaml.old $(CHART_NAME)/Chart.yaml; \
+        fi ; \
         exit 103 ; \
     fi ; \
     if [ "$(CHART_VERSION_OVERRIDE)" != "none" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,7 @@ package-specific:
 	@echo "Packing chart"
 	@cd $(WORKDIR); \
 	if [ "$(CHART_VERSION_OVERRIDE)" != "none" ]; then \
+        cp $(CHART_NAME)/Chart.yaml $(CHART_NAME)/Chart.yaml.old; \
         awk '{if ($$1=="version:") {$$2="$(CHART_VERSION_OVERRIDE)"; print $$0} else print $$0}' $(CHART_NAME)/Chart.yaml > $(CHART_NAME)/tmp; \
         mv $(CHART_NAME)/tmp $(CHART_NAME)/Chart.yaml; \
     fi ; \

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ package-all:
 
 .PHONY: package-specific
 package-specific:
-	@echo "Packing chart"
+	echo "Packing chart"
 	@cd $(WORKDIR); \
 	if [ "$(CHART_VERSION_OVERRIDE)" != "none" ]; then \
 	    cp $(CHART_NAME)/Chart.yaml $(CHART_NAME)/Chart.yaml.old; \

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ package-all:
 
 .PHONY: package-specific
 package-specific:
-	echo "Packing chart"
+	@echo "Packing chart"
 	@cd $(WORKDIR); \
 	if [ "$(CHART_VERSION_OVERRIDE)" != "none" ]; then \
 	    cp $(CHART_NAME)/Chart.yaml $(CHART_NAME)/Chart.yaml.old; \


### PR DESCRIPTION
relevant for `stable/demo/incubator-specific` operations
Example:
running `CHART_NAME=pipelines CHART_VERSION_OVERRIDE=1.0.0  make stable-specific` will build and package the pipelines helm chart as it is in version `1.0.0`