### PR TITLE
[mlrun] Adding liveness and readiness probes & bumping to 0.5.3-rc1

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mlrun
-version: 0.5.4
-appVersion: 0.5.2
+version: 0.5.5
+appVersion: 0.5.3
 description: Machine Learning automation and tracking
 sources:
   - https://github.com/mlrun/mlrun

--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.5.3
+version: 0.5.4
 appVersion: 0.5.2
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.5.6
+version: 0.5.7
 appVersion: 0.5.3
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/api-deployment.yaml
+++ b/stable/mlrun/templates/api-deployment.yaml
@@ -67,6 +67,14 @@ spec:
           envFrom:
           {{ toYaml .Values.api.envFrom | nindent 10 }}
           {{- end }}
+          {{- if .Values.api.livenessProbe }}
+          livenessProbe:
+          {{ toYaml .Values.api.livenessProbe | nindent 10 }}
+          {{- end }}
+          {{- if .Values.api.readinessProbe }}
+          readinessProbe:
+          {{ toYaml .Values.api.readinessProbe | nindent 10 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
           volumeMounts:

--- a/stable/mlrun/templates/api-deployment.yaml
+++ b/stable/mlrun/templates/api-deployment.yaml
@@ -69,11 +69,11 @@ spec:
           {{- end }}
           {{- if .Values.api.livenessProbe }}
           livenessProbe:
-          {{ toYaml .Values.api.livenessProbe | nindent 10 }}
+            {{ toYaml .Values.api.livenessProbe | nindent 12 }}
           {{- end }}
           {{- if .Values.api.readinessProbe }}
           readinessProbe:
-          {{ toYaml .Values.api.readinessProbe | nindent 10 }}
+            {{ toYaml .Values.api.readinessProbe | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -79,13 +79,13 @@ api:
     failureThreshold: 10
 
   livenessProbe:
-    exec:
-      command:
-        - /bin/bash
-        - -c
-        - pgrep -f mlrun
+    httpGet:
+      path: /api/healthz
+      port: http
     initialDelaySeconds: 60
     timeoutSeconds: 10
+    periodSeconds: 15
+    failureThreshold: 10
 
   volumes:
     storageOverride: {}

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -85,7 +85,7 @@ api:
         - -c
         - ps -efw | grep "[m]lrun"
     initialDelaySeconds: 120
-    timeoutSeconds: 5
+    timeoutSeconds: 10
 
   volumes:
     storageOverride: {}

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -81,10 +81,10 @@ api:
   livenessProbe:
     exec:
       command:
-        - /bin/sh
+        - /bin/bash
         - -c
         - ps -efw | grep "[m]lrun"
-    initialDelaySeconds: 120
+    initialDelaySeconds: 60
     timeoutSeconds: 10
 
   volumes:

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -7,7 +7,7 @@ api:
 
   image:
     repository: mlrun/mlrun-api
-    tag: 0.5.2
+    tag: 0.5.3
     pullPolicy: IfNotPresent
     pullSecrets: []
 
@@ -98,7 +98,7 @@ ui:
 
   image:
     repository: mlrun/mlrun-ui
-    tag: 0.5.2
+    tag: 0.5.3
     pullPolicy: IfNotPresent
     pullSecrets: []
 

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -69,6 +69,24 @@ api:
   # runAsNonRoot: true
   # runAsUser: 1000
 
+  readinessProbe:
+    httpGet:
+      path: /api/healthz
+      port: http
+    initialDelaySeconds: 10
+    timeoutSeconds: 30
+    periodSeconds: 5
+    failureThreshold: 10
+
+  livenessProbe:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - ps -efw | grep "[m]lrun"
+    initialDelaySeconds: 120
+    timeoutSeconds: 5
+
   volumes:
     storageOverride: {}
 

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -7,7 +7,7 @@ api:
 
   image:
     repository: mlrun/mlrun-api
-    tag: 0.5.3
+    tag: 0.5.3-rc1
     pullPolicy: IfNotPresent
     pullSecrets: []
 
@@ -98,7 +98,7 @@ ui:
 
   image:
     repository: mlrun/mlrun-ui
-    tag: 0.5.3
+    tag: 0.5.3-rc1
     pullPolicy: IfNotPresent
     pullSecrets: []
 

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -83,7 +83,7 @@ api:
       command:
         - /bin/bash
         - -c
-        - ps -efw | grep "[m]lrun"
+        - pgrep -f mlrun
     initialDelaySeconds: 60
     timeoutSeconds: 10
 

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -76,7 +76,7 @@ api:
     initialDelaySeconds: 10
     timeoutSeconds: 10
     periodSeconds: 15
-    failureThreshold: 10
+    failureThreshold: 4
 
   livenessProbe:
     httpGet:
@@ -85,7 +85,7 @@ api:
     initialDelaySeconds: 60
     timeoutSeconds: 10
     periodSeconds: 15
-    failureThreshold: 10
+    failureThreshold: 4
 
   volumes:
     storageOverride: {}

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -74,8 +74,8 @@ api:
       path: /api/healthz
       port: http
     initialDelaySeconds: 10
-    timeoutSeconds: 30
-    periodSeconds: 5
+    timeoutSeconds: 10
+    periodSeconds: 15
     failureThreshold: 10
 
   livenessProbe:


### PR DESCRIPTION
**Note:**
The liveness probe uses the `pgrep` command, `procps` added to mlrun-api container only in 0.5.3, so this version can work only with MLRun 0.5.3 and above

### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)