### PR TITLE
[mlrun] Disable the adaptive hash index and increase parallelism in MySQL [Backport integ_3.2]

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.6.14
+version: 0.6.15
 appVersion: 0.7.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/db-configmap.yaml
+++ b/stable/mlrun/templates/db-configmap.yaml
@@ -55,7 +55,10 @@ data:
     mysqld \
       --user=root \
       --sql_mode="" \
-      --innodb-adaptive-hash-index-parts=128 \
+      --innodb-adaptive-hash-index=0 \
+      --innodb-read-io-threads=32 \
+      --innodb-write-io-threads=32 \
+      --innodb-purge-threads=16 \
       --innodb-buffer-pool-size=1073741824 \
       --innodb-buffer-pool-instances=8 \
       --innodb-page-cleaners=4 \


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Backport of https://github.com/v3io/helm-charts/pull/674