### PR TITLE
Build: replace deprecated api versions due upgrading k8s to 17.9

### DIFF
--- a/demo/taxi-demo/Chart.yaml
+++ b/demo/taxi-demo/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.4.0
+version: 0.4.1
 name: taxi-demo
 description: V3IO Taxi Demo
 home: https://iguazio.com

--- a/demo/taxi-demo/templates/demo-deployment.yaml
+++ b/demo/taxi-demo/templates/demo-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "demo.fullname" . }}

--- a/stable/dex-crds/Chart.yaml
+++ b/stable/dex-crds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dex-crds
-version: 0.2.0
+version: 0.2.1
 appVersion: 2.23.0
 description: A Helm chart for deploying Dex's CRDs
 type: application

--- a/stable/dex-crds/templates/authcodes.yaml
+++ b/stable/dex-crds/templates/authcodes.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: authcodes.dex.coreos.com

--- a/stable/dex-crds/templates/authrequests.yaml
+++ b/stable/dex-crds/templates/authrequests.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: authrequests.dex.coreos.com

--- a/stable/dex-crds/templates/connectors.yaml
+++ b/stable/dex-crds/templates/connectors.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: connectors.dex.coreos.com

--- a/stable/dex-crds/templates/oauth2clients.yaml
+++ b/stable/dex-crds/templates/oauth2clients.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: oauth2clients.dex.coreos.com

--- a/stable/dex-crds/templates/offlinesessionses.yaml
+++ b/stable/dex-crds/templates/offlinesessionses.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: offlinesessionses.dex.coreos.com

--- a/stable/dex-crds/templates/passwords.yaml
+++ b/stable/dex-crds/templates/passwords.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: passwords.dex.coreos.com

--- a/stable/dex-crds/templates/refreshtokens.yaml
+++ b/stable/dex-crds/templates/refreshtokens.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: refreshtokens.dex.coreos.com

--- a/stable/dex-crds/templates/signingkeies.yaml
+++ b/stable/dex-crds/templates/signingkeies.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: signingkeies.dex.coreos.com

--- a/stable/gpu-feature-discovery/Chart.yaml
+++ b/stable/gpu-feature-discovery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0.0-beta"
 description: A Helm chart for Kubernetes
 name: gpu-feature-discovery
-version: 0.3.0
+version: 0.3.1
 maintainers:
   - name: Vladimir Syromyatnikov
     email: vladimirs@iguazio.com

--- a/stable/gpu-feature-discovery/templates/rbac.yaml
+++ b/stable/gpu-feature-discovery/templates/rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "gpu-feature-discovery.fullname" . }}
@@ -18,7 +18,7 @@ rules:
     - list
     - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "gpu-feature-discovery.fullname" . }}

--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 4.7.0
+version: 4.7.1
 appVersion: 6.5.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/ingress.yaml
+++ b/stable/grafana/templates/ingress.yaml
@@ -3,7 +3,7 @@
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $extraPaths := .Values.ingress.extraPaths -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/stable/grafana/templates/role.yaml
+++ b/stable/grafana/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "grafana.fullname" . }}

--- a/stable/grafana/templates/rolebinding.yaml
+++ b/stable/grafana/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "grafana.fullname" . }}

--- a/stable/iguazio-system/Chart.yaml
+++ b/stable/iguazio-system/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for creating iguazio-system namespace and jobs
 name: iguazio-system
-version: 0.6.1
+version: 0.6.2
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
 sources:

--- a/stable/iguazio-system/templates/namespace-admin-clusterrole.yaml
+++ b/stable/iguazio-system/templates/namespace-admin-clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/stable/iguazio-system/templates/namespace-admin-clusterrolebinding.yaml
+++ b/stable/iguazio-system/templates/namespace-admin-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/stable/jupyterhub/Chart.yaml
+++ b/stable/jupyterhub/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.8.0
+version: 0.8.1
 appVersion: 0.9.2
 name: jupyterhub
 description: Multi-user Jupyter installation

--- a/stable/jupyterhub/templates/hub/rbac.yaml
+++ b/stable/jupyterhub/templates/hub/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: hub
   labels:
@@ -21,7 +21,7 @@ rules:
     verbs: ["get", "watch", "list"]
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: hub
   labels:

--- a/stable/jupyterhub/templates/image-puller/_daemonset-helper.yaml
+++ b/stable/jupyterhub/templates/image-puller/_daemonset-helper.yaml
@@ -4,7 +4,7 @@ Returns an image-puller daemonset. Two daemonsets will be created like this.
 - continuous-image-puller: for newly added nodes image pulling
 */}}
 {{- define "jupyterhub.imagePuller.daemonset" -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ print .componentPrefix "image-puller" }}

