### PR TITLE
[node-feature-discovery, pod-gpu-metric-exporter] node feature discovery labels only vendor_id on gpu nodes

### DIFF
--- a/stable/node-feature-discovery/Chart.yaml
+++ b/stable/node-feature-discovery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for Kubernetes
 name: node-feature-discovery
-version: 0.2.0
+version: 0.2.1
 maintainers:
   - name: Vladimir Syromyatnikov
     email: vladimirs@iguazio.com

--- a/stable/node-feature-discovery/values.yaml
+++ b/stable/node-feature-discovery/values.yaml
@@ -35,6 +35,7 @@ nfdMaster:
 nfdWorker:
   extraArgs:
     - --sleep-interval=60s
+    - --options={"sources":{"pci":{"deviceLabelFields":["vendor"]}}}
 
 podSecurityContext: {}
   # fsGroup: 2000

--- a/stable/pod-gpu-metrics-exporter/Chart.yaml
+++ b/stable/pod-gpu-metrics-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.0.0-alpha"
 description: Pod GPU metrics exporter
 name: pod-gpu-metrics-exporter
-version: 0.3.4
+version: 0.3.5
 sources:
   - https://github.com/NVIDIA/gpu-monitoring-tools/tree/master/exporters/prometheus-dcgm/k8s/pod-gpu-metrics-exporter
 maintainers:

--- a/stable/pod-gpu-metrics-exporter/values.yaml
+++ b/stable/pod-gpu-metrics-exporter/values.yaml
@@ -37,7 +37,6 @@ resources: {}
   #   memory: 128Mi
 
 gpuNodeSelectors:
-  - feature.node.kubernetes.io/pci-0302_10de.present
-  - feature.node.kubernetes.io/pci-0300_10de.present
+  - feature.node.kubernetes.io/pci-10de.present
 
 tolerations: []


### PR DESCRIPTION
Configured node-feature-discovery to label nodes with GPU vendor only
This way we can set a nodeSelector for the pod-gpu-metric-exporter that makes it run on all nodes that has a nvidia/gpu vendor id (10de)
(instead of having to mention every gpu id we may use)

### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)