### PR TITLE
[mpi-operator] Add subresources to mpijob crd

### DIFF
--- a/stable/mpi-operator/Chart.yaml
+++ b/stable/mpi-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "==0.2.0"
 description: Kubeflow MPI job operator
 name: mpi-operator
-version: 0.4.3
+version: 0.4.4
 home: https://www.kubeflow.org/
 icon: https://github.com/kubeflow/marketing-materials/blob/master/logos/Raster/Kubeflow-Logo-RGB.png
 sources:

--- a/stable/mpi-operator/templates/mpijob-crd.yaml
+++ b/stable/mpi-operator/templates/mpijob-crd.yaml
@@ -16,6 +16,8 @@ spec:
     served: true
     storage: true
 {{- if eq (include "crd.apiVersion" .) "apiextensions.k8s.io/v1" }}
+    subresources:
+      status: {}
     schema:
       openAPIV3Schema:
         type: object


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Another fix to mpijob crd - subresources definition was missing for when using the v1 custom resources definition version (which was preventing the operator from being able to update custom objects status)