### PR TITLE
[mlrun] MySQL - set adaptive hash indexing partitions to 128

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.6.12
+version: 0.6.13
 appVersion: 0.7.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/db-configmap.yaml
+++ b/stable/mlrun/templates/db-configmap.yaml
@@ -52,5 +52,5 @@ data:
 
     echo "Starting MySQL ..."
     # Note, "--user=root" flag allows running server as user root (default user)
-    mysqld --user=root --sql_mode="" --socket=$MYSQL_SOCKET_FILE
+    mysqld --user=root --sql_mode="" --innodb-adaptive-hash-index-parts=128 --socket=$MYSQL_SOCKET_FILE
 {{- end }}


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Explanation for the fix in the Bug RCA - https://jira.iguazeng.com/browse/ML-1513?focusedCommentId=85547&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-85547 