### PR TITLE
[mpi-operator] Additional managed namespaces

### DIFF
--- a/stable/mpi-operator/Chart.yaml
+++ b/stable/mpi-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "==0.2.0"
 description: Kubeflow MPI job operator
 name: mpi-operator
-version: 0.4.1
+version: 0.4.2
 home: https://www.kubeflow.org/
 icon: https://github.com/kubeflow/marketing-materials/blob/master/logos/Raster/Kubeflow-Logo-RGB.png
 sources:

--- a/stable/mpi-operator/templates/mpi-operator-rolebinding.yaml
+++ b/stable/mpi-operator/templates/mpi-operator-rolebinding.yaml
@@ -1,9 +1,12 @@
 {{- if .Values.rbac.namespaced.create }}
+
+# append empty namespace so a role binding to current namespace will always be created
+{{- range (append .Values.rbac.additionalManagedNamespaces "") }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ . }}
   labels:
     app: {{ template "mpi-operator.name" . }}
     chart: {{ template "mpi-operator.chart" . }}
@@ -17,4 +20,7 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "mpi-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+---
+{{- end }}
+
 {{- end }}

--- a/stable/mpi-operator/templates/mpi-operator-rolebinding.yaml
+++ b/stable/mpi-operator/templates/mpi-operator-rolebinding.yaml
@@ -1,32 +1,25 @@
 {{- if .Values.rbac.namespaced.create }}
-{{- $releaseName := .Release.Name }}
-{{- $releaseNamespace := .Release.Namespace }}
-{{- $releaseService := .Release.Service }}
-{{- $mpiOperatorName := include "mpi-operator.name" . }}
-{{- $mpiOperatorChart := include "mpi-operator.chart" . }}
-{{- $mpiOperatorClusterRoleName := include "mpi-operator.clusterRoleName" . }}
-{{- $mpiOperatorServiceAccountName := include "mpi-operator.serviceAccountName" . }}
 
 # append empty namespace for the current namespace
 {{- range (append .Values.rbac.additionalManagedNamespaces "") }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ $releaseName }}
+  name: {{ $.Release.Name }}
   namespace: {{ . }}
   labels:
-    app: {{ $mpiOperatorName }}
-    chart: {{ $mpiOperatorChart }}
-    release: {{ $releaseName }}
-    heritage: {{ $releaseService }}
+    app: {{ include "mpi-operator.name" $ }}
+    chart: {{ include "mpi-operator.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ $mpiOperatorClusterRoleName }}
+  name: {{ include "mpi-operator.clusterRoleName" $ }}
 subjects:
 - kind: ServiceAccount
-  name: {{ $mpiOperatorServiceAccountName }}
-  namespace: {{ $releaseNamespace }}
+  name: {{ include "mpi-operator.serviceAccountName" $ }}
+  namespace: {{ $.Release.Namespace }}
 ---
 {{- end }}
 

--- a/stable/mpi-operator/templates/mpi-operator-rolebinding.yaml
+++ b/stable/mpi-operator/templates/mpi-operator-rolebinding.yaml
@@ -1,25 +1,32 @@
 {{- if .Values.rbac.namespaced.create }}
+{{- $releaseName := .Release.Name }}
+{{- $releaseNamespace := .Release.Namespace }}
+{{- $releaseService := .Release.Service }}
+{{- $mpiOperatorName := include "mpi-operator.name" . }}
+{{- $mpiOperatorChart := include "mpi-operator.chart" . }}
+{{- $mpiOperatorClusterRoleName := include "mpi-operator.clusterRoleName" . }}
+{{- $mpiOperatorServiceAccountName := include "mpi-operator.serviceAccountName" . }}
 
 # append empty namespace for the current namespace
 {{- range (append .Values.rbac.additionalManagedNamespaces "") }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ $releaseName }}
   namespace: {{ . }}
   labels:
-    app: {{ template "mpi-operator.name" . }}
-    chart: {{ template "mpi-operator.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app: {{ $mpiOperatorName }}
+    chart: {{ $mpiOperatorChart }}
+    release: {{ $releaseName }}
+    heritage: {{ $releaseService }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "mpi-operator.clusterRoleName" . }}
+  name: {{ $mpiOperatorClusterRoleName }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "mpi-operator.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ $mpiOperatorServiceAccountName }}
+  namespace: {{ $releaseNamespace }}
 ---
 {{- end }}
 

--- a/stable/mpi-operator/templates/mpi-operator-rolebinding.yaml
+++ b/stable/mpi-operator/templates/mpi-operator-rolebinding.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.rbac.namespaced.create }}
-
 # append empty namespace for the current namespace
 {{- range (append .Values.rbac.additionalManagedNamespaces "") }}
 kind: RoleBinding
@@ -22,5 +21,4 @@ subjects:
   namespace: {{ $.Release.Namespace }}
 ---
 {{- end }}
-
 {{- end }}

--- a/stable/mpi-operator/templates/mpi-operator-rolebinding.yaml
+++ b/stable/mpi-operator/templates/mpi-operator-rolebinding.yaml
@@ -1,13 +1,8 @@
 {{- if .Values.rbac.namespaced.create }}
 
 # create a full list of managed namesapces (append current namespace with additionalManagedNamespaces)
-# done this way as a workaround for the helm bug, which translates {}->{""} when passing empty list on cli
-{{- $managedNamespaces := list }}
-{{- if and (eq (len .Values.additionalManagedNamespaces) 1) (has "" .Values.additionalManagedNamespaces) }}
-{{- $managedNamespaces = list .Release.Namespace }}
-{{- else }}
-{{- $managedNamespaces = append .Values.additionalManagedNamespaces .Release.Namespace }}
-{{- end }}
+# use "without" to remove empty namespace from being there when an empty list is passed
+{{- $managedNamespaces := append (without .Values.additionalManagedNamespaces "") .Release.Namespace | uniq | sortAlpha }}
 
 # append empty namespace for the current namespace
 {{- range $managedNamespaces }}
@@ -17,17 +12,17 @@ metadata:
   name: {{ $.Release.Name }}
   namespace: {{ . }}
   labels:
-    app: {{ include "mpi-operator.name" $ }}
-    chart: {{ include "mpi-operator.chart" $ }}
+    app: {{ template "mpi-operator.name" $ }}
+    chart: {{ template "mpi-operator.chart" $ }}
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "mpi-operator.clusterRoleName" $ }}
+  name: {{ template "mpi-operator.clusterRoleName" $ }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "mpi-operator.serviceAccountName" $ }}
+  name: {{ template "mpi-operator.serviceAccountName" $ }}
   namespace: {{ $.Release.Namespace }}
 ---
 {{- end }}

