### PR TITLE
build: change minimal k8s version for CRD v1 to 1.19

### DIFF
--- a/stable/dex-crds/Chart.yaml
+++ b/stable/dex-crds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dex-crds
-version: 0.2.2
+version: 0.2.3
 appVersion: 2.23.0
 description: A Helm chart for deploying Dex's CRDs
 type: application

--- a/stable/dex-crds/templates/_helpers.tpl
+++ b/stable/dex-crds/templates/_helpers.tpl
@@ -55,7 +55,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Return the appropriate apiVersion for CRD APIs.
 */}}
 {{- define "crd.apiVersion" -}}
-{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "apiextensions.k8s.io/v1" }}
 {{- else -}}
 {{- print "apiextensions.k8s.io/v1beta1" }}

--- a/stable/mpi-operator/Chart.yaml
+++ b/stable/mpi-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "==0.2.0"
 description: Kubeflow MPI job operator
 name: mpi-operator
-version: 0.3.2
+version: 0.3.3
 home: https://www.kubeflow.org/
 icon: https://github.com/kubeflow/marketing-materials/blob/master/logos/Raster/Kubeflow-Logo-RGB.png
 sources:

--- a/stable/mpi-operator/templates/_helpers.tpl
+++ b/stable/mpi-operator/templates/_helpers.tpl
@@ -46,7 +46,7 @@ Allow overriding of service account and clusterrole names.
 Return the appropriate apiVersion for CRD APIs.
 */}}
 {{- define "crd.apiVersion" -}}
-{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "apiextensions.k8s.io/v1" }}
 {{- else -}}
 {{- print "apiextensions.k8s.io/v1beta1" }}

--- a/stable/pipelines/Chart.yaml
+++ b/stable/pipelines/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=1.0.1"
 description: Kubeflow pipelines framework for machine learning
 name: pipelines
-version: 0.5.2
+version: 0.5.3
 home: https://www.kubeflow.org/
 icon: https://github.com/kubeflow/marketing-materials/blob/master/logos/Raster/Kubeflow-Logo-RGB.png
 sources:

--- a/stable/pipelines/templates/_helpers.tpl
+++ b/stable/pipelines/templates/_helpers.tpl
@@ -25,7 +25,7 @@ heritage: {{ .Release.Service }}
 Return the appropriate apiVersion for CRD APIs.
 */}}
 {{- define "crd.apiVersion" -}}
-{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "apiextensions.k8s.io/v1" }}
 {{- else -}}
 {{- print "apiextensions.k8s.io/v1beta1" }}

--- a/stable/provazio/Chart.yaml
+++ b/stable/provazio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Iguazio provisioner
 name: provazio
-version: 0.5.2
+version: 0.5.3
 appVersion: 0.20.10
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://iguazio.com

--- a/stable/provazio/templates/_helpers.tpl
+++ b/stable/provazio/templates/_helpers.tpl
@@ -23,7 +23,7 @@
 Return the appropriate apiVersion for CRD APIs.
 */}}
 {{- define "crd.apiVersion" -}}
-{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "apiextensions.k8s.io/v1" }}
 {{- else -}}
 {{- print "apiextensions.k8s.io/v1beta1" }}

--- a/stable/sparkoperator/Chart.yaml
+++ b/stable/sparkoperator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.3.2
+version: 1.3.3
 appVersion: v1beta2-1.0.1-2.4.4
 icon: http://spark.apache.org/images/spark-logo-trademark.png
 keywords:

--- a/stable/sparkoperator/templates/_helpers.tpl
+++ b/stable/sparkoperator/templates/_helpers.tpl
@@ -51,7 +51,7 @@ Create the name of the service account to use
 Return the appropriate apiVersion for CRD APIs.
 */}}
 {{- define "crd.apiVersion" -}}
-{{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "apiextensions.k8s.io/v1" }}
 {{- else -}}
 {{- print "apiextensions.k8s.io/v1beta1" }}


### PR DESCRIPTION
### Checklist
- [x] Chart Version bumped

### Charts changed:
- dex-crds
- mpi-operator
- pipelines
- provazio
- sparkoperator

There is a problem with migration to CRD v1:
* the structure of CRD is too different, for example: 
   * `spec.version` has been removed 
   * `spec.validation.openAPIV3Schema` has been moved to `spec.versions[].scheme.openAPIV3Schema`
   * `spec.versions[].scheme.openAPIV3Schema` now is required option
