### PR TITLE
[hive][mariadb] IG-19906 - Fix resources templating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CHART_NAME := $(if $(CHART_NAME),$(CHART_NAME),chart-name)
 CHART_VERSION_OVERRIDE := $(if $(CHART_VERSION_OVERRIDE),$(CHART_VERSION_OVERRIDE),none)
 
 
-#### Some exmamples:
+#### Some examples:
 # make print-versions
 # make helm-publish - release all changes from development
 # GITHUB_BRANCH_OVERRIDE=integ_2.8 make helm-publish - release all changes from integ_2.8

--- a/stable/hive/Chart.yaml
+++ b/stable/hive/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: Hive metastore service
 name: hive
-version: 0.6.0
+version: 0.6.1
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
 sources:

--- a/stable/hive/templates/hive-deployment.yaml
+++ b/stable/hive/templates/hive-deployment.yaml
@@ -45,7 +45,7 @@ spec:
           image: "{{ .Values.createHiveUserMariaDbImage.repository }}:{{ .Values.createHiveUserMariaDbImage.tag }}"
           imagePullPolicy: {{ .Values.createHiveUserMariaDbImage.pullPolicy }}
           resources:
-  {{ toYaml .Values.resources | indent 10 }}
+            {{- toYaml .Values.resources | nindent 12 }}
           env:
             - name: HIVE_METASTORE_ADMIN_PASSWORD
               valueFrom:
@@ -70,7 +70,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
-        {{ toYaml .Values.resources | indent 10 }}
+            {{- toYaml .Values.resources | nindent 12 }}
           env:
             - name: HIVE_DB_TYPE
               value: {{ .Values.metastore.database.type }}
@@ -161,18 +161,18 @@ spec:
 {{ include .Values.volumes.volumeMountsTemplate . | indent 12 }}
 {{- end }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}

--- a/stable/index.yaml
+++ b/stable/index.yaml
@@ -1,24 +1,3 @@
 apiVersion: v1
-entries:
-  mariadb:
-  - apiVersion: v1
-    appVersion: '>=2.0.0'
-    created: "2021-12-23T01:38:11.779831+02:00"
-    dependencies:
-    - name: v3io-configs
-      repository: https://v3io.github.io/helm-charts/stable
-      version: 0.9.0
-    description: MariaDB (MySQL) service
-    digest: ee1163cd588baa81693389cf1e5074971b1851cc79e3a9ecdd79bec76415eba2
-    home: https://iguazio.com
-    icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
-    maintainers:
-    - email: igorm@iguazio.com
-      name: imakhlin
-    name: mariadb
-    sources:
-    - https://github.com/iguazio/kubeops/
-    urls:
-    - https://v3io.github.io/helm-charts/stable/mariadb-0.6.0.tgz
-    version: 0.6.0
-generated: "2021-12-23T01:38:11.778571+02:00"
+entries: ~
+generated: 2018-01-30T17:09:13.202782+02:00

--- a/stable/index.yaml
+++ b/stable/index.yaml
@@ -1,3 +1,24 @@
 apiVersion: v1
-entries: ~
-generated: 2018-01-30T17:09:13.202782+02:00
+entries:
+  mariadb:
+  - apiVersion: v1
+    appVersion: '>=2.0.0'
+    created: "2021-12-23T01:38:11.779831+02:00"
+    dependencies:
+    - name: v3io-configs
+      repository: https://v3io.github.io/helm-charts/stable
+      version: 0.9.0
+    description: MariaDB (MySQL) service
+    digest: ee1163cd588baa81693389cf1e5074971b1851cc79e3a9ecdd79bec76415eba2
+    home: https://iguazio.com
+    icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
+    maintainers:
+    - email: igorm@iguazio.com
+      name: imakhlin
+    name: mariadb
+    sources:
+    - https://github.com/iguazio/kubeops/
+    urls:
+    - https://v3io.github.io/helm-charts/stable/mariadb-0.6.0.tgz
+    version: 0.6.0
+generated: "2021-12-23T01:38:11.778571+02:00"

--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: MariaDB (MySQL) service
 name: mariadb
-version: 0.6.0
+version: 0.6.1
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
 sources:

--- a/stable/mariadb/templates/mariadb-deployment.yaml
+++ b/stable/mariadb/templates/mariadb-deployment.yaml
@@ -42,7 +42,7 @@ spec:
           image: "{{ .Values.initializationImage.repository }}:{{ .Values.initializationImage.tag }}"
           imagePullPolicy: {{ .Values.initializationImage.pullPolicy }}
           resources:
-  {{ toYaml .Values.resources | indent 10 }}
+{{ toYaml .Values.resources | indent 12 }}
           env:
             - name: MYSQL_ROOT_PASSWORD
               valueFrom:

--- a/stable/mariadb/templates/mariadb-deployment.yaml
+++ b/stable/mariadb/templates/mariadb-deployment.yaml
@@ -42,7 +42,7 @@ spec:
           image: "{{ .Values.initializationImage.repository }}:{{ .Values.initializationImage.tag }}"
           imagePullPolicy: {{ .Values.initializationImage.pullPolicy }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}
           env:
             - name: MYSQL_ROOT_PASSWORD
               valueFrom:
@@ -115,18 +115,18 @@ spec:
             - name: {{ .Release.Name }}-init-scripts
               mountPath: {{ .Values.configMountPath }}/init-scripts
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Creating the charts flat-out failed with json-yaml issues, which resulted from wrongly formatted `resources` blocks.
e.g.
```
Error: YAML parse error on hive/templates/hive-deployment.yaml: error converting YAML to JSON: yaml: line 83: did not find expected key
helm.go:84: [debug] error converting YAML to JSON: yaml: line 83: did not find expected key
YAML parse error on hive/templates/hive-deployment.yaml
helm.sh/helm/v3/pkg/releaseutil.(*manifestFile).sort
	/home/circleci/helm.sh/helm/pkg/releaseutil/manifest_sorter.go:146
helm.sh/helm/v3/pkg/releaseutil.SortManifests
	/home/circleci/helm.sh/helm/pkg/releaseutil/manifest_sorter.go:106
helm.sh/helm/v3/pkg/action.(*Configuration).renderResources
	/home/circleci/helm.sh/helm/pkg/action/action.go:159
helm.sh/helm/v3/pkg/action.(*Install).Run
	/home/circleci/helm.sh/helm/pkg/action/install.go:238
main.runInstall
	/home/circleci/helm.sh/helm/cmd/helm/install.go:229
main.newTemplateCmd.func1
	/home/circleci/helm.sh/helm/cmd/helm/template.go:66
github.com/spf13/cobra.(*Command).execute
	/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:842
github.com/spf13/cobra.(*Command).ExecuteC
	/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950
github.com/spf13/cobra.(*Command).Execute
	/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
main.main
	/home/circleci/helm.sh/helm/cmd/helm/helm.go:83
runtime.main
	/usr/local/go/src/runtime/proc.go:203
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1357
```