### PR TITLE
[mlrun-kit] Bump default mlrun image tags to 0.6.4-rc1

### DIFF
--- a/stable/mlrun-kit/Chart.yaml
+++ b/stable/mlrun-kit/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.5
+version: 0.1.6
 name: mlrun-kit
 description: MLRUn Open Source Stack
 home: https://iguazio.com

--- a/stable/mlrun-kit/values.yaml
+++ b/stable/mlrun-kit/values.yaml
@@ -58,7 +58,7 @@ mlrun:
   api:
     fullnameOverride: mlrun-api
     image:
-      tag: 0.6.0
+      tag: 0.6.4-rc1
     service:
       type: NodePort
       nodePort: 30070
@@ -72,7 +72,7 @@ mlrun:
       type: NodePort
       nodePort: 30060
     image:
-      tag: 0.6.0
+      tag: 0.6.4-rc1
 
 # mlrun persistency resources creation can be disabled if the user would like to provide their own PVC
 mlrunPersistency:
@@ -86,7 +86,7 @@ jupyterNotebook:
     nodePort: 30040
   image:
     repository: quay.io/mlrun/jupyter
-    tag: 0.6.0
+    tag: 0.6.4-rc1
     pullPolicy: IfNotPresent
   # use this to override mlrunUIURL, by default it will be auto-resolved to externalHostAddress and
   # mlrun UI's node port


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
0.6.4-rc1 is basically 0.6.3 with only https://github.com/mlrun/mlrun/pull/873 on top so should be safe, and smaller images is good for the kit