### PR TITLE
CRDs fix - k8s versions interoperability (fixing for k8s <v1.16)

### DIFF
--- a/stable/dex-crds/Chart.yaml
+++ b/stable/dex-crds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dex-crds
-version: 0.2.1
+version: 0.2.2
 appVersion: 2.23.0
 description: A Helm chart for deploying Dex's CRDs
 type: application

--- a/stable/dex-crds/templates/_helpers.tpl
+++ b/stable/dex-crds/templates/_helpers.tpl
@@ -50,3 +50,14 @@ Selector labels
 app.kubernetes.io/name: {{ include "dex-crds.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for CRD APIs.
+*/}}
+{{- define "crd.apiVersion" -}}
+{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apiextensions.k8s.io/v1" }}
+{{- else -}}
+{{- print "apiextensions.k8s.io/v1beta1" }}
+{{- end -}}
+{{- end -}}

--- a/stable/dex-crds/templates/authcodes.yaml
+++ b/stable/dex-crds/templates/authcodes.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: {{ template "crd.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   name: authcodes.dex.coreos.com
@@ -7,6 +7,10 @@ metadata:
 spec:
   group: dex.coreos.com
   version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   scope: Namespaced
   names:
     plural: authcodes

--- a/stable/dex-crds/templates/authcodes.yaml
+++ b/stable/dex-crds/templates/authcodes.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "dex-crds.labels" . | nindent 4 }}
 spec:
   group: dex.coreos.com
-  version: v1
   versions:
   - name: v1
     served: true

--- a/stable/dex-crds/templates/authrequests.yaml
+++ b/stable/dex-crds/templates/authrequests.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: {{ template "crd.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   name: authrequests.dex.coreos.com
@@ -7,6 +7,10 @@ metadata:
 spec:
   group: dex.coreos.com
   version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   scope: Namespaced
   names:
     plural: authrequests

--- a/stable/dex-crds/templates/authrequests.yaml
+++ b/stable/dex-crds/templates/authrequests.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "dex-crds.labels" . | nindent 4 }}
 spec:
   group: dex.coreos.com
-  version: v1
   versions:
   - name: v1
     served: true

--- a/stable/dex-crds/templates/connectors.yaml
+++ b/stable/dex-crds/templates/connectors.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: {{ template "crd.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   name: connectors.dex.coreos.com
@@ -7,6 +7,10 @@ metadata:
 spec:
   group: dex.coreos.com
   version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   scope: Namespaced
   names:
     plural: connectors

--- a/stable/dex-crds/templates/connectors.yaml
+++ b/stable/dex-crds/templates/connectors.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "dex-crds.labels" . | nindent 4 }}
 spec:
   group: dex.coreos.com
-  version: v1
   versions:
   - name: v1
     served: true

--- a/stable/dex-crds/templates/oauth2clients.yaml
+++ b/stable/dex-crds/templates/oauth2clients.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "dex-crds.labels" . | nindent 4 }}
 spec:
   group: dex.coreos.com
-  version: v1
   versions:
   - name: v1
     served: true

--- a/stable/dex-crds/templates/oauth2clients.yaml
+++ b/stable/dex-crds/templates/oauth2clients.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: {{ template "crd.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   name: oauth2clients.dex.coreos.com
@@ -7,6 +7,10 @@ metadata:
 spec:
   group: dex.coreos.com
   version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   scope: Namespaced
   names:
     plural: oauth2clients

--- a/stable/dex-crds/templates/offlinesessionses.yaml
+++ b/stable/dex-crds/templates/offlinesessionses.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: {{ template "crd.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   name: offlinesessionses.dex.coreos.com
@@ -7,6 +7,10 @@ metadata:
 spec:
   group: dex.coreos.com
   version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   scope: Namespaced
   names:
     plural: offlinesessionses

--- a/stable/dex-crds/templates/offlinesessionses.yaml
+++ b/stable/dex-crds/templates/offlinesessionses.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "dex-crds.labels" . | nindent 4 }}
 spec:
   group: dex.coreos.com
-  version: v1
   versions:
   - name: v1
     served: true

--- a/stable/dex-crds/templates/passwords.yaml
+++ b/stable/dex-crds/templates/passwords.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "dex-crds.labels" . | nindent 4 }}
 spec:
   group: dex.coreos.com
