### PR TITLE
[v3iod] - locator resources bug fix

### DIFF
--- a/stable/v3iod/Chart.yaml
+++ b/stable/v3iod/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.14.5
+version: 0.14.6
 appVersion: ">=1.9.4"
 name: v3iod
 description: v3io daemon

--- a/stable/v3iod/templates/v3io-locator-deployment.yaml
+++ b/stable/v3iod/templates/v3io-locator-deployment.yaml
@@ -36,7 +36,7 @@ spec:
           ports:
             - containerPort: 8080
           resources:
-{{ toYaml .Values.v3iod.resources | indent 12 }}
+{{ toYaml .Values.locator.resources | indent 12 }}
           env:
             - name: CURRENT_NAMESPACE
               valueFrom:


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Was mistakeingly taken from `Values.v3iod`