### PR TITLE
[mpi-operator] Use iguazio mpi operator image by default

### DIFF
--- a/stable/mpi-operator/Chart.yaml
+++ b/stable/mpi-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "==0.2.0"
 description: Kubeflow MPI job operator
 name: mpi-operator
-version: 0.4.4
+version: 0.4.5
 home: https://www.kubeflow.org/
 icon: https://github.com/kubeflow/marketing-materials/blob/master/logos/Raster/Kubeflow-Logo-RGB.png
 sources:

--- a/stable/mpi-operator/values.yaml
+++ b/stable/mpi-operator/values.yaml
@@ -16,8 +16,8 @@ deployment:
 image:
   deployment:
     replicas: 1
-    repository: mpioperator/mpi-operator
-    tag: v0.2.3
+    repository: gcr.io/iguazio/mpi-operator
+    tag: v0.2.3-igz
     pullPolicy: IfNotPresent
   kubectlDelivery:
     repository: mpioperator/kubectl-delivery


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
This `gcr.io/iguazio/mpi-operator:v0.2.3-igz` image is exactly the same as the regular `mpioperator/mpi-operator:v0.2.3` with [this fix ](https://github.com/kubeflow/mpi-operator/pull/271) added on top.
Without the fix mpijob pods are not labeled (which means mlrun cleanup doesn't work on them).