### PR TITLE
[mlrun-kit] Bump mpi-operator chart version

### DIFF
--- a/stable/mlrun-kit/Chart.yaml
+++ b/stable/mlrun-kit/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.4
+version: 0.1.5
 name: mlrun-kit
 description: MLRUn Open Source Stack
 home: https://iguazio.com

--- a/stable/mlrun-kit/requirements.lock
+++ b/stable/mlrun-kit/requirements.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 1.1.1
 - name: mpi-operator
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.4.4
-digest: sha256:bf2ea7e0dff057ab4a9b42660997b8570c5d98fc3566b2743d809e29ee0c0305
-generated: "2021-04-29T04:17:21.599247+03:00"
+  version: 0.4.5
+digest: sha256:f43e4df4d189a7faf3a7d422a5933e4ea86d512ee2505cc57555f729b5145764
+generated: "2021-04-30T18:23:58.304512+03:00"

--- a/stable/mlrun-kit/requirements.yaml
+++ b/stable/mlrun-kit/requirements.yaml
@@ -9,5 +9,5 @@ dependencies:
   version: "1.1.1"
   repository: "https://charts.helm.sh/stable"
 - name: mpi-operator
-  version: "0.4.4"
+  version: "0.4.5"
   repository: "https://v3io.github.io/helm-charts/stable"

--- a/stable/mlrun-kit/values.yaml
+++ b/stable/mlrun-kit/values.yaml
@@ -114,10 +114,6 @@ mpi-operator:
       create: true
   deployment:
     create: true
-  image:
-    deployment:
-      repository: gcr.io/iguazio/mpi-operator
-      tag: v0.2.3-igz
 
 ## customize PV spec used for nfs-server provisioner
 ## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/

--- a/stable/mlrun-kit/values.yaml
+++ b/stable/mlrun-kit/values.yaml
@@ -114,6 +114,10 @@ mpi-operator:
       create: true
   deployment:
     create: true
+  image:
+    deployment:
+      repository: gcr.io/iguazio/mpi-operator
+      tag: v0.2.3-igz
 
 ## customize PV spec used for nfs-server provisioner
 ## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Changing to use the chart version that includes this fix - https://github.com/v3io/helm-charts/pull/579