### PR TITLE
[tsdb-functions] IG-17445 - don't use display name

### DIFF
--- a/stable/tsdb-functions/Chart.yaml
+++ b/stable/tsdb-functions/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.4.2
+version: 0.4.3
 appVersion: 0.0.12
 name: tsdb-functions
 description: V3IO TSDB nuclio functions

--- a/stable/tsdb-functions/templates/_helpers.tpl
+++ b/stable/tsdb-functions/templates/_helpers.tpl
@@ -22,5 +22,5 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{- define "tsdb-functions.projectName" -}}
-{{- printf "%s-%s" .Release.Name "project" | trunc 63 | trimSuffix "-" -}}
+{{- printf "tsdb-nuclio-functions-%s" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/stable/tsdb-functions/templates/project.yaml
+++ b/stable/tsdb-functions/templates/project.yaml
@@ -12,5 +12,3 @@ metadata:
     release: {{ .Release.Name }}  # TODO deprecate, use app.kubernetes.io/instance instead
     heritage: {{ .Release.Service }}
     component: project
-spec:
-  displayName: {{ .Values.project.displayName }}

--- a/stable/tsdb-functions/values.yaml
+++ b/stable/tsdb-functions/values.yaml
@@ -6,8 +6,6 @@ webapi:
   auth:
 #     must include username and password/accessKey
     secretName: ""
-project:
-  displayName: TSDB functions
 resources: {}
   # limits:
     # cpu: 1


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Nuclio display name field is deprecated don't use it
Plus change the default project name
full explanation in https://jira.iguazeng.com/browse/IG-17445