### PR TITLE
[Jupyter] [Shell] IG-9854: Suppress Slf4jLogger startup log

### DIFF
--- a/stable/jupyter/Chart.yaml
+++ b/stable/jupyter/Chart.yaml
@@ -1,4 +1,4 @@
-version: 0.12.1
+version: 0.12.2
 apiVersion: v1
 appVersion: ">=2.0.0"
 name: jupyter

--- a/stable/jupyter/templates/jupyter-configmap.yaml
+++ b/stable/jupyter/templates/jupyter-configmap.yaml
@@ -132,7 +132,8 @@ data:
 
     # IG-9854
     if [ "$(grep --count Slf4jLogger /hadoop/etc/hadoop/log4j.properties)" == "0" ]; then
-        echo "\nlog4j.logger.vendor.akka.event.slf_4j.Slf4jLogger=WARN" >> /hadoop/etc/hadoop/log4j.properties
+        echo >> /hadoop/etc/hadoop/log4j.properties
+        echo log4j.logger.vendor.akka.event.slf_4j.Slf4jLogger=WARN >> /hadoop/etc/hadoop/log4j.properties
     fi
 
 {{- if .Values.spark }}

--- a/stable/jupyter/templates/jupyter-configmap.yaml
+++ b/stable/jupyter/templates/jupyter-configmap.yaml
@@ -130,6 +130,11 @@ data:
     export JUPYTER_DATA_DIR=${HOME}/.local/share/jupyter/{{ template "jupyter.fullname" . }}
     mkdir -p "${JUPYTER_DATA_DIR}"
 
+    # IG-9854
+    if [ "$(grep --count Slf4jLogger /hadoop/etc/hadoop/log4j.properties)" == "0" ]; then
+        echo "\nlog4j.logger.vendor.akka.event.slf_4j.Slf4jLogger=WARN" >> /hadoop/etc/hadoop/log4j.properties
+    fi
+
 {{- if .Values.spark }}
     echo "spark.master=spark://{{ .Values.spark.hostname }}:{{ .Values.spark.port }}" >> ${SPARK_HOME}/conf/spark-defaults.conf
     echo spark.driver.host=$(hostname -i) >> ${SPARK_HOME}/conf/spark-defaults.conf

--- a/stable/shell/Chart.yaml
+++ b/stable/shell/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: Shell access to data services
 name: shell
-version: 0.14.1
+version: 0.14.2
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
 sources:

--- a/stable/shell/templates/shell-configmap.yaml
+++ b/stable/shell/templates/shell-configmap.yaml
@@ -58,6 +58,11 @@ data:
     fi
 {{- end }}
 
+    # IG-9854
+    if [ "$(grep --count Slf4jLogger /hadoop/etc/hadoop/log4j.properties)" == "0" ]; then
+        echo "\nlog4j.logger.vendor.akka.event.slf_4j.Slf4jLogger=WARN" >> /hadoop/etc/hadoop/log4j.properties
+    fi
+
     # Create /tmp in default container if not exists and set premissions to 777 (See: IG-11583)
     hadoop fs -test -e {{ .Values.hive.scratchDirPrefix }} || hadoop fs -mkdir {{ .Values.hive.scratchDirPrefix }}
     hadoop fs -chmod 777 {{ .Values.hive.scratchDirPrefix }}

--- a/stable/shell/templates/shell-configmap.yaml
+++ b/stable/shell/templates/shell-configmap.yaml
@@ -60,7 +60,8 @@ data:
 
     # IG-9854
     if [ "$(grep --count Slf4jLogger /hadoop/etc/hadoop/log4j.properties)" == "0" ]; then
-        echo "\nlog4j.logger.vendor.akka.event.slf_4j.Slf4jLogger=WARN" >> /hadoop/etc/hadoop/log4j.properties
+        echo >> /hadoop/etc/hadoop/log4j.properties
+        echo log4j.logger.vendor.akka.event.slf_4j.Slf4jLogger=WARN >> /hadoop/etc/hadoop/log4j.properties
     fi
 
     # Create /tmp in default container if not exists and set premissions to 777 (See: IG-11583)


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Suppresses Slf4jLogger startup log:
```
$ hadoop fs -ls
2022-01-27 12:48:05,626 INFO slf_4j.Slf4jLogger: Slf4jLogger started
Found 3 items
...
```
=>
```
$ hadoop fs -ls
Found 3 items
...
```