### PR TITLE
[mlrun] MySQL - set adaptive hash indexing partitions to 128 [Backport integ 3.2]

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.6.11
+version: 0.6.13
 appVersion: 0.7.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/db-configmap.yaml
+++ b/stable/mlrun/templates/db-configmap.yaml
@@ -52,5 +52,5 @@ data:
 
     echo "Starting MySQL ..."
     # Note, "--user=root" flag allows running server as user root (default user)
-    mysqld --user=root --sql_mode="" --socket=$MYSQL_SOCKET_FILE
+    mysqld --user=root --sql_mode="" --innodb-adaptive-hash-index-parts=128 --socket=$MYSQL_SOCKET_FILE
 {{- end }}


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
backport for https://github.com/v3io/helm-charts/pull/665 