### PR TITLE
Bumping platform charts post 3.2.0 release

### DIFF
--- a/stable/dcgm-exporter/Chart.yaml
+++ b/stable/dcgm-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dcgm-exporter
 appVersion: "2.3.1"
 description: A Helm chart for DCGM exporter
-version: 0.1.4
+version: 0.2.0
 sources:
 - https://gitlab.com/nvidia/container-toolkit/gpu-monitoring-tools
 home: https://github.com/nvidia/gpu-monitoring-tools/

--- a/stable/dex-crds/Chart.yaml
+++ b/stable/dex-crds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dex-crds
-version: 0.4.2
+version: 0.5.0
 appVersion: 2.30.0
 icon: https://di5r923elu32w2e633ofbxj9-wpengine.netdna-ssl.com/wp-content/uploads/2019/10/Iguazio-Logo.png
 description: A Helm chart for deploying Dex's CRDs

--- a/stable/grafana/Chart.yaml
+++ b/stable/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: grafana
-version: 4.8.0
+version: 4.9.0
 appVersion: 6.5.2
 kubeVersion: "^1.8.0-0"
 description: The leading tool for querying and visualizing time series and metrics.
@@ -9,11 +9,5 @@ icon: https://raw.githubusercontent.com/grafana/grafana/master/public/img/logo_t
 sources:
   - https://github.com/grafana/grafana
 maintainers:
-  - name: zanhsieh
-    email: zanhsieh@gmail.com
-  - name: rtluckie
-    email: rluckie@cisco.com
-  - name: maorfr
-    email: maor.friedman@redhat.com
-engine: gotpl
-tillerVersion: ">=2.12.0"
+  - name: hedingber
+    email: hedii@iguazio.com

--- a/stable/label-studio/Chart.yaml
+++ b/stable/label-studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.9.0
 description: A swiss army knife of data labeling and annotation tools
 name: label-studio
-version: 0.1.4
+version: 0.2.0
 home: https://labelstud.io/
 icon: https://labelstud.io/images/ls_logo.png
 sources:

--- a/stable/metrics-server-exporter/Chart.yaml
+++ b/stable/metrics-server-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: ">=2.0.0"
-version: 0.5.2
+version: 0.6.0
 description: K8s metrics exporter in prometheus format
 name: metrics-server-exporter
 home: https://iguazio.com

--- a/stable/mpi-operator/Chart.yaml
+++ b/stable/mpi-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "==0.2.0"
 description: Kubeflow MPI job operator
 name: mpi-operator
-version: 0.4.8
+version: 0.5.0
 home: https://www.kubeflow.org/
 icon: https://github.com/kubeflow/marketing-materials/blob/master/logos/Raster/Kubeflow-Logo-RGB.png
 sources:

--- a/stable/node-feature-discovery/Chart.yaml
+++ b/stable/node-feature-discovery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.5.0"
 description: A Helm chart for Kubernetes
 name: node-feature-discovery
-version: 0.4.1
+version: 0.5.0
 maintainers:
   - name: Vladimir Syromyatnikov
     email: vladimirs@iguazio.com

--- a/stable/pipelines/Chart.yaml
+++ b/stable/pipelines/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: ">=1.0.1"
-version: 0.7.2
+version: 0.8.0
 name: pipelines
 description: Kubeflow pipelines framework for machine learning
 home: https://www.kubeflow.org/

--- a/stable/provazio/Chart.yaml
+++ b/stable/provazio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Iguazio provisioner
 name: provazio
-version: 0.8.3
+version: 0.9.0
 appVersion: 0.22.140
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://iguazio.com

--- a/stable/scaler/Chart.yaml
+++ b/stable/scaler/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 0.4.0
-version: 0.8.2
+version: 0.9.0
 description: A Helm chart creating a scaler and dlx for iguazio app-services
 name: scaler
 home: https://iguazio.com

--- a/stable/tenant-creator/Chart.yaml
+++ b/stable/tenant-creator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for creating tenant creator
 name: tenant-creator
-version: 0.4.0
+version: 0.5.0
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
 sources:

--- a/stable/tenant/Chart.yaml
+++ b/stable/tenant/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for creating tenant
 name: tenant
-version: 0.5.0
+version: 0.6.0
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
 sources:

--- a/stable/tensorboard/Chart.yaml
+++ b/stable/tensorboard/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: 2.6.0
-version: 0.0.4
+version: 0.1.0
 description: A Helm chart creating the tensorboard service, based on tensorflow image
 name: tensorboard
 home: https://iguazio.com


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped~
- [ ] ~Title of the PR starts with chart name (e.g. `[mychartname]`)~

### Description:
Bumping versions for charts:
- stable/dcgm-exporter
- stable/dex-crds
- stable/grafana
- stable/label-studio
- stable/metrics-server-exporter
- stable/mpi-operator
- stable/node-feature-discovery
- stable/pipelines
- stable/provazio
- stable/scaler
- stable/tenant-creator
- stable/tenant
- stable/tensorboard