### PR TITLE
[mlrun] Support MySQL 8.0

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.6.17
+version: 0.6.18
 appVersion: 0.7.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mlrun
-version: 0.6.18
-appVersion: 0.7.0
+version: 0.7.0
+appVersion: 0.10.0
 description: Machine Learning automation and tracking
 sources:
   - https://github.com/mlrun/mlrun

--- a/stable/mlrun/templates/db-configmap-init.yaml
+++ b/stable/mlrun/templates/db-configmap-init.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   enable-root-remote-access.sql: |
     -- Allow passwordless (insecure) access to root user from anywhere
-    UPDATE mysql.user SET host='%' WHERE user='root';
+    CREATE USER IF NOT EXISTS 'root'@'%';
     GRANT ALL PRIVILEGES ON *.* TO 'root'@'%';
     FLUSH PRIVILEGES;
     CREATE DATABASE IF NOT EXISTS mlrun;

--- a/stable/mlrun/templates/db-configmap.yaml
+++ b/stable/mlrun/templates/db-configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
 
   health_check.sh: |
-    mysql -h 127.0.0.1 -e 'SELECT 1'
+    mysql -S /var/run/mysqld/mysql.sock -e 'SELECT 1'
 
   init-v3io-mysql.sh: |
     #!/usr/bin/env bash
@@ -36,25 +36,14 @@ data:
     echo "Current user -> $(whoami)"
 
     MYSQL_SOCKET_FILE=/var/run/mysqld/mysql.sock
-    LOCK_FILE=/var/lib/mysql/.allow-remote-access-complete
-    if [ ! -f $LOCK_FILE ]
-    then
-      MYSQL_CONFIG=/etc/my.cnf
-      INIT_SCRIPT="/etc/config/mysql/init-scripts/enable-root-remote-access.sql"
-
-      # Call init script on startup
-      echo "Adding $INIT_SCRIPT to $MYSQL_CONFIG ..."
-      echo "" >> $MYSQL_CONFIG
-      echo "init-file=$INIT_SCRIPT" >> $MYSQL_CONFIG
-
-      touch $LOCK_FILE
-    fi
+    INIT_SCRIPT="/etc/config/mysql/init-scripts/enable-root-remote-access.sql"
 
     echo "Starting MySQL ..."
     # Note, "--user=root" flag allows running server as user root (default user)
     mysqld \
       --user=root \
       --sql_mode="" \
+      --init-file=$INIT_SCRIPT \
       --innodb-adaptive-hash-index=0 \
       --innodb-read-io-threads=32 \
       --innodb-write-io-threads=32 \

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -197,7 +197,7 @@ db:
 
   image:
     repository: mysql
-    tag: 5.7
+    tag: 8.0
     pullPolicy: IfNotPresent
     pullSecrets: []
 


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Also bumping the minor version for the mlrun helm chart, 0.6.x is for iguazio 3.2, we're now on 3.4, so bumping to 0.7.x