### PR TITLE
[mlrun] - Add option to override env through config map

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mlrun
-version: 0.4.0
-appVersion: 0.5.0
+version: 0.4.1
+appVersion: 0.5.2
 description: Machine Learning automation and tracking
 sources:
   - https://github.com/mlrun/mlrun

--- a/stable/mlrun/templates/api-deployment.yaml
+++ b/stable/mlrun/templates/api-deployment.yaml
@@ -52,6 +52,13 @@ spec:
               secretKeyRef:
                 name: {{ .Release.Name }}-v3io-fuse
                 key: username
+          {{- if .Values.api.extraEnv }}
+          {{ toYaml .Values.api.extraEnv | nindent 10 }}
+          {{- end }}
+          {{- if .Values.api.envFrom }}
+          envFrom:
+          {{ toYaml .Values.api.envFrom | nindent 10 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
           volumeMounts:

--- a/stable/mlrun/templates/ui-deployment.yaml
+++ b/stable/mlrun/templates/ui-deployment.yaml
@@ -33,6 +33,13 @@ spec:
           env:
           - name: MLRUN_API_PROXY_URL
             value: 'http://{{ include "mlrun.api.fullname" . }}:{{ .Values.api.service.port }}'
+          {{- if .Values.ui.extraEnv }}
+          {{ toYaml .Values.ui.extraEnv | nindent 10 }}
+          {{- end }}
+          {{- if .Values.ui.envFrom }}
+          envFrom:
+          {{ toYaml .Values.ui.envFrom | nindent 10 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.ui.resources | nindent 12 }}
       {{- with .Values.ui.nodeSelector }}

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -7,7 +7,7 @@ api:
 
   image:
     repository: mlrun/mlrun-api
-    tag: 0.5.0
+    tag: 0.5.2
     pullPolicy: IfNotPresent
     pullSecrets: []
 
@@ -28,6 +28,17 @@ api:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
+
+  # Extra env variables
+  extraEnv: []
+
+  # envFrom can be used to pass configmaps or secrets as environment
+  # Adding these default values as a hack to be able to use this config map to override values in systems without
+  # upgrading Provazio controller
+  envFrom:
+    - configMapRef:
+        name: mlrun-override-env
+        optional: true
 
   resources: {}
     # limits:
@@ -70,7 +81,7 @@ ui:
 
   image:
     repository: mlrun/mlrun-ui
-    tag: 0.5.0
+    tag: 0.5.2
     pullPolicy: IfNotPresent
     pullSecrets: []
 
@@ -91,6 +102,12 @@ ui:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
+
+  # Extra env variables
+  extraEnv: []
+
+  # envFrom can be used to pass configmaps or secrets as environment
+  envFrom: []
 
   resources: {}
     # limits:


### PR DESCRIPTION
Backport of https://github.com/v3io/helm-charts/pull/484
but with adding defaults values to prevent the need to upgrade provazio controller on 2.10 system
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)