### PR TITLE
[v3iod] - Tolerate AKS Spot nodes taint - IG-19970

### DIFF
--- a/stable/v3iod/Chart.yaml
+++ b/stable/v3iod/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.15.1
+version: 0.15.2
 appVersion: ">=1.9.4"
 name: v3iod
 description: v3io daemon

--- a/stable/v3iod/values.yaml
+++ b/stable/v3iod/values.yaml
@@ -48,6 +48,12 @@ v3iod:
     operator: Equal
     value: present
 
+  # Allow this pod to be scheduled on AKS spot nodes (AKS taints spot nodes with kubernetes.azure.com/scalesetpriority=spot:NoSchedule)
+  - key: kubernetes.azure.com/scalesetpriority
+    effect: NoSchedule
+    operator: Equal
+    value: spot
+
   ## Affinity
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
We want v3iod to tolerate, by default, the taint that AKS puts on all spot nodes.
See for more info: https://docs.microsoft.com/en-us/azure/aks/spot-node-pool
See also Iguazio JIRA issue (only available in Iguazio network): https://jira.iguazeng.com/browse/IG-19970