--- a/stable/mpi-operator/templates/mpi-operator-rolebinding.yaml
+++ b/stable/mpi-operator/templates/mpi-operator-rolebinding.yaml
@@ -1,6 +1,16 @@
 {{- if .Values.rbac.namespaced.create }}
+
+# create a full list of managed namesapces (append current namespace with additionalManagedNamespaces)
+# done this way as a workaround for the helm bug, which translates {}->{""} when passing empty list on cli
+{{- $managedNamespaces := list }}
+{{- if and (eq (len .Values.rbac.additionalManagedNamespaces) 1) (has "" .Values.rbac.additionalManagedNamespaces) }}
+{{- $managedNamespaces = list .Release.Namespace }}
+{{- else }}
+{{- $managedNamespaces = append .Values.rbac.additionalManagedNamespaces .Release.Namespace }}
+{{- end }}
+
 # append empty namespace for the current namespace
-{{- range (append .Values.rbac.additionalManagedNamespaces "") }}
+{{- range $managedNamespaces }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/stable/mpi-operator/templates/mpi-operator-rolebinding.yaml
+++ b/stable/mpi-operator/templates/mpi-operator-rolebinding.yaml
@@ -3,10 +3,10 @@
 # create a full list of managed namesapces (append current namespace with additionalManagedNamespaces)
 # done this way as a workaround for the helm bug, which translates {}->{""} when passing empty list on cli
 {{- $managedNamespaces := list }}
-{{- if and (eq (len .Values.rbac.additionalManagedNamespaces) 1) (has "" .Values.rbac.additionalManagedNamespaces) }}
+{{- if and (eq (len .Values.additionalManagedNamespaces) 1) (has "" .Values.additionalManagedNamespaces) }}
 {{- $managedNamespaces = list .Release.Namespace }}
 {{- else }}
-{{- $managedNamespaces = append .Values.rbac.additionalManagedNamespaces .Release.Namespace }}
+{{- $managedNamespaces = append .Values.additionalManagedNamespaces .Release.Namespace }}
 {{- end }}
 
 # append empty namespace for the current namespace

--- a/stable/mpi-operator/templates/mpi-operator-rolebinding.yaml
+++ b/stable/mpi-operator/templates/mpi-operator-rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.namespaced.create }}
 
-# append empty namespace so a role binding to current namespace will always be created
+# append empty namespace for the current namespace
 {{- range (append .Values.rbac.additionalManagedNamespaces "") }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/stable/mpi-operator/templates/mpi-operator-serviceaccount.yaml
+++ b/stable/mpi-operator/templates/mpi-operator-serviceaccount.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.rbac.namespaced.create }}
-# append empty namespace for the current namespace
-{{- range (append .Values.rbac.additionalManagedNamespaces "") }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -11,5 +9,4 @@ metadata:
     chart: {{ template "mpi-operator.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- end }}
 {{- end }}

--- a/stable/mpi-operator/templates/mpi-operator-serviceaccount.yaml
+++ b/stable/mpi-operator/templates/mpi-operator-serviceaccount.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.rbac.namespaced.create }}
+# append empty namespace for the current namespace
+{{- range (append .Values.rbac.additionalManagedNamespaces "") }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,4 +11,5 @@ metadata:
     chart: {{ template "mpi-operator.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- end }}
 {{- end }}

--- a/stable/mpi-operator/values.yaml
+++ b/stable/mpi-operator/values.yaml
@@ -10,6 +10,9 @@ rbac:
   namespaced:
     create: true
 
+  # A list of namespaces that the operator will also get resources access to
+  additionalManagedNamespaces: []
+
 deployment:
   create: true
 

--- a/stable/mpi-operator/values.yaml
+++ b/stable/mpi-operator/values.yaml
@@ -1,3 +1,6 @@
+# A list of namespaces that the operator will also get resources access to
+additionalManagedNamespaces: []
+
 crd:
   create: false
   version: v1
@@ -9,9 +12,6 @@ rbac:
     create: false
   namespaced:
     create: true
-
-  # A list of namespaces that the operator will also get resources access to
-  additionalManagedNamespaces: []
 
 deployment:
   create: true


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Additional managed namespaces as an input to the chart - grants needed roles (using role-bindings) for the controller to run on the additional namespaces