--- a/stable/jupyterhub/templates/image-puller/rbac.yaml
+++ b/stable/jupyterhub/templates/image-puller/rbac.yaml
@@ -22,7 +22,7 @@ metadata:
 ... will be used by this role...
 */}}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: hook-image-awaiter
   labels:
@@ -41,7 +41,7 @@ rules:
 ... as declared by this binding.
 */}}
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: hook-image-awaiter
   labels:

--- a/stable/jupyterhub/templates/ingress.yaml
+++ b/stable/jupyterhub/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: jupyterhub

--- a/stable/jupyterhub/templates/pod-culler/rbac.yaml
+++ b/stable/jupyterhub/templates/pod-culler/rbac.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pod-culler
   labels:
@@ -25,7 +25,7 @@ rules:
     - watch
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: pod-culler
   labels:

--- a/stable/jupyterhub/templates/proxy/autohttps/deployment.yaml
+++ b/stable/jupyterhub/templates/proxy/autohttps/deployment.yaml
@@ -1,7 +1,7 @@
 {{- $HTTPS := (and .Values.proxy.https.hosts .Values.proxy.https.enabled) }}
 {{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) }}
 {{- if $autoHTTPS -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: autohttps

--- a/stable/jupyterhub/templates/proxy/autohttps/ingress-internal.yaml
+++ b/stable/jupyterhub/templates/proxy/autohttps/ingress-internal.yaml
@@ -2,7 +2,7 @@
 {{- $autoHTTPS := (and $HTTPS (eq .Values.proxy.https.type "letsencrypt")) }}
 {{- if $autoHTTPS -}}
 # This is solely used to provide auto HTTPS with our bundled kube-lego
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: jupyterhub-internal

--- a/stable/jupyterhub/templates/proxy/autohttps/rbac.yaml
+++ b/stable/jupyterhub/templates/proxy/autohttps/rbac.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: nginx-{{ .Release.Name }}
@@ -74,7 +74,7 @@ rules:
     verbs:
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: nginx-{{ .Release.Name }}
@@ -89,7 +89,7 @@ subjects:
     name: autohttps
     namespace: {{ .Release.Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: nginx
@@ -129,7 +129,7 @@ rules:
       - get
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: kube-lego
@@ -166,7 +166,7 @@ rules:
   - create
   - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: nginx
@@ -181,7 +181,7 @@ subjects:
     name: autohttps
     namespace: {{ .Release.Namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: kube-lego

--- a/stable/jupyterhub/templates/proxy/deployment.yaml
+++ b/stable/jupyterhub/templates/proxy/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $manualHTTPS := (and .Values.proxy.https.enabled (eq .Values.proxy.https.type "manual")) -}}
 {{- $manualHTTPSwithsecret := (and .Values.proxy.https.enabled (eq .Values.proxy.https.type "secret")) -}}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: proxy

--- a/stable/metrics-server-exporter/Chart.yaml
+++ b/stable/metrics-server-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: K8s metrics exporter in prometheus format
 name: metrics-server-exporter
-version: 0.4.0
+version: 0.4.1
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
 sources:

--- a/stable/metrics-server-exporter/templates/metrics-server-exporter-binding.yaml
+++ b/stable/metrics-server-exporter/templates/metrics-server-exporter-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "metrics-server-exporter.name" . }}

--- a/stable/metrics-server-exporter/templates/metrics-server-exporter-deployment.yaml
+++ b/stable/metrics-server-exporter/templates/metrics-server-exporter-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "metrics-server-exporter.fullname" . }}

--- a/stable/metrics-server-exporter/templates/metrics-server-exporter-deployment.yaml
+++ b/stable/metrics-server-exporter/templates/metrics-server-exporter-deployment.yaml
@@ -13,6 +13,11 @@ spec:
       maxSurge: 1
       maxUnavailable: 0
     type: RollingUpdate
+  selector:
+    matchLabels:
+      app: {{ template "metrics-server-exporter.name" . }}
+      chart: {{ template "metrics-server-exporter.chart" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/stable/metrics-server-exporter/templates/metrics-server-exporter-role.yaml
+++ b/stable/metrics-server-exporter/templates/metrics-server-exporter-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "metrics-server-exporter.name" . }}-role

