### PR TITLE
[Grafana] IG-17747 - Don't fail on empty dashboards folder

### DIFF
--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 4.7.1
+version: 4.7.2
 appVersion: 6.5.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.

--- a/stable/grafana/templates/configmap.yaml
+++ b/stable/grafana/templates/configmap.yaml
@@ -102,17 +102,21 @@ data:
 
     # Check only if the directory found.
     if [[ $? -eq 0 ]]; then
-      for i in *; do
-        case "$DashboardNamesString" in
-          *,$i,*)
-            echo "Not Deleting: $i"
-            ;;
-          *)
-            echo "Deleting: $i"
-            rm "$i"
-            ;;
-        esac
-      done
+      if [ -z "$(ls -A .)" ]; then
+        echo "Empty folder, no dashboard files to delete"
+      else
+        for i in *; do
+          case "$DashboardNamesString" in
+            *,$i,*)
+              echo "Not Deleting dashboard file: $i"
+              ;;
+            *)
+              echo "Deleting dashboard file: $i"
+              rm "$i"
+              ;;
+          esac
+        done
+      fi
     fi
 
       {{- end }}

--- a/stable/grafana/templates/configmap.yaml
+++ b/stable/grafana/templates/configmap.yaml
@@ -73,6 +73,7 @@ data:
 
   rm_obsolete_provisioned_dashboards.sh: |
     #!/usr/bin/env sh
+    set -x
     cd /var/lib/grafana/dashboards
 
     # Exit if the directory isn't found.


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
When a dashboard folder was empty the `for i in *` loop was assigning the `*` value to `i` (instead of not looping as I thought when writing it).
Wrapped the loop in a condition that verifying the folder isn't empty
Fixes IG-17747