### PR TITLE
[mlrun] Fix extra volume template typo

### DIFF
--- a/stable/mlrun/templates/api-deployment.yaml
+++ b/stable/mlrun/templates/api-deployment.yaml
@@ -96,7 +96,7 @@ spec:
           volumeMounts:
             - name: storage
               mountPath: {{ .Values.httpDB.dirPath }}
-            {{- range .Values.extraPersistentVolumeMounts }}
+            {{- range .Values.api.extraPersistentVolumeMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath | default "" }}
@@ -115,7 +115,7 @@ spec:
             secretRef:
               name: {{ .Release.Name }}-v3io-fuse
           {{- end }}
-        {{- range .Values.extraPersistentVolumeMounts }}
+        {{- range .Values.api.extraPersistentVolumeMounts }}
         - name: {{ .name }}
           persistentVolumeClaim:
             claimName: {{ .existingClaim }}


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Fix of typo in https://github.com/v3io/helm-charts/pull/584
Not bumping chart version, simply re-releasing with the fix