--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.5.3
+version: 0.5.4
 appVersion: 0.5.2
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.5.4
+version: 0.5.5
 appVersion: 0.5.2
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/api-role.yaml
+++ b/stable/mlrun/templates/api-role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "mlrun.api.fullname" . }}

--- a/stable/mlrun/templates/api-rolebinding.yaml
+++ b/stable/mlrun/templates/api-rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "mlrun.api.fullname" . }}

--- a/stable/mpi-operator/Chart.yaml
+++ b/stable/mpi-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "==0.2.0"
 description: Kubeflow MPI job operator
 name: mpi-operator
-version: 0.3.0
+version: 0.3.1
 home: https://www.kubeflow.org/
 icon: https://github.com/kubeflow/marketing-materials/blob/master/logos/Raster/Kubeflow-Logo-RGB.png
 sources:

--- a/stable/mpi-operator/templates/mpijob-crd.yaml
+++ b/stable/mpi-operator/templates/mpijob-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: mpijobs.kubeflow.org

--- a/stable/pipelines/Chart.yaml
+++ b/stable/pipelines/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=0.2.5"
 description: Kubeflow pipelines framework for machine learning
 name: pipelines
-version: 0.5.0
+version: 0.5.1
 home: https://www.kubeflow.org/
 icon: https://github.com/kubeflow/marketing-materials/blob/master/logos/Raster/Kubeflow-Logo-RGB.png
 sources:

--- a/stable/pipelines/templates/argo/workflow-controller-deployment.yaml
+++ b/stable/pipelines/templates/argo/workflow-controller-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.create }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: workflow-controller

--- a/stable/pipelines/templates/crd/application-crd.yaml
+++ b/stable/pipelines/templates/crd/application-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: applications.app.k8s.io

--- a/stable/pipelines/templates/crd/scheduled-workflow-crd.yaml
+++ b/stable/pipelines/templates/crd/scheduled-workflow-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: scheduledworkflows.kubeflow.org

--- a/stable/pipelines/templates/crd/viewer-crd.yaml
+++ b/stable/pipelines/templates/crd/viewer-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: viewers.kubeflow.org

--- a/stable/pipelines/templates/crd/workflow-crd.yaml
+++ b/stable/pipelines/templates/crd/workflow-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: workflows.argoproj.io

--- a/stable/pipelines/templates/metadata/deployment.yaml
+++ b/stable/pipelines/templates/metadata/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.create }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metadata

--- a/stable/pipelines/templates/metadata/envoy-deployment.yaml
+++ b/stable/pipelines/templates/metadata/envoy-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.create }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metadata-envoy

--- a/stable/pipelines/templates/metadata/writer-deployment.yaml
+++ b/stable/pipelines/templates/metadata/writer-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.create }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metadata-writer

--- a/stable/pipelines/templates/ml-pipeline/apiserver/deployment.yaml
+++ b/stable/pipelines/templates/ml-pipeline/apiserver/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.create }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/stable/pipelines/templates/ml-pipeline/persistenceagent/deployment.yaml
+++ b/stable/pipelines/templates/ml-pipeline/persistenceagent/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.create }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ml-pipeline-persistenceagent

--- a/stable/pipelines/templates/ml-pipeline/persistenceagent/rolebinding.yaml
+++ b/stable/pipelines/templates/ml-pipeline/persistenceagent/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: ml-pipeline-persistenceagent-binding

--- a/stable/pipelines/templates/ml-pipeline/scheduledworkflow/deployment.yaml
+++ b/stable/pipelines/templates/ml-pipeline/scheduledworkflow/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.create }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ml-pipeline-scheduledworkflow

--- a/stable/pipelines/templates/ml-pipeline/ui/deployment.yaml
+++ b/stable/pipelines/templates/ml-pipeline/ui/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.create }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ml-pipeline-ui

--- a/stable/pipelines/templates/ml-pipeline/viewer-crd/deployment.yaml
+++ b/stable/pipelines/templates/ml-pipeline/viewer-crd/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.create }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ml-pipeline-viewer-crd

--- a/stable/pipelines/templates/ml-pipeline/visualizationserver/deployment.yaml
+++ b/stable/pipelines/templates/ml-pipeline/visualizationserver/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.create }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ml-pipeline-visualizationserver

--- a/stable/pipelines/templates/mysql/deployment.yaml
+++ b/stable/pipelines/templates/mysql/deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.create }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}

--- a/stable/pod-gpu-metrics-exporter/Chart.yaml
+++ b/stable/pod-gpu-metrics-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.0.0-alpha"
 description: Pod GPU metrics exporter
 name: pod-gpu-metrics-exporter
