### PR TITLE
[tsdb-functions] IG-17448 - Add managed-by label to tsdb-nuclio project

### DIFF
--- a/stable/tsdb-functions/Chart.yaml
+++ b/stable/tsdb-functions/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.4.3
+version: 0.4.4
 appVersion: 0.0.12
 name: tsdb-functions
 description: V3IO TSDB nuclio functions

--- a/stable/tsdb-functions/templates/project.yaml
+++ b/stable/tsdb-functions/templates/project.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ template "tsdb-functions.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: "tsdb-functions"
     nuclio.io/project-name: {{ template "tsdb-functions.projectName" . }}
     app: {{ template "tsdb-functions.name" . }}  # TODO deprecate, use app.kubernetes.io/name instead


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Add managed-by label to TSDB-functions project chart. So MLRun can add the label to its own project. So if it recreates it with the labels, on the next helm upgrade, helm can adopt the project as managed by itself (according to https://github.com/helm/helm/pull/7649)