### PR TITLE
[mlrun-kit] - Bumping version to pick up mlrun fix

### DIFF
--- a/stable/mlrun-kit/requirements.lock
+++ b/stable/mlrun-kit/requirements.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: nuclio
   repository: https://nuclio.github.io/nuclio/charts
-  version: 0.7.0
+  version: 0.7.8
 - name: mlrun
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.5.8
+  version: 0.5.9
 - name: nfs-server-provisioner
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.1.1
 - name: mpi-operator
   repository: https://v3io.github.io/helm-charts/stable
   version: 0.2.1
-digest: sha256:3dc135649e1afd91e9d82aa67a674fbffd396d0a47cc9ab5c31e1a3587e644a6
-generated: "2020-11-23T17:54:33.982899+02:00"
+digest: sha256:468bc159b0b1d8cad17fc4ae9ac7d9c0587e631246a8fb6ac92172b9c4cdfa16
+generated: "2020-11-26T14:55:25.181264+02:00"

--- a/stable/mlrun-kit/requirements.yaml
+++ b/stable/mlrun-kit/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
 - name: nuclio
-  version: "0.7.0"
+  version: "0.7.8"
   repository: "https://nuclio.github.io/nuclio/charts"
 - name: mlrun
-  version: "0.5.8"
+  version: "0.5.9"
   repository: "https://v3io.github.io/helm-charts/stable"
 - name: nfs-server-provisioner
   version: "1.1.1"

--- a/stable/mlrun-kit/templates/NOTES.txt
+++ b/stable/mlrun-kit/templates/NOTES.txt
@@ -1,3 +1,5 @@
+You're up and running !
+
 1. Jupyter is available at:
   http://localhost:{{ .Values.jupyterNotebook.service.nodePort }}
 

--- a/stable/mlrun-kit/templates/jupyter-notebook/deployment.yaml
+++ b/stable/mlrun-kit/templates/jupyter-notebook/deployment.yaml
@@ -53,8 +53,6 @@ spec:
           value: {{ printf "http://%s:%s" (include "mlrun-kit.mlrun.api.fullname" .) (include "mlrun-kit.mlrun.api.port" .) }}
         - name: MLRUN_UI_URL
           value: {{ .Values.jupyterNotebook.mlrunUIURL }}
-        - name: MLRUN_NUCLIO_DASHBOARD_URL
-          value: {{ .Values.jupyterNotebook.nuclioDashboardURL }}
         - name: MLRUN_MPIJOB_CRD_VERSION
           value: {{ index .Values "mpi-operator" "crd" "version" }}
         - name: MLRUN_ARTIFACT_PATH

--- a/stable/mlrun-kit/values.yaml
+++ b/stable/mlrun-kit/values.yaml
@@ -39,7 +39,6 @@ mlrun:
   nameOverride: mlrun
   nuclio:
     mode: enabled
-    apiURL: "http://127.0.0.1:30060"
   rbac:
     create: true
   v3io:
@@ -73,7 +72,7 @@ jupyterNotebook:
     tag: 0.5.5-rc1
     pullPolicy: IfNotPresent
   mlrunUIURL: "http://127.0.0.1:30050"
-  nuclioDashboardURL: "http://127.0.0.1:30060"
+
 mpi-operator:
   nameOverride: mpi-operator
   crd:


### PR DESCRIPTION
Newest mlrun resolves the `nuclio.nuclioDashboardURL` on mlrun-api, no need for it on jupyter for now