### PR TITLE
[mlrun-kit] Make docker registry secret not mandatory + bump mlrun chart version to 0.6.11

### DIFF
--- a/stable/mlrun-kit/Chart.yaml
+++ b/stable/mlrun-kit/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.13
+version: 0.1.14
 name: mlrun-kit
 description: MLRUn Open Source Stack
 home: https://iguazio.com

--- a/stable/mlrun-kit/requirements.lock
+++ b/stable/mlrun-kit/requirements.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 0.9.6
 - name: mlrun
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.6.9
+  version: 0.6.11
 - name: nfs-server-provisioner
   repository: https://charts.helm.sh/stable
   version: 1.1.1
 - name: mpi-operator
   repository: https://v3io.github.io/helm-charts/stable
   version: 0.4.5
-digest: sha256:254fa5bc3f1ebe6e01b024e0eef8d7968241a56df9dd281a086a81da06d591f0
-generated: "2021-09-24T05:19:16.293298+03:00"
+digest: sha256:b507e7a8a5214a6a7071256838710798d1b81dbeb44ee0a09ec36e9394ca5e07
+generated: "2021-11-07T18:47:34.199336+02:00"

--- a/stable/mlrun-kit/requirements.yaml
+++ b/stable/mlrun-kit/requirements.yaml
@@ -3,7 +3,7 @@ dependencies:
   version: "0.9.6"
   repository: "https://nuclio.github.io/nuclio/charts"
 - name: mlrun
-  version: "0.6.9"
+  version: "0.6.11"
   repository: "https://v3io.github.io/helm-charts/stable"
 - name: nfs-server-provisioner
   version: "1.1.1"

--- a/stable/mlrun-kit/values.yaml
+++ b/stable/mlrun-kit/values.yaml
@@ -5,7 +5,7 @@ global:
   externalHostAddress: localhost
   registry:
     url: mustprovide
-    secretName: mustprovide
+    secretName:
   nuclio:
     dashboard:
       nodePort: 30050


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
The registry can be an unsecured registry (used with minikube in mlrun/mlrun open source system tests for example) in which secret is not needed