### PR TITLE
[mlrun] MySQL Graceful Shutdown

### DIFF
--- a/stable/index.yaml
+++ b/stable/index.yaml
@@ -1,3 +1,23 @@
 apiVersion: v1
-entries: ~
-generated: 2018-01-30T17:09:13.202782+02:00
+entries:
+  mlrun:
+  - apiVersion: v1
+    appVersion: 0.10.0
+    created: "2022-01-19T10:38:37.951996+02:00"
+    dependencies:
+    - name: v3io-configs
+      repository: https://v3io.github.io/helm-charts/stable
+      version: 0.9.0
+    description: Machine Learning automation and tracking
+    digest: 71c5e242ee4327d378ce977d4c49e8b1387ff2cb61871a13024c040ec6f3b5e4
+    icon: https://di5r923elu32w2e633ofbxj9-wpengine.netdna-ssl.com/wp-content/uploads/2019/10/Iguazio-Logo.png
+    maintainers:
+    - email: hedii@iguazio.com
+      name: hedingber
+    name: mlrun
+    sources:
+    - https://github.com/mlrun/mlrun
+    urls:
+    - https://v3io.github.io/helm-charts/stable/mlrun-0.6.17.tgz
+    version: 0.6.17
+generated: "2022-01-19T10:38:37.949652+02:00"

--- a/stable/index.yaml
+++ b/stable/index.yaml
@@ -1,23 +1,3 @@
 apiVersion: v1
-entries:
-  mlrun:
-  - apiVersion: v1
-    appVersion: 0.10.0
-    created: "2022-01-19T10:38:37.951996+02:00"
-    dependencies:
-    - name: v3io-configs
-      repository: https://v3io.github.io/helm-charts/stable
-      version: 0.9.0
-    description: Machine Learning automation and tracking
-    digest: 71c5e242ee4327d378ce977d4c49e8b1387ff2cb61871a13024c040ec6f3b5e4
-    icon: https://di5r923elu32w2e633ofbxj9-wpengine.netdna-ssl.com/wp-content/uploads/2019/10/Iguazio-Logo.png
-    maintainers:
-    - email: hedii@iguazio.com
-      name: hedingber
-    name: mlrun
-    sources:
-    - https://github.com/mlrun/mlrun
-    urls:
-    - https://v3io.github.io/helm-charts/stable/mlrun-0.6.17.tgz
-    version: 0.6.17
-generated: "2022-01-19T10:38:37.949652+02:00"
+entries: ~
+generated: 2018-01-30T17:09:13.202782+02:00

--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.7.0
+version: 0.7.1
 appVersion: 0.10.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/db-configmap.yaml
+++ b/stable/mlrun/templates/db-configmap.yaml
@@ -10,6 +10,10 @@ data:
   health_check.sh: |
     mysql -S /var/run/mysqld/mysql.sock -e 'SELECT 1'
 
+  graceful_shutdown.sh: |
+    mysql -S /var/run/mysqld/mysql.sock -e 'SET GLOBAL innodb_fast_shutdown = 0; FLUSH TABLES WITH READ LOCK;'
+    mysqladmin -S /var/run/mysqld/mysql.sock shutdown
+
   init-v3io-mysql.sh: |
     #!/usr/bin/env bash
     set -e

--- a/stable/mlrun/templates/db-deployment.yaml
+++ b/stable/mlrun/templates/db-deployment.yaml
@@ -21,6 +21,7 @@ spec:
     {{- end }}
       securityContext:
         {{- toYaml .Values.db.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: 120
       initContainers:
         - name: init-mysql
           image: "{{ .Values.db.image.repository }}:{{ .Values.db.image.tag }}"
@@ -49,6 +50,10 @@ spec:
           - name: mysql
             containerPort: 3306
             protocol: TCP
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/bash", "/etc/config/mysql/graceful_shutdown.sh"]
           {{- if .Values.db.livenessProbe }}
           livenessProbe:
             {{ toYaml .Values.db.livenessProbe | nindent 12 }}


### PR DESCRIPTION
Before killing the MySQL DB container:
- Set the `innodb_fast_shutdown` to 0 (according to mysql documentation regarding major release upgrades - https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html#sysvar_innodb_fast_shutdown)
- Flush all tables with read lock, to ensure no data is in the DB's cache before shutdown (This action can be fast or slow depending on the amount of data in the cache, which is why we might need the `terminationGracePeriodSeconds: 120` in the deployment).
- Use the `mysqladmin` command to properly shutdown the DB.

### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
[Please add a description of the change request.]