### PR TITLE
[mlrun] Adding liveness and readiness probes & bumping to 0.5.3-rc1 [backport integ_2.10]

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mlrun
-version: 0.4.1
-appVersion: 0.5.2
+version: 0.4.2
+appVersion: 0.5.3
 description: Machine Learning automation and tracking
 sources:
   - https://github.com/mlrun/mlrun

--- a/stable/mlrun/templates/api-deployment.yaml
+++ b/stable/mlrun/templates/api-deployment.yaml
@@ -59,6 +59,14 @@ spec:
           envFrom:
           {{ toYaml .Values.api.envFrom | nindent 10 }}
           {{- end }}
+          {{- if .Values.api.livenessProbe }}
+          livenessProbe:
+            {{ toYaml .Values.api.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.api.readinessProbe }}
+          readinessProbe:
+            {{ toYaml .Values.api.readinessProbe | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
           volumeMounts:

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -1,13 +1,13 @@
 api:
   name: api
 
-  logLevel: INFO
+  logLevel: DEBUG
 
   replicaCount: 1
 
   image:
     repository: mlrun/mlrun-api
-    tag: 0.5.2
+    tag: 0.5.3-rc1
     pullPolicy: IfNotPresent
     pullSecrets: []
 
@@ -74,6 +74,24 @@ api:
   # runAsNonRoot: true
   # runAsUser: 1000
 
+  readinessProbe:
+    httpGet:
+      path: /api/healthz
+      port: http
+    initialDelaySeconds: 10
+    timeoutSeconds: 10
+    periodSeconds: 15
+    failureThreshold: 4
+
+  livenessProbe:
+    httpGet:
+      path: /api/healthz
+      port: http
+    initialDelaySeconds: 60
+    timeoutSeconds: 10
+    periodSeconds: 15
+    failureThreshold: 4
+
 ui:
   name: ui
 
@@ -81,7 +99,7 @@ ui:
 
   image:
     repository: mlrun/mlrun-ui
-    tag: 0.5.2
+    tag: 0.5.3-rc1
     pullPolicy: IfNotPresent
     pullSecrets: []
 


### PR DESCRIPTION
Also changing log level to debug (in 3.0 provazio is doing that)

### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)