### PR TITLE
[mlrun] Use fully qualified domain name (FQDN) for API URL env var on UI pod

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.5.12
+version: 0.5.13
 appVersion: 0.5.4
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/ui-deployment.yaml
+++ b/stable/mlrun/templates/ui-deployment.yaml
@@ -32,7 +32,7 @@ spec:
               protocol: TCP
           env:
           - name: MLRUN_API_PROXY_URL
-            value: 'http://{{ include "mlrun.api.fullname" . }}:{{ .Values.api.service.port }}'
+            value: 'http://{{ include "mlrun.api.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.api.service.port }}'
           - name: MLRUN_NUCLIO_MODE
             value: {{ .Values.nuclio.mode }}
           {{- if eq .Values.nuclio.mode "enabled" }}

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -188,6 +188,7 @@ nuclio:
 
   # Used by MLRun API/UI to access nuclio API to manipulate nuclio resources
   # This is resolved automatically for mlrun-kit or can be overridden explicitly
+  # Must be fully qualified domain name (FQDN) e.g. http://nuclio-dashboard.tenant-name.svc.cluster.local:8070
   apiURL:
 
 # global is a stanza that is used if this is used as a subchart. Ignore otherwise


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Required as result of https://github.com/mlrun/ui/pull/377