### PR TITLE
[v3io-webapi] - fix duplicated tolerations block

### DIFF
--- a/stable/v3io-webapi/Chart.yaml
+++ b/stable/v3io-webapi/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.10.3
+version: 0.10.4
 appVersion: "~1.7.0"
 name: v3io-webapi
 description: v3io WebAPI

--- a/stable/v3io-webapi/values.yaml
+++ b/stable/v3io-webapi/values.yaml
@@ -24,15 +24,6 @@ resources: {}
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
-tolerations:
-  - key: node-role.kubernetes.io/master
-    effect: NoSchedule
-
-    # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
-    # This, along with the annotation above marks this pod as a critical add-on.
-  - key: CriticalAddonsOnly
-    operator: Exists
-
 nodeSelector: {}
 
 ## List of node taints to tolerate (requires Kubernetes >= 1.6)


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
The second empty toleration block took effect anyhow. It was probably an error originally, no need to schedule webapi on master node and on nodes with CriticalAddonsOnly