### PR TITLE
[v3iod] IG-19791: move v3iod away from /dev/shm to avoid systemd's RemoveIPC

### DIFF
--- a/stable/v3io-configs/Chart.yaml
+++ b/stable/v3io-configs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: V3IO configuration templates
 name: v3io-configs
-version: 0.11.0
+version: 0.11.1
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
 sources:
   - https://github.com/iguazio/kubeops/

--- a/stable/v3io-configs/templates/_mounts.tpl
+++ b/stable/v3io-configs/templates/_mounts.tpl
@@ -1,7 +1,7 @@
 {{- define "v3io-configs.deployment.mount" -}}
 - name: shm
   hostPath:
-    path: "/dev/shm/{{ .Release.Namespace }}"
+    path: "/var/run/iguazio/dayman-shm/{{ .Release.Namespace }}"
 - name: v3iod-comm
   hostPath:
     path: "/var/run/iguazio/dayman/{{ .Release.Namespace }}"
@@ -15,7 +15,7 @@
 
 {{- define "v3io-configs.deployment.volumeMounts" -}}
 - name: shm
-  mountPath: "/dev/shm"
+  mountPath: "/var/run/iguazio/dayman-shm"
 - name: v3iod-comm
   mountPath: "/var/run/iguazio/dayman"
 - name: v3io-config

--- a/stable/v3iod/Chart.yaml
+++ b/stable/v3iod/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.15.2
+version: 0.15.3
 appVersion: ">=1.9.4"
 name: v3iod
 description: v3io daemon

--- a/stable/v3iod/templates/v3iod-client-daemonset.yaml
+++ b/stable/v3iod/templates/v3iod-client-daemonset.yaml
@@ -45,7 +45,7 @@ spec:
       volumes:
         - name: v3iod-shm
           hostPath:
-            path: /dev/shm
+            path: /var/run/iguazio/dayman-shm
         - name: v3iod-comm
           hostPath:
             path: /var/run/iguazio/dayman/{{ .Release.Namespace }}

--- a/stable/v3iod/templates/v3iod-daemonset.yaml
+++ b/stable/v3iod/templates/v3iod-daemonset.yaml
@@ -92,7 +92,7 @@ spec:
       volumes:
         - name: v3iod-shm
           hostPath:
-            path: /dev/shm/{{ .Release.Namespace }}
+            path: /var/run/iguazio/dayman-shm/{{ .Release.Namespace }}
         - name: v3iod-comm
           hostPath:
             path: /var/run/iguazio/dayman/{{ .Release.Namespace }}


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
IG-19791: move v3iod away from /dev/shm to avoid systemd's RemoveIPC