### PR TITLE
[mpi-operator] Make crd yaml deployable on k8s >= 1.19

### DIFF
--- a/stable/mpi-operator/Chart.yaml
+++ b/stable/mpi-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "==0.2.0"
 description: Kubeflow MPI job operator
 name: mpi-operator
-version: 0.3.3
+version: 0.3.4
 home: https://www.kubeflow.org/
 icon: https://github.com/kubeflow/marketing-materials/blob/master/logos/Raster/Kubeflow-Logo-RGB.png
 sources:

--- a/stable/mpi-operator/templates/mpijob-crd.yaml
+++ b/stable/mpi-operator/templates/mpijob-crd.yaml
@@ -15,6 +15,34 @@ spec:
   - name: {{ .Values.crd.version }}
     served: true
     storage: true
+{{- if eq (include "crd.apiVersion" .) "apiextensions.k8s.io/v1" }}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              slotsPerWorker:
+                type: integer
+                minimum: 1
+              mpiReplicaSpecs:
+                type: object
+                properties:
+                  Launcher:
+                    type: object
+                    properties:
+                      replicas:
+                        type: integer
+                        minimum: 1
+                        maximum: 1
+                  Worker:
+                    type: object
+                    properties:
+                      replicas:
+                        type: integer
+                        minimum: 1
+{{- end }}
   scope: Namespaced
   names:
     plural: mpijobs
@@ -23,6 +51,7 @@ spec:
     shortNames:
     - mj
     - mpij
+{{- if eq (include "crd.apiVersion" .) "apiextensions.k8s.io/v1beta1" }}
   subresources:
     status: {}
   validation:
@@ -46,4 +75,5 @@ spec:
                     replicas:
                       type: integer
                       minimum: 1
+{{- end }}
 {{- end }}


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Fixes root cause of https://github.com/mlrun/mlrun/issues/768 (After this will be merged and released, need to release the mlrun-kit with updated requirement to fix the issue)