### PR TITLE
[mpi-operator,pipelines,spark-operator] Align openAPIV3Schema preserve unknown fields to be under root

### DIFF
--- a/stable/mpi-operator/Chart.yaml
+++ b/stable/mpi-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "==0.2.0"
 description: Kubeflow MPI job operator
 name: mpi-operator
-version: 0.4.6
+version: 0.4.7
 home: https://www.kubeflow.org/
 icon: https://github.com/kubeflow/marketing-materials/blob/master/logos/Raster/Kubeflow-Logo-RGB.png
 sources:

--- a/stable/mpi-operator/templates/mpijob-crd.yaml
+++ b/stable/mpi-operator/templates/mpijob-crd.yaml
@@ -21,11 +21,8 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
-        properties:
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
+        x-kubernetes-preserve-unknown-fields: true
+
 {{- end }}
   scope: Namespaced
   names:

--- a/stable/pipelines/Chart.yaml
+++ b/stable/pipelines/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: ">=1.0.1"
-version: 0.7.0
+version: 0.7.1
 name: pipelines
 description: Kubeflow pipelines framework for machine learning
 home: https://www.kubeflow.org/

--- a/stable/pipelines/templates/crd/scheduled-workflow-crd.yaml
+++ b/stable/pipelines/templates/crd/scheduled-workflow-crd.yaml
@@ -23,9 +23,5 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
-        properties:
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
+        x-kubernetes-preserve-unknown-fields: true
 {{- end }}

--- a/stable/pipelines/templates/crd/viewer-crd.yaml
+++ b/stable/pipelines/templates/crd/viewer-crd.yaml
@@ -23,9 +23,5 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
-        properties:
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
+        x-kubernetes-preserve-unknown-fields: true
 {{- end }}

--- a/stable/pipelines/templates/crd/workflow-crd.yaml
+++ b/stable/pipelines/templates/crd/workflow-crd.yaml
@@ -21,11 +21,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
-        properties:
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
+        x-kubernetes-preserve-unknown-fields: true
     additionalPrinterColumns:
     - jsonPath: .status.phase
       description: Status of the workflow
@@ -60,11 +56,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
-        properties:
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
+        x-kubernetes-preserve-unknown-fields: true
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -89,11 +81,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
-        properties:
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
+        x-kubernetes-preserve-unknown-fields: true
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -117,9 +105,5 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
-        properties:
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
+        x-kubernetes-preserve-unknown-fields: true
 {{- end }}

--- a/stable/sparkoperator/Chart.yaml
+++ b/stable/sparkoperator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sparkoperator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.5.1
+version: 1.5.2
 appVersion: v1beta2-1.0.1-2.4.4
 icon: http://spark.apache.org/images/spark-logo-trademark.png
 keywords:

--- a/stable/sparkoperator/templates/crds.yaml
+++ b/stable/sparkoperator/templates/crds.yaml
@@ -2539,11 +2539,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
-        properties:
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
+        x-kubernetes-preserve-unknown-fields: true
 {{- end }}
 status:
   acceptedNames:
@@ -5110,11 +5106,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
-        properties:
-          spec:
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            x-kubernetes-preserve-unknown-fields: true
+        x-kubernetes-preserve-unknown-fields: true
 {{- end }}
 status:
   acceptedNames:


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
[Please add a description of the change request.]
Follow up to https://github.com/v3io/helm-charts/pull/613 which introduced a problem where CRD's fields (of CRDs that are not controlled by us) are not under `spec` and `status` which may cause setting the fields under `spec` and `status` to fail using them. 