-version: 0.4.0
+version: 0.4.1
 sources:
   - https://github.com/NVIDIA/gpu-monitoring-tools/tree/master/exporters/prometheus-dcgm/k8s/pod-gpu-metrics-exporter
 maintainers:

--- a/stable/pod-gpu-metrics-exporter/templates/daemonset.yaml
+++ b/stable/pod-gpu-metrics-exporter/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "pod-gpu-metrics-exporter.fullname" . }}

--- a/stable/pod-gpu-metrics-exporter/templates/rbac.yaml
+++ b/stable/pod-gpu-metrics-exporter/templates/rbac.yaml
@@ -15,7 +15,7 @@ rules:
   - patch
   - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "pod-gpu-metrics-exporter.fullname" . }}

--- a/stable/prebaked-registry/Chart.yaml
+++ b/stable/prebaked-registry/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Docker Registry with prebaked images and without persistency
 name: prebaked-registry
-version: 1.10.0
+version: 1.10.1
 appVersion: 2.7.1
 home: https://hub.docker.com/_/registry/
 icon: https://hub.docker.com/public/images/logos/mini-logo.svg

--- a/stable/prebaked-registry/templates/ingress.yaml
+++ b/stable/prebaked-registry/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "docker-registry.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $path := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "docker-registry.fullname" . }}

--- a/stable/provazio/Chart.yaml
+++ b/stable/provazio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Iguazio provisioner
 name: provazio
-version: 0.5.0
+version: 0.5.1
 appVersion: 0.20.10
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://iguazio.com

--- a/stable/provazio/templates/apigateway-crd.yaml
+++ b/stable/provazio/templates/apigateway-crd.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.controller.crd.create }}
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: iguazioapigateways.iguazio.com

--- a/stable/provazio/templates/appcluster-crd.yaml
+++ b/stable/provazio/templates/appcluster-crd.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.controller.crd.create }}
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: iguazioappclusters.iguazio.com

--- a/stable/provazio/templates/dashboard-ingress.yaml
+++ b/stable/provazio/templates/dashboard-ingress.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.dashboard.enabled .Values.dashboard.host }}
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "provazio.dashboard.name" . }}

--- a/stable/provazio/templates/tenant-appserviceset-crd-admin-cluster-role.yaml
+++ b/stable/provazio/templates/tenant-appserviceset-crd-admin-cluster-role.yaml
@@ -3,7 +3,7 @@
 # Allows access to the IguazioTenantAppServiceSet CRD.
 # This should be used by the platform-level controller
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: iguaziotenantappserviceset-crd-admin

--- a/stable/provazio/templates/tenant-appserviceset-crd.yaml
+++ b/stable/provazio/templates/tenant-appserviceset-crd.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.controller.crd.create }}
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: iguaziotenantappservicesets.iguazio.com

--- a/stable/provazio/templates/tenant-crd-admin-cluster-role.yaml
+++ b/stable/provazio/templates/tenant-crd-admin-cluster-role.yaml
@@ -3,7 +3,7 @@
 # Allows access to the IguazioTenant CRD.
 # This should be used by the platform-level controller
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: iguaziotenant-crd-admin

--- a/stable/provazio/templates/tenant-crd.yaml
+++ b/stable/provazio/templates/tenant-crd.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.controller.crd.create }}
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: iguaziotenants.iguazio.com

--- a/stable/provazio/templates/vault-ingress.yaml
+++ b/stable/provazio/templates/vault-ingress.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.vault.enabled .Values.vault.host }}
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "provazio.vault.name" . }}

--- a/stable/scaler/Chart.yaml
+++ b/stable/scaler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for creating scaler - dlx
 name: scaler
-version: 0.6.0
+version: 0.6.1
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
 sources:

--- a/stable/scaler/templates/role.yaml
+++ b/stable/scaler/templates/role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Release.Name }}-role

--- a/stable/scaler/templates/rolebinding.yaml
+++ b/stable/scaler/templates/rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}-rolebinding

--- a/stable/sparkoperator/Chart.yaml
+++ b/stable/sparkoperator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.3.0
+version: 1.3.1
 appVersion: v1beta2-1.0.1-2.4.4
 icon: http://spark.apache.org/images/spark-logo-trademark.png
 keywords:

