### PR TITLE
[open-mlops] - Fixes to mlrun pvc env var, and ui image patch

### DIFF
--- a/stable/open-mlops/Chart.yaml
+++ b/stable/open-mlops/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.0.1
+version: 0.0.2
 name: open-mlops
 description: Open MLOPS Stack
 home: https://iguazio.com

--- a/stable/open-mlops/templates/_helpers.tpl
+++ b/stable/open-mlops/templates/_helpers.tpl
@@ -24,6 +24,10 @@ Create fully qualified names.
 {{- printf "%s-jupyter"  (include "open-mlops.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "open-mlops.jupyter-pvc.fullname" -}}
+{{- printf "%s-pvc"  (include "open-mlops.jupyter.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{/*
 Copied over from mlrun chart to duplicate the logic without constraining the values
 */}}

--- a/stable/open-mlops/templates/jupyter-notebook/deployment.yaml
+++ b/stable/open-mlops/templates/jupyter-notebook/deployment.yaml
@@ -59,6 +59,8 @@ spec:
           value: {{ index .Values "mpi-operator" "crd" "version" }}
         - name: MLRUN_ARTIFACT_PATH
           value: "/home/jovyan/data"
+        - name: MLRUN_PVC_MOUNT
+          value: {{ printf "%s:/home/jovyan/data" (include "open-mlops.jupyter-pvc.fullname" .) }}
         - name: CHOWN_HOME
           value: "yes"
         - name: CHOWN_HOME_OPTS

--- a/stable/open-mlops/templates/jupyter-notebook/deployment.yaml
+++ b/stable/open-mlops/templates/jupyter-notebook/deployment.yaml
@@ -80,4 +80,4 @@ spec:
       volumes:
       - name: notebooks
         persistentVolumeClaim:
-          claimName: {{ template "open-mlops.jupyter.fullname" . }}-pvc
+          claimName: {{ template "open-mlops.jupyter-pvc.fullname" . }}

--- a/stable/open-mlops/templates/jupyter-notebook/pvc.yaml
+++ b/stable/open-mlops/templates/jupyter-notebook/pvc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ template "open-mlops.jupyter.fullname" . }}-pvc
+  name: {{ template "open-mlops.jupyter-pvc.fullname" . }}
   labels:
     app.kubernetes.io/name: {{ template "open-mlops.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/stable/open-mlops/values.yaml
+++ b/stable/open-mlops/values.yaml
@@ -45,6 +45,9 @@ mlrun:
       storageOverride:
         persistentVolumeClaim:
           claimName: mlrun-pvc
+  ui:
+    image:
+      tag: 0.5.2-p1
 
 # mlrun persistency resources creation can be disabled if the user would like to provide their own PVC
 mlrunPersistency:


### PR DESCRIPTION
- Adding `MLRUN_PVC_MOUNT` env var for mlrun jobs to work
- Freezing to the manually built ui image in values with job screen fix