### PR TITLE
[mlrun-kit] Change nuclio chart version to 0.11.2

### DIFF
--- a/stable/mlrun-kit/Chart.yaml
+++ b/stable/mlrun-kit/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.16
+version: 0.1.17
 name: mlrun-kit
 description: MLRUn Open Source Stack
 home: https://iguazio.com

--- a/stable/mlrun-kit/requirements.lock
+++ b/stable/mlrun-kit/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: nuclio
   repository: https://nuclio.github.io/nuclio/charts
-  version: 0.11.3
+  version: 0.11.2
 - name: mlrun
   repository: https://v3io.github.io/helm-charts/stable
   version: 0.7.3
@@ -11,5 +11,5 @@ dependencies:
 - name: mpi-operator
   repository: https://v3io.github.io/helm-charts/stable
   version: 0.4.5
-digest: sha256:dcc4beea6cd6d6333194ad72e2e1266413fe92b7a28af90bf092b3621695e644
-generated: "2022-02-01T10:39:01.643681+02:00"
+digest: sha256:bf65e5e372be792e52b097ca759209ccdb250d36e0f7801a4fda38e7b2316764
+generated: "2022-02-11T01:47:17.520412+02:00"

--- a/stable/mlrun-kit/requirements.yaml
+++ b/stable/mlrun-kit/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: nuclio
-  version: "0.11.3"
+  version: "0.11.2"
   repository: "https://nuclio.github.io/nuclio/charts"
 - name: mlrun
   version: "0.7.3"


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
In 0.11.3 [the change](https://github.com/nuclio/nuclio/pull/2428) to support k8s 1.21 and specifically [this change](https://github.com/nuclio/nuclio/pull/2428/files#diff-801289e698018f0ddfa8eedb9c6713314ec41bd5bc0be2a4543ceaa2b2130e91R38) broke the compatibility with k8s 1.18
we're using 1.7.4 Nuclio in order to keep support for 1.18, and 0.11.2 is the right chart version for it