### PR TITLE
[iguazio-system] pre-pull flex-fuse image

### DIFF
--- a/stable/iguazio-system/Chart.yaml
+++ b/stable/iguazio-system/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for creating iguazio-system namespace and jobs
 name: iguazio-system
-version: 0.8.1
+version: 0.8.2
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
 sources:

--- a/stable/iguazio-system/templates/flex-volume-daemonset.yaml
+++ b/stable/iguazio-system/templates/flex-volume-daemonset.yaml
@@ -45,6 +45,16 @@ spec:
         runAsUser: 0
         fsGroup: 0
       containers:
+
+        # holds the image for us
+        - name: v3io-fuse-img-holder
+          image: {{ .Values.job.flexVolume.v3ioFuse.image.repository }}:{{ .Values.job.flexVolume.v3ioFuse.image.tag }}
+          imagePullPolicy: {{ .Values.job.flexVolume.image.pullPolicy | quote }}
+          command:
+          - /bin/sh
+          args:
+          - -c
+          - while true; do sleep 3600; done
         - name: v3io-fuse
           image: {{ .Values.job.flexVolume.image.repository }}:{{ .Values.job.flexVolume.image.tag }}
           imagePullPolicy: {{ .Values.job.flexVolume.image.pullPolicy | quote }}


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
On some deployments we want the flex-fuse image to be pre-pulled on each node to allow fuse to spin pods faster / avoid providing authentication to flex volume > kubelet > flex fuse and so on.