### PR TITLE
[jupyter,spark,zeppelin] - remove security contexts

### DIFF
--- a/stable/jupyter/Chart.yaml
+++ b/stable/jupyter/Chart.yaml
@@ -1,4 +1,4 @@
-version: 0.8.2
+version: 0.8.3
 apiVersion: v1
 appVersion: ">=2.0.0"
 name: jupyter

--- a/stable/jupyter/templates/jupyter-deployment.yaml
+++ b/stable/jupyter/templates/jupyter-deployment.yaml
@@ -159,8 +159,6 @@ spec:
           ports:
             - containerPort: {{ .Values.proxy.servicePort }}
               name: sidecar-proxy
-      securityContext:
-        fsGroup: 1000
       volumes:
         - name: config-volume
           configMap:

--- a/stable/spark/Chart.yaml
+++ b/stable/spark/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.10.2
+version: 0.10.3
 appVersion: ">=2.0.0"
 name: spark
 description: Fast and general-purpose cluster computing system.

--- a/stable/spark/templates/spark-master-deployment.yaml
+++ b/stable/spark/templates/spark-master-deployment.yaml
@@ -103,8 +103,6 @@ spec:
                 port: {{ .Values.master.uiProxy.containerPort }}
               initialDelaySeconds: 120
               timeoutSeconds: 5
-      securityContext:
-        fsGroup: 1000
       volumes:
 {{- if .Values.volumes }}
 {{ include .Values.volumes.master.volumesTemplate . | indent 8 }}

--- a/stable/spark/templates/spark-worker-deployment.yaml
+++ b/stable/spark/templates/spark-worker-deployment.yaml
@@ -80,8 +80,6 @@ spec:
               value: {{ $value }}
 {{- end }}
 {{- end }}
-      securityContext:
-        fsGroup: 1000
       volumes:
 {{- if .Values.volumes }}
 {{ include .Values.volumes.worker.volumesTemplate . | indent 8 }}

--- a/stable/zeppelin/Chart.yaml
+++ b/stable/zeppelin/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.4.1
+version: 0.4.2
 appVersion: ">=2.0.0"
 name: zeppelin
 description: Zeppelin

--- a/stable/zeppelin/templates/zeppelin-deployment.yaml
+++ b/stable/zeppelin/templates/zeppelin-deployment.yaml
@@ -96,8 +96,6 @@ spec:
             - mountPath: /etc/config/zeppelin/notebooks
               name: notebook-volume
 {{- end }}
-      securityContext:
-        fsGroup: 1000
       volumes:
 {{- if .Values.volumes }}
 {{ include .Values.volumes.volumesTemplate . | indent 8 }}


### PR DESCRIPTION
Those security contexts are in the charts approximately from day 1.
The thing is they were mistakenly added under the deployment's `spec` instead of under `spec.template.spec` so they were basically doing nothing.
Helm 3 as part of it's lint, verify your templates against the schema, so when we moved to helm 3 the lint fail on this incorrectly placed security contexts, so in https://github.com/v3io/helm-charts/pull/414 which was the preparation PR to the move to helm3 I fixed them to be correctly placed.
Lately we've started to have problems from this fsGroup definitions so decided to remove them


### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)