### PR TITLE
[jupyter] - fix nodeSelector/tolerations/affinity usage

### DIFF
--- a/stable/jupyter/Chart.yaml
+++ b/stable/jupyter/Chart.yaml
@@ -1,4 +1,4 @@
-version: 0.10.1
+version: 0.10.2
 apiVersion: v1
 appVersion: ">=2.0.0"
 name: jupyter

--- a/stable/jupyter/templates/jupyter-deployment.yaml
+++ b/stable/jupyter/templates/jupyter-deployment.yaml
@@ -81,7 +81,6 @@ spec:
               name: jupyter
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-{{- if .Values.nodeSelector }}
           livenessProbe:
             exec:
               command:
@@ -184,6 +183,7 @@ spec:
 {{- if .Values.pvc }}
 {{ include .Values.pvc.pvcVolumesTemplate . | indent 8 }}
 {{- end }}
+{{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
 {{- end }}

--- a/stable/jupyter/templates/jupyter-deployment.yaml
+++ b/stable/jupyter/templates/jupyter-deployment.yaml
@@ -82,17 +82,6 @@ spec:
           resources:
 {{ toYaml .Values.resources | indent 12 }}
 {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-{{- end }}
-{{- if .Values.affinity }}
-      affinity:
-{{ toYaml .Values.affinity | indent 8 }}
-{{- end }}
-{{- if .Values.tolerations }}
-      tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
-{{- end }}
           livenessProbe:
             exec:
               command:
@@ -194,4 +183,15 @@ spec:
 {{- end }}
 {{- if .Values.pvc }}
 {{ include .Values.pvc.pvcVolumesTemplate . | indent 8 }}
+{{- end }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
 {{- end }}


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
new blocks added not in place (mid containers block), so if `nodeSelector` was given then the `livenessProbe` was out of place