### PR TITLE
[tensorboard] - Changes to storage/mounts for better control

### DIFF
--- a/stable/tensorboard/Chart.yaml
+++ b/stable/tensorboard/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 2.6.0
-version: 0.0.1
+version: 0.0.2
 description: A Helm chart creating the tensorboard service, based on tensorflow image
 name: tensorboard
 home: https://iguazio.com

--- a/stable/tensorboard/templates/deployment.yaml
+++ b/stable/tensorboard/templates/deployment.yaml
@@ -23,16 +23,6 @@ spec:
           imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
           command: ["/bin/sh", "-c"]
           args: ["tensorboard --host 0.0.0.0 --logdir {{ .Values.deployment.logDir }}"]
-          ports:
-            - containerPort: 6006
-              name: http
-              protocol: TCP
-          volumeMounts:
-            - name: storage
-              mountPath: {{ .Values.deployment.logDir }}
-{{- if .Values.v3io }}
-              subPath: {{ .Values.deployment.volumeMounts.v3ioSubPath }}
-{{- end }}
           env:
 {{- if .Values.deployment.environment }}
 {{- range $name, $val := .Values.deployment.environment.extra }}
@@ -40,6 +30,13 @@ spec:
               value: {{ $val | quote }}
 {{- end }}
 {{- end }}
+          ports:
+            - containerPort: 6006
+              name: http
+              protocol: TCP
+          volumeMounts:
+            - name: storage
+              mountPath: {{ .Values.deployment.volumeMounts.mountPath }}
       volumes:
         - name: storage
 {{- if .Values.v3io }}
@@ -47,6 +44,9 @@ spec:
             driver: "v3io/fuse"
             secretRef:
               name: {{ .Release.Name }}-v3io-fuse
+            options:
+              dirsToCreate: '[{"name": "{{ .Values.deployment.volumes.v3io.dirToCreate }}", "permissions": 488}]'
+
 {{- else }}
           emptyDir: {}
 {{- end }}

--- a/stable/tensorboard/templates/deployment.yaml
+++ b/stable/tensorboard/templates/deployment.yaml
@@ -20,17 +20,18 @@ spec:
       containers:
         - name: tensorboard
           image: {{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}
-          imagePullPolicy: {{ .Values.deployment.pullPolicy }}
+          imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
           command: ["/bin/sh", "-c"]
+          args: ["tensorboard --host 0.0.0.0 --logdir {{ .Values.deployment.logDir }}"]
           ports:
             - containerPort: 6006
               name: http
               protocol: TCP
           volumeMounts:
             - name: storage
-              mountPath: {{ .Values.deployment.volumeMounts.mountPath }}
+              mountPath: {{ .Values.deployment.logDir }}
 {{- if .Values.v3io }}
-              subPath: "{{ default "users" .Values.global.v3io.homeContainer }}/{{ default "" .Values.global.v3io.homePrefix }}/{{ .Values.v3io.username }}"
+              subPath: {{ .Values.deployment.volumeMounts.v3ioSubPath }}
 {{- end }}
           env:
 {{- if .Values.deployment.environment }}
@@ -39,7 +40,6 @@ spec:
               value: {{ $val | quote }}
 {{- end }}
 {{- end }}
-          args: ["tensorboard --host 0.0.0.0 --logdir {{ .Values.deployment.logDir }}"]
       volumes:
         - name: storage
 {{- if .Values.v3io }}

--- a/stable/tensorboard/templates/deployment.yaml
+++ b/stable/tensorboard/templates/deployment.yaml
@@ -45,8 +45,9 @@ spec:
             secretRef:
               name: {{ .Release.Name }}-v3io-fuse
             options:
-              dirsToCreate: '[{"name": "{{ .Values.deployment.volumes.v3io.dirToCreate }}", "permissions": 488}]'
-
+{{- if .Values.deployment.volumes.v3io.dirToCreate.name }}
+              dirsToCreate: '[{"name": "{{ .Values.deployment.volumes.v3io.dirToCreate.name }}", "permissions": {{ .Values.deployment.volumes.v3io.dirToCreate.name }}}]'
+{{- end }}
 {{- else }}
           emptyDir: {}
 {{- end }}

--- a/stable/tensorboard/templates/v3io-fuse-secret.yaml
+++ b/stable/tensorboard/templates/v3io-fuse-secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-v3io-fuse
   labels:
-    app: {{ template "tensorboard.name.name" . }}
+    app: {{ template "tensorboard.name" . }}
     chart: {{ template "tensorboard.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/stable/tensorboard/values.yaml
+++ b/stable/tensorboard/values.yaml
@@ -10,8 +10,11 @@ deployment:
   environment:
     extra: {}
   volumeMounts:
-    # fill if v3io mount is provided, e.g. "users//<username/.tensorboard"
-    v3ioSubPath: ""
+    mountPath: "/tensorboard"
+  volumes:
+    v3io:
+      dirToCreate: ""
+
 
 # providing v3io.username v3io.accessKey will request a fuseMount for the deployment
 v3io: {}

--- a/stable/tensorboard/values.yaml
+++ b/stable/tensorboard/values.yaml
@@ -13,7 +13,9 @@ deployment:
     mountPath: "/tensorboard"
   volumes:
     v3io:
-      dirToCreate: ""
+      dirToCreate:
+        name: ""
+        permissions: 488
 
 
 # providing v3io.username v3io.accessKey will request a fuseMount for the deployment

--- a/stable/tensorboard/values.yaml
+++ b/stable/tensorboard/values.yaml
@@ -6,11 +6,12 @@ deployment:
     repository: tensorflow/tensorflow
     tag: 2.6.0
     pullPolicy: IfNotPresent
-  logDir: "/User/tensorboard"
+  logDir: "/User/.tensorboard"
   environment:
     extra: {}
   volumeMounts:
-    mountPath: "/User"
+    # fill if v3io mount is provided, e.g. "users//<username/.tensorboard"
+    v3ioSubPath: ""
 
 # providing v3io.username v3io.accessKey will request a fuseMount for the deployment
 v3io: {}

--- a/stable/tensorboard/values.yaml
+++ b/stable/tensorboard/values.yaml
@@ -6,7 +6,7 @@ deployment:
     repository: tensorflow/tensorflow
     tag: 2.6.0
     pullPolicy: IfNotPresent
-  logDir: "/User/.tensorboard"
+  logDir: "/tensorboard"
   environment:
     extra: {}
   volumeMounts:


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Now with only 1 path tensorboard will be mounted on the right mountPath and look at it, logDir needn't be changed at all in iguazio, we can just move `.Values.deployment.volumeMounts.v3ioSubPath` around