--- a/stable/sparkoperator/templates/crd-cleanup-job.yaml
+++ b/stable/sparkoperator/templates/crd-cleanup-job.yaml
@@ -31,7 +31,7 @@ spec:
           -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" \
           -H \"Accept: application/json\" \
           -H \"Content-Type: application/json\" \
-          https://kubernetes.default.svc/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/sparkapplications.sparkoperator.k8s.io"
+          https://kubernetes.default.svc/apis/apiextensions.k8s.io/v1/customresourcedefinitions/sparkapplications.sparkoperator.k8s.io"
         - name: delete-scheduledsparkapp-crd
           image: {{ .Values.operatorImageName }}:{{ .Values.operatorVersion }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -43,5 +43,5 @@ spec:
           -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" \
           -H \"Accept: application/json\" \
           -H \"Content-Type: application/json\" \
-          https://kubernetes.default.svc/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/scheduledsparkapplications.sparkoperator.k8s.io"
+          https://kubernetes.default.svc/apis/apiextensions.k8s.io/v1/customresourcedefinitions/scheduledsparkapplications.sparkoperator.k8s.io"
 {{ end }}

--- a/stable/sparkoperator/templates/crds.yaml
+++ b/stable/sparkoperator/templates/crds.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
@@ -2535,7 +2535,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null

--- a/stable/tenant-creator/Chart.yaml
+++ b/stable/tenant-creator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for creating tenant creator
 name: tenant-creator
-version: 0.3.0
+version: 0.3.1
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
 sources:

--- a/stable/tenant-creator/templates/tiller-role.yaml
+++ b/stable/tenant-creator/templates/tiller-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:

--- a/stable/tenant-creator/templates/tiller-rolebinding.yaml
+++ b/stable/tenant-creator/templates/tiller-rolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:

--- a/stable/tenant/Chart.yaml
+++ b/stable/tenant/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for creating tenant
 name: tenant
-version: 0.4.0
+version: 0.4.1
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
 sources:

--- a/stable/tenant/templates/namespace-tag-role.yaml
+++ b/stable/tenant/templates/namespace-tag-role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.namespace.tagJob.run -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:

--- a/stable/tenant/templates/namespace-tag-rolebinding.yaml
+++ b/stable/tenant/templates/namespace-tag-rolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.namespace.tagJob.run -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:

--- a/stable/tenant/templates/pod-security-policy.yaml
+++ b/stable/tenant/templates/pod-security-policy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.security.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "tenant.name" . }}-default-policy

--- a/stable/v3io-webapi/Chart.yaml
+++ b/stable/v3io-webapi/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.9.0
+version: 0.9.1
 appVersion: "~1.7.0"
 name: v3io-webapi
 description: v3io WebAPI

--- a/stable/v3io-webapi/templates/v3io-webapi-daemonset.yaml
+++ b/stable/v3io-webapi/templates/v3io-webapi-daemonset.yaml
@@ -1,5 +1,5 @@
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ template "v3io-webapi.name" . }}
   labels:

--- a/stable/v3iod/Chart.yaml
+++ b/stable/v3iod/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.13.0
+version: 0.13.1
 appVersion: ">=1.9.4"
 name: v3iod
 description: v3io daemon

--- a/stable/v3iod/templates/v3io-locator-deployment.yaml
+++ b/stable/v3iod/templates/v3io-locator-deployment.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ template "v3iod.cache.name" . }}
   labels:

--- a/stable/v3iod/templates/v3io-locator-role.yaml
+++ b/stable/v3iod/templates/v3io-locator-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:

--- a/stable/v3iod/templates/v3io-locator-rolebinding.yaml
+++ b/stable/v3iod/templates/v3io-locator-rolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:

--- a/stable/v3iod/templates/v3iod-client-daemonset.yaml
+++ b/stable/v3iod/templates/v3iod-client-daemonset.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.benchmark.enabled }}
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ template "v3iod.client.name" . }}
   labels:

--- a/stable/v3iod/templates/v3iod-daemonset.yaml
+++ b/stable/v3iod/templates/v3iod-daemonset.yaml
@@ -1,5 +1,5 @@
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ template "v3iod.name" . }}
   labels:


### PR DESCRIPTION
### Charts changed and bumped:
- demo/tax-demo
- stable/dex-crds
- stable/gpu-feature-discovery
- stable/grafana
- stable/iguazio-system
- stable/jupyterhub
- stable/metrics/server-exporter
- stable/mlrun
- stable/mpi-operator
- stable/pipelines
- stable/pod-gpu-metrics-exporter
- stable/prebaked-registry
- stable/provazio
- stable/scaler
- stable/sparkoperator
- stable/tenant-creator
- stable/tenant
- stable/v3io-webapi
- stable/v3iod