### PR TITLE
[v3iod, iguazio-system] Add extra environment support

### DIFF
--- a/stable/iguazio-system/Chart.yaml
+++ b/stable/iguazio-system/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for creating iguazio-system namespace and jobs
 name: iguazio-system
-version: 0.7.0
+version: 0.7.1
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
 sources:

--- a/stable/iguazio-system/templates/flex-volume-daemonset.yaml
+++ b/stable/iguazio-system/templates/flex-volume-daemonset.yaml
@@ -43,6 +43,13 @@ spec:
         - name: v3io-fuse
           image: {{ .Values.job.flexVolume.image.repository }}:{{ .Values.job.flexVolume.image.tag }}
           imagePullPolicy: {{ .Values.job.flexVolume.image.pullPolicy | quote }}
+          env:
+{{- if .Values.job.flexVolume.environment.extra }}
+{{- range $name, $val := .Values.job.flexVolume.environment.extra }}
+            - name: {{ $name }}
+              value: {{ $val | quote }}
+{{- end }}
+{{- end }}
           volumeMounts:
             - mountPath: /flexmnt
               name: flexvolume-mount

--- a/stable/iguazio-system/values.yaml
+++ b/stable/iguazio-system/values.yaml
@@ -22,6 +22,8 @@ job:
       repository: iguaziodocker/flex-fuse
       tag: 2.0.0-0.6.0
       pullPolicy: IfNotPresent
+    environment:
+      extra: {}
     executablePath: /home/iguazio/igz/clients/fuse/bin/v3io_adapters_fuse
     mountType: os
     hostPaths:

--- a/stable/v3iod/Chart.yaml
+++ b/stable/v3iod/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.14.1
+version: 0.14.2
 appVersion: ">=1.9.4"
 name: v3iod
 description: v3io daemon
@@ -8,7 +8,5 @@ icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
 sources:
   - https://github.com/v3io/v3iod
 maintainers:
-  - name: Igor Makhlin
-    email: igorm@iguazio.com
   - name: Eran Duchan
     email: erand@iguazio.com

--- a/stable/v3iod/Chart.yaml
+++ b/stable/v3iod/Chart.yaml
@@ -8,5 +8,7 @@ icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
 sources:
   - https://github.com/v3io/v3iod
 maintainers:
+  - name: Igor Makhlin
+    email: igorm@iguazio.com
   - name: Eran Duchan
     email: erand@iguazio.com

--- a/stable/v3iod/templates/v3iod-daemonset.yaml
+++ b/stable/v3iod/templates/v3iod-daemonset.yaml
@@ -49,6 +49,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+{{- if .Values.v3iod.environment.extra }}
+{{- range $name, $val := .Values.v3iod.environment.extra }}
+            - name: {{ $name }}
+              value: {{ $val | quote }}
+{{- end }}
+{{- end }}
           volumeMounts:
             - mountPath: /dev/shm
               name: v3iod-shm

--- a/stable/v3iod/values.yaml
+++ b/stable/v3iod/values.yaml
@@ -7,6 +7,10 @@ v3iod:
     tag: 2.0.0
     pullPolicy: IfNotPresent
 
+  environment:
+    extra: {}
+
+
   user:
     # create new user when running (new username must not match iguazio and must have UID gt 1000)
     create: false


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
- Add extra env in values for charts - `v3iod` and `iguazio-system` (to the flex-fuse job).
this is meant to effect flex-fuse driver and the v3iod daemon