### PR TITLE
[mlrun] - Adding support for new features for open-mlops

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.5.1
+version: 0.5.2
 appVersion: 0.5.2
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/_helpers.tpl
+++ b/stable/mlrun/templates/_helpers.tpl
@@ -126,3 +126,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccounts.api.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Resolve the effective docker registry url and secret Name allowing for global values
+*/}}
+{{- define "mlrun.defaultDockerRegistry.url" -}}
+{{ default .Values.defaultDockerRegistryURL .Values.global.registry.url }}
+{{- end -}}
+
+{{- define "mlrun.defaultDockerRegistry.secretName" -}}
+{{ default .Values.defaultDockerRegistrySecretName .Values.global.registry.secretName }}
+{{- end -}}

--- a/stable/mlrun/templates/api-deployment.yaml
+++ b/stable/mlrun/templates/api-deployment.yaml
@@ -39,9 +39,12 @@ spec:
           - name: MLRUN_HTTPDB__DIRPATH
             value: {{ .Values.httpDB.dirPath }}
           - name: DEFAULT_DOCKER_REGISTRY
-            value: {{ .Values.defaultDockerRegistryURL }}
+            value: {{ template "mlrun.defaultDockerRegistry.url" . }}
+          - name: DEFAULT_DOCKER_SECRET
+            value: {{ template "mlrun.defaultDockerRegistry.secretName" . }}
           - name: MLRUN_HTTPDB__DSN
             value: {{ .Values.httpDB.dsn }}
+          {{- if .Values.v3io.enabled }}
           - name: V3IO_ACCESS_KEY
             valueFrom:
               secretKeyRef:
@@ -52,6 +55,7 @@ spec:
               secretKeyRef:
                 name: {{ .Release.Name }}-v3io-fuse
                 key: username
+          {{- end }}
           {{- if .Values.api.extraEnv }}
           {{ toYaml .Values.api.extraEnv | nindent 10 }}
           {{- end }}
@@ -66,6 +70,9 @@ spec:
               mountPath: {{ .Values.httpDB.dirPath }}
       volumes:
         - name: storage
+          {{- if .Values.api.volumes.storageOverride }}
+          {{- toYaml .Values.api.volumes.storageOverride | nindent 10 }}
+          {{- else }}
           flexVolume:
             driver: "v3io/fuse"
             options:
@@ -73,6 +80,7 @@ spec:
               subPath: /{{ .Values.v3io.username }}/.mlrun
             secretRef:
               name: {{ .Release.Name }}-v3io-fuse
+          {{- end }}
       {{- with .Values.api.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/stable/mlrun/templates/v3io-fuse-secret.yaml
+++ b/stable/mlrun/templates/v3io-fuse-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.v3io.enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ metadata:
 type: v3io/fuse
 data:
 {{ include "v3io-configs.fuse.secret" . | indent 2 }}
+{{- end }}

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -69,6 +69,10 @@ api:
   # runAsNonRoot: true
   # runAsUser: 1000
 
+  volumes:
+    storageOverride: {}
+
+
 ui:
   name: ui
 
@@ -138,6 +142,9 @@ ui:
   # runAsNonRoot: true
   # runAsUser: 1000
 
+v3io:
+  enabled: true
+
 rbac:
   create: true
 
@@ -155,3 +162,10 @@ httpDB:
   dsn: "sqlite:////mlrun/db/mlrun.db?check_same_thread=false"
 
 defaultDockerRegistryURL: ""
+defaultDockerRegistrySecretName: ""
+
+# global is a stanza that is used if this is used as a subchart. Ignore otherwise
+global:
+  registry:
+    url:
+    secretName:

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -142,9 +142,6 @@ ui:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-v3io:
-  enabled: true
-
 rbac:
   create: true
 
@@ -154,7 +151,8 @@ serviceAccounts:
     # If not set and create is true, a name is generated using the fullname template
     name:
 
-v3io: {}
+v3io:
+  enabled: true
 
 httpDB:
   dbType: "sqldb"


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### New features:
- disabling v3io
- Overriding storage volume
- Providing registry secret name
- Providing registry details via global