### PR TITLE
[mlrun] - Fix opa resource definitions

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.6.8
+version: 0.6.9
 appVersion: 0.7.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -157,10 +157,10 @@ api:
       pullSecrets: []
 
     resources:
-     limits:
+     requests:
        cpu: 100m
        memory: 10Mi
-     requests:
+     limits:
        cpu: 3
        memory: 200Mi
 


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
- limits/requests were swapped, this caused failure in bringing up systems because limit < request