### PR TITLE
Ensure using helm v3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ helm-publish:
 helm-publish: cleanup-tmp-workspace
 
 .PHONY: helm-publish-demo-specific
-helm-publish-demo-specific: check-helm cleanup-tmp-workspace
+helm-publish-demo-specific: cleanup-tmp-workspace
 helm-publish-demo-specific:
 	@echo "Preparing to release a new demo index for $(CHART_NAME) from $(GITHUB_BRANCH)"
 	@git clone git@github.com:v3io/helm-charts /tmp/v3io-helm-charts
@@ -97,7 +97,7 @@ helm-publish-demo-specific:
 helm-publish-demo-specific: cleanup-tmp-workspace
 
 .PHONY: helm-publish-incubator-specific
-helm-publish-incubator-specific: check-helm cleanup-tmp-workspace
+helm-publish-incubator-specific: cleanup-tmp-workspace
 helm-publish-incubator-specific:
 	@echo "Preparing to release a new incubator index for $(CHART_NAME) from $(GITHUB_BRANCH)"
 	@rm -rf /tmp/v3io-helm-charts
@@ -117,7 +117,7 @@ helm-publish-incubator-specific:
 helm-publish-incubator-specific: cleanup-tmp-workspace
 
 .PHONY: helm-publish-stable-specific
-helm-publish-stable-specific: check-helm cleanup-tmp-workspace
+helm-publish-stable-specific: cleanup-tmp-workspace
 helm-publish-stable-specific:
 	@echo "Preparing to release a new stable index for $(CHART_NAME) from $(GITHUB_BRANCH)"
 	@git clone git@github.com:v3io/helm-charts /tmp/v3io-helm-charts

--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ package-specific: check-helm
     fi ; \
 
 .PHONY: index
-index: check-helm
+index:
 	@echo "Generating index.yaml"
 	$(HELM) repo index --merge $(WORKDIR)/index.yaml --url $(HELM_REPO_ROOT)/$(WORKDIR) $(WORKDIR)
 	@if [ "$$?" != "0" ]; then \


### PR DESCRIPTION
Changing the make file so that every command executed will first execute the `check_helm` block
Added logic to this block to verify that helm running version is v3.
Done mainly to prevent people from mistakenly releasing helm charts with helm v2 binary