-  version: v1
   versions:
   - name: v1
     served: true

--- a/stable/dex-crds/templates/passwords.yaml
+++ b/stable/dex-crds/templates/passwords.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: {{ template "crd.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   name: passwords.dex.coreos.com
@@ -7,6 +7,10 @@ metadata:
 spec:
   group: dex.coreos.com
   version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   scope: Namespaced
   names:
     plural: passwords

--- a/stable/dex-crds/templates/refreshtokens.yaml
+++ b/stable/dex-crds/templates/refreshtokens.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: {{ template "crd.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   name: refreshtokens.dex.coreos.com
@@ -7,6 +7,10 @@ metadata:
 spec:
   group: dex.coreos.com
   version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   scope: Namespaced
   names:
     plural: refreshtokens

--- a/stable/dex-crds/templates/refreshtokens.yaml
+++ b/stable/dex-crds/templates/refreshtokens.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "dex-crds.labels" . | nindent 4 }}
 spec:
   group: dex.coreos.com
-  version: v1
   versions:
   - name: v1
     served: true

--- a/stable/dex-crds/templates/signingkeies.yaml
+++ b/stable/dex-crds/templates/signingkeies.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "dex-crds.labels" . | nindent 4 }}
 spec:
   group: dex.coreos.com
-  version: v1
   versions:
   - name: v1
     served: true

