### PR TITLE
[mlrun] Remove OPA default resources, enable to configure priority class name to db pod and default to api values [Backport integ_3.2]

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.6.22
+version: 0.6.23
 appVersion: 0.7.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/db-deployment.yaml
+++ b/stable/mlrun/templates/db-deployment.yaml
@@ -150,4 +150,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .Values.api.priorityClassName }}
+      priorityClassName: {{ .Values.api.priorityClassName | quote }}
+    {{- end }}
 {{- end }}

--- a/stable/mlrun/templates/db-deployment.yaml
+++ b/stable/mlrun/templates/db-deployment.yaml
@@ -130,9 +130,12 @@ spec:
               subPath: /{{ .Values.v3io.username }}/.mlrun/mysql
             secretRef:
               name: {{ .Release.Name }}-v3io-fuse
-      {{- with .Values.db.nodeSelector }}
+      {{- if .Values.db.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.db.nodeSelector | nindent 8 }}
+      {{- else if .Values.api.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.api.nodeSelector | nindent 8 }}
       {{- end }}
     {{- with .Values.db.affinity }}
       affinity:
@@ -150,7 +153,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if .Values.api.priorityClassName }}
+    {{- if .Values.db.priorityClassName }}
+      priorityClassName: {{ .Values.db.priorityClassName | quote }}
+    {{- else if .Values.api.priorityClassName }}
       priorityClassName: {{ .Values.api.priorityClassName | quote }}
     {{- end }}
 {{- end }}

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -234,6 +234,8 @@ db:
   ##
   affinity: {}
 
+  priorityClassName: ""
+
   podSecurityContext: {}
   # fsGroup: 2000
 

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -157,12 +157,12 @@ api:
       pullSecrets: []
 
     resources:
-     requests:
-       cpu: 100m
-       memory: 10Mi
-     limits:
-       cpu: 3
-       memory: 200Mi
+#     requests:
+#       cpu: 100m
+#       memory: 10Mi
+#     limits:
+#       cpu: 3
+#       memory: 200Mi
 
     securityContext: {}
       # capabilities:


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Kind of backport of https://github.com/v3io/helm-charts/pull/707
* Removing OPA container default resources
* Allowing to set priority class name for DB, BUT, if it's not set, using what set on the API (if set) to prevent us from having to patch the helm runner component on systems where it doesn't yet patch the DB values
* Changing the node selector to be taken from API (if exists) if DB value does not exist for the same reasons

Part of https://jira.iguazeng.com/browse/ML-1803