### PR TITLE
[hive][mariadb] IG-19906 - Fix resources templating [integ_3.2]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CHART_NAME := $(if $(CHART_NAME),$(CHART_NAME),chart-name)
 CHART_VERSION_OVERRIDE := $(if $(CHART_VERSION_OVERRIDE),$(CHART_VERSION_OVERRIDE),none)
 
 
-#### Some exmamples:
+#### Some examples:
 # make print-versions
 # make helm-publish - release all changes from development
 # GITHUB_BRANCH_OVERRIDE=integ_2.8 make helm-publish - release all changes from integ_2.8

--- a/stable/hive/Chart.yaml
+++ b/stable/hive/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: Hive metastore service
 name: hive
-version: 0.5.1
+version: 0.5.2
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
 sources:

--- a/stable/hive/templates/hive-deployment.yaml
+++ b/stable/hive/templates/hive-deployment.yaml
@@ -45,7 +45,7 @@ spec:
           image: "{{ .Values.createHiveUserMariaDbImage.repository }}:{{ .Values.createHiveUserMariaDbImage.tag }}"
           imagePullPolicy: {{ .Values.createHiveUserMariaDbImage.pullPolicy }}
           resources:
-  {{ toYaml .Values.resources | indent 10 }}
+            {{- toYaml .Values.resources | nindent 12 }}
           env:
             - name: HIVE_METASTORE_ADMIN_PASSWORD
               valueFrom:
@@ -70,7 +70,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
-        {{ toYaml .Values.resources | indent 10 }}
+            {{- toYaml .Values.resources | nindent 12 }}
           env:
             - name: HIVE_DB_TYPE
               value: {{ .Values.metastore.database.type }}
@@ -161,18 +161,18 @@ spec:
 {{ include .Values.volumes.volumeMountsTemplate . | indent 12 }}
 {{- end }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}

--- a/stable/mariadb/Chart.yaml
+++ b/stable/mariadb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: MariaDB (MySQL) service
 name: mariadb
-version: 0.5.1
+version: 0.5.2
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
 sources:

--- a/stable/mariadb/templates/mariadb-deployment.yaml
+++ b/stable/mariadb/templates/mariadb-deployment.yaml
@@ -42,7 +42,7 @@ spec:
           image: "{{ .Values.initializationImage.repository }}:{{ .Values.initializationImage.tag }}"
           imagePullPolicy: {{ .Values.initializationImage.pullPolicy }}
           resources:
-  {{ toYaml .Values.resources | indent 10 }}
+            {{- toYaml .Values.resources | nindent 12 }}
           env:
             - name: MYSQL_ROOT_PASSWORD
               valueFrom:
@@ -115,18 +115,18 @@ spec:
             - name: {{ .Release.Name }}-init-scripts
               mountPath: {{ .Values.configMountPath }}/init-scripts
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Backporting https://github.com/v3io/helm-charts/pull/685 fixes to `integ_3.2` for 3.2.1 oriented charts