--- a/stable/dex-crds/templates/signingkeies.yaml
+++ b/stable/dex-crds/templates/signingkeies.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: {{ template "crd.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   name: signingkeies.dex.coreos.com
@@ -7,6 +7,10 @@ metadata:
 spec:
   group: dex.coreos.com
   version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
   scope: Namespaced
   names:
     plural: signingkeies

--- a/stable/mpi-operator/Chart.yaml
+++ b/stable/mpi-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "==0.2.0"
 description: Kubeflow MPI job operator
 name: mpi-operator
-version: 0.3.1
+version: 0.3.2
 home: https://www.kubeflow.org/
 icon: https://github.com/kubeflow/marketing-materials/blob/master/logos/Raster/Kubeflow-Logo-RGB.png
 sources:

--- a/stable/mpi-operator/templates/_helpers.tpl
+++ b/stable/mpi-operator/templates/_helpers.tpl
@@ -41,3 +41,14 @@ Allow overriding of service account and clusterrole names.
 {{- define "mpi-operator.clusterRoleName" -}}
 {{- default .Chart.Name .Values.rbac.clusterRoleName -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for CRD APIs.
+*/}}
+{{- define "crd.apiVersion" -}}
+{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apiextensions.k8s.io/v1" }}
+{{- else -}}
+{{- print "apiextensions.k8s.io/v1beta1" }}
+{{- end -}}
+{{- end -}}

--- a/stable/mpi-operator/templates/mpijob-crd.yaml
+++ b/stable/mpi-operator/templates/mpijob-crd.yaml
@@ -11,7 +11,6 @@ metadata:
     component: crd
 spec:
   group: kubeflow.org
-  version: {{ .Values.crd.version }}
   versions:
   - name: {{ .Values.crd.version }}
     served: true

--- a/stable/mpi-operator/templates/mpijob-crd.yaml
+++ b/stable/mpi-operator/templates/mpijob-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: {{ template "crd.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   name: mpijobs.kubeflow.org
@@ -12,6 +12,10 @@ metadata:
 spec:
   group: kubeflow.org
   version: {{ .Values.crd.version }}
+  versions:
+  - name: {{ .Values.crd.version }}
+    served: true
+    storage: true
   scope: Namespaced
   names:
     plural: mpijobs

--- a/stable/pipelines/templates/_helpers.tpl
+++ b/stable/pipelines/templates/_helpers.tpl
@@ -20,3 +20,14 @@ chart: {{ include "pipelines.chart" . }}
 release: {{ .Release.Name }}
 heritage: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for CRD APIs.
+*/}}
+{{- define "crd.apiVersion" -}}
+{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apiextensions.k8s.io/v1" }}
+{{- else -}}
+{{- print "apiextensions.k8s.io/v1beta1" }}
+{{- end -}}
+{{- end -}}

--- a/stable/pipelines/templates/crd/application-crd.yaml
+++ b/stable/pipelines/templates/crd/application-crd.yaml
@@ -234,7 +234,6 @@ spec:
               format: int64
               type: integer
           type: object
-  version: v1beta1
   versions:
   - name: v1beta1
     served: true

--- a/stable/pipelines/templates/crd/application-crd.yaml
+++ b/stable/pipelines/templates/crd/application-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: {{ template "crd.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   name: applications.app.k8s.io
@@ -235,4 +235,8 @@ spec:
               type: integer
           type: object
   version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
 {{- end }}

--- a/stable/pipelines/templates/crd/scheduled-workflow-crd.yaml
+++ b/stable/pipelines/templates/crd/scheduled-workflow-crd.yaml
@@ -16,7 +16,6 @@ spec:
     - swf
     singular: scheduledworkflow
   scope: Namespaced
-  version: v1beta1
   versions:
   - name: v1beta1
     served: true

--- a/stable/pipelines/templates/crd/scheduled-workflow-crd.yaml
+++ b/stable/pipelines/templates/crd/scheduled-workflow-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: {{ template "crd.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   name: scheduledworkflows.kubeflow.org
@@ -16,6 +16,7 @@ spec:
     - swf
     singular: scheduledworkflow
   scope: Namespaced
+  version: v1beta1
   versions:
   - name: v1beta1
     served: true

--- a/stable/pipelines/templates/crd/viewer-crd.yaml
+++ b/stable/pipelines/templates/crd/viewer-crd.yaml
@@ -16,7 +16,6 @@ spec:
     - vi
     singular: viewer
   scope: Namespaced
-  version: v1beta1
   versions:
   - name: v1beta1
     served: true

--- a/stable/pipelines/templates/crd/viewer-crd.yaml
+++ b/stable/pipelines/templates/crd/viewer-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: {{ template "crd.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   name: viewers.kubeflow.org
@@ -16,6 +16,7 @@ spec:
     - vi
     singular: viewer
   scope: Namespaced
+  version: v1beta1
   versions:
   - name: v1beta1
     served: true

--- a/stable/pipelines/templates/crd/workflow-crd.yaml
+++ b/stable/pipelines/templates/crd/workflow-crd.yaml
@@ -8,7 +8,6 @@ metadata:
 {{ include "pipelines.commonLabels" . | indent 4 }}
 spec:
   group: argoproj.io
-  version: v1beta1
   versions:
   - name: v1beta1
     served: true

--- a/stable/pipelines/templates/crd/workflow-crd.yaml
+++ b/stable/pipelines/templates/crd/workflow-crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: {{ template "crd.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   name: workflows.argoproj.io
@@ -9,6 +9,10 @@ metadata:
 spec:
   group: argoproj.io
   version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
   scope: Namespaced
   names:
     kind: Workflow

--- a/stable/pipelines/templates/crd/workflow-crd.yaml
+++ b/stable/pipelines/templates/crd/workflow-crd.yaml
@@ -8,9 +8,9 @@ metadata:
 {{ include "pipelines.commonLabels" . | indent 4 }}
 spec:
   group: argoproj.io
-  version: v1alpha1
+  version: v1beta1
   versions:
-  - name: v1alpha1
+  - name: v1beta1
     served: true
     storage: true
   scope: Namespaced

--- a/stable/provazio/Chart.yaml
+++ b/stable/provazio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Iguazio provisioner
 name: provazio
-version: 0.5.1
+version: 0.5.2
 appVersion: 0.20.10
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://iguazio.com

--- a/stable/provazio/templates/_helpers.tpl
+++ b/stable/provazio/templates/_helpers.tpl
@@ -18,3 +18,14 @@
 {{- define "provazio.vault.name" -}}
 {{- printf "%s-vault" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for CRD APIs.
+*/}}
+{{- define "crd.apiVersion" -}}
+{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apiextensions.k8s.io/v1" }}
+{{- else -}}
+{{- print "apiextensions.k8s.io/v1beta1" }}
+{{- end -}}
+{{- end -}}

--- a/stable/provazio/templates/apigateway-crd.yaml
+++ b/stable/provazio/templates/apigateway-crd.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.controller.crd.create }}
 
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: {{ template "crd.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   name: iguazioapigateways.iguazio.com
@@ -18,5 +18,8 @@ spec:
     singular: iguazioapigateway
   scope: Namespaced
   version: v1beta1
-
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
 {{- end }}

--- a/stable/provazio/templates/apigateway-crd.yaml
+++ b/stable/provazio/templates/apigateway-crd.yaml
@@ -17,7 +17,6 @@ spec:
     plural: iguazioapigateways
     singular: iguazioapigateway
   scope: Namespaced
-  version: v1beta1
   versions:
   - name: v1beta1
     served: true

--- a/stable/provazio/templates/appcluster-crd.yaml
+++ b/stable/provazio/templates/appcluster-crd.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.controller.crd.create }}
 
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: {{ template "crd.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   name: iguazioappclusters.iguazio.com
@@ -18,5 +18,8 @@ spec:
     singular: iguazioappcluster
   scope: Namespaced
   version: v1beta1
-
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
 {{- end }}

--- a/stable/provazio/templates/appcluster-crd.yaml
+++ b/stable/provazio/templates/appcluster-crd.yaml
@@ -17,7 +17,6 @@ spec:
     plural: iguazioappclusters
     singular: iguazioappcluster
   scope: Namespaced
-  version: v1beta1
   versions:
   - name: v1beta1
     served: true

--- a/stable/provazio/templates/tenant-appserviceset-crd.yaml
+++ b/stable/provazio/templates/tenant-appserviceset-crd.yaml
@@ -17,7 +17,6 @@ spec:
     plural: iguaziotenantappservicesets
     singular: iguaziotenantappserviceset
   scope: Namespaced
-  version: v1beta1
   versions:
   - name: v1beta1
     served: true

--- a/stable/provazio/templates/tenant-appserviceset-crd.yaml
+++ b/stable/provazio/templates/tenant-appserviceset-crd.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.controller.crd.create }}
 
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: {{ template "crd.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   name: iguaziotenantappservicesets.iguazio.com
@@ -18,5 +18,8 @@ spec:
     singular: iguaziotenantappserviceset
   scope: Namespaced
   version: v1beta1
-
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
 {{- end }}

--- a/stable/provazio/templates/tenant-crd.yaml
+++ b/stable/provazio/templates/tenant-crd.yaml
@@ -17,7 +17,6 @@ spec:
     plural: iguaziotenants
     singular: iguaziotenant
   scope: Namespaced
-  version: v1beta1
   versions:
   - name: v1beta1
     served: true

--- a/stable/provazio/templates/tenant-crd.yaml
+++ b/stable/provazio/templates/tenant-crd.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.controller.crd.create }}
 
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: {{ template "crd.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   name: iguaziotenants.iguazio.com
@@ -18,5 +18,8 @@ spec:
     singular: iguaziotenant
   scope: Namespaced
   version: v1beta1
-
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
 {{- end }}

--- a/stable/sparkoperator/Chart.yaml
+++ b/stable/sparkoperator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.3.1
+version: 1.3.2
 appVersion: v1beta2-1.0.1-2.4.4
 icon: http://spark.apache.org/images/spark-logo-trademark.png
 keywords:

--- a/stable/sparkoperator/templates/_helpers.tpl
+++ b/stable/sparkoperator/templates/_helpers.tpl
@@ -46,3 +46,14 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccounts.spark.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for CRD APIs.
+*/}}
+{{- define "crd.apiVersion" -}}
+{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apiextensions.k8s.io/v1" }}
+{{- else -}}
+{{- print "apiextensions.k8s.io/v1beta1" }}
+{{- end -}}
+{{- end -}}

--- a/stable/sparkoperator/templates/crds.yaml
+++ b/stable/sparkoperator/templates/crds.yaml
@@ -2523,7 +2523,6 @@ spec:
       - metadata
       - spec
       type: object
-  version: v1beta2
   versions:
   - name: v1beta2
     served: true
@@ -5077,7 +5076,6 @@ spec:
       - metadata
       - spec
       type: object
-  version: v1beta2
   versions:
   - name: v1beta2
     served: true

--- a/stable/sparkoperator/templates/crds.yaml
+++ b/stable/sparkoperator/templates/crds.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.crd.create }}
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: {{ template "crd.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
@@ -2535,7 +2535,7 @@ status:
   conditions: []
   storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: {{ template "crd.apiVersion" . }}
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
### Charts changed:
- dex-crds
- mpi-operator
- pipelines
- provazio
- sparkoperator