### PR TITLE
[mlrun-kit] Bump mpi-operator chart (dependency) version

### DIFF
--- a/stable/mlrun-kit/Chart.yaml
+++ b/stable/mlrun-kit/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.3
+version: 0.1.4
 name: mlrun-kit
 description: MLRUn Open Source Stack
 home: https://iguazio.com

--- a/stable/mlrun-kit/requirements.lock
+++ b/stable/mlrun-kit/requirements.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 1.1.1
 - name: mpi-operator
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.4.1
-digest: sha256:1498df43059dfd1674f2eb656264781d9fc6548f1749d718409e8f2bfa542bb2
-generated: "2021-02-27T21:51:33.522916+02:00"
+  version: 0.4.3
+digest: sha256:733361076f56b8a43293111612931b699e1451667d871f0125b697a18493166a
+generated: "2021-04-29T03:07:51.738509+03:00"

--- a/stable/mlrun-kit/requirements.lock
+++ b/stable/mlrun-kit/requirements.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 1.1.1
 - name: mpi-operator
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.4.3
-digest: sha256:733361076f56b8a43293111612931b699e1451667d871f0125b697a18493166a
-generated: "2021-04-29T03:07:51.738509+03:00"
+  version: 0.4.4
+digest: sha256:bf2ea7e0dff057ab4a9b42660997b8570c5d98fc3566b2743d809e29ee0c0305
+generated: "2021-04-29T04:17:21.599247+03:00"

--- a/stable/mlrun-kit/requirements.yaml
+++ b/stable/mlrun-kit/requirements.yaml
@@ -9,5 +9,5 @@ dependencies:
   version: "1.1.1"
   repository: "https://charts.helm.sh/stable"
 - name: mpi-operator
-  version: "0.4.1"
+  version: "0.4.3"
   repository: "https://v3io.github.io/helm-charts/stable"

--- a/stable/mlrun-kit/requirements.yaml
+++ b/stable/mlrun-kit/requirements.yaml
@@ -9,5 +9,5 @@ dependencies:
   version: "1.1.1"
   repository: "https://charts.helm.sh/stable"
 - name: mpi-operator
-  version: "0.4.3"
+  version: "0.4.4"
   repository: "https://v3io.github.io/helm-charts/stable"


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Done in order to get the fixes done in https://github.com/v3io/helm-charts/pull/573 and https://github.com/v3io/helm-charts/pull/575