### PR TITLE
[mpi-operator] Fix mpijob crd schema + cluster role name

### DIFF
--- a/stable/mpi-operator/Chart.yaml
+++ b/stable/mpi-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "==0.2.0"
 description: Kubeflow MPI job operator
 name: mpi-operator
-version: 0.4.2
+version: 0.4.3
 home: https://www.kubeflow.org/
 icon: https://github.com/kubeflow/marketing-materials/blob/master/logos/Raster/Kubeflow-Logo-RGB.png
 sources:

--- a/stable/mpi-operator/templates/mpi-operator-clusterrole.yaml
+++ b/stable/mpi-operator/templates/mpi-operator-clusterrole.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ template "mpi-operator.clusterRoleName" . }}
   labels:
     app: {{ template "mpi-operator.name" . }}
     chart: {{ template "mpi-operator.chart" . }}

--- a/stable/mpi-operator/templates/mpijob-crd.yaml
+++ b/stable/mpi-operator/templates/mpijob-crd.yaml
@@ -21,27 +21,9 @@ spec:
         type: object
         properties:
           spec:
-            type: object
-            properties:
-              slotsPerWorker:
-                type: integer
-                minimum: 1
-              mpiReplicaSpecs:
-                type: object
-                properties:
-                  Launcher:
-                    type: object
-                    properties:
-                      replicas:
-                        type: integer
-                        minimum: 1
-                        maximum: 1
-                  Worker:
-                    type: object
-                    properties:
-                      replicas:
-                        type: integer
-                        minimum: 1
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
 {{- end }}
   scope: Namespaced
   names:


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
In https://github.com/v3io/helm-charts/pull/559 I added the schema cause otherwise it wouldn't let install the CRD on k8s>=1.19. the schema I used there was just taken from the validation block which I thought back then to be aligned.
Apparently, this schema is missing A LOT of stuff, and what practically happening is that when you create a custom object pretty much all of it is [getting pruned ](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning). 
The actual schema includes a Pod template, and currently there is no way to use already defined structure ( https://github.com/kubernetes/kubernetes/issues/62872 and https://github.com/kubernetes/kubernetes/issues/82292), I'm not willing to duplicate the whole pod template schema since it's huge, so I simply added `x-kubernetes-preserve-unknown-fields: true` which just turn off field pruning (I assume at some point k8s won't let us do that, but also at that point they will hopefully resolve those issues so we will be able to re-use stuff)

Also, fixed the cluster role name to use the correct value (before it was assigned to a value different than the role binding, so was practically not getting the binding to the cluster role)