### PR TITLE
[mlrun-kit] Bump mlrun and nuclio versions to support k8s 1.19+

### DIFF
--- a/stable/mlrun-kit/Chart.yaml
+++ b/stable/mlrun-kit/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.17
+version: 0.2.0
 name: mlrun-kit
 description: MLRUn Open Source Stack
 home: https://iguazio.com

--- a/stable/mlrun-kit/requirements.lock
+++ b/stable/mlrun-kit/requirements.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: nuclio
   repository: https://nuclio.github.io/nuclio/charts
-  version: 0.11.2
+  version: 0.11.11
 - name: mlrun
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.7.3
+  version: 0.7.6
 - name: nfs-server-provisioner
   repository: https://charts.helm.sh/stable
   version: 1.1.1
 - name: mpi-operator
   repository: https://v3io.github.io/helm-charts/stable
   version: 0.4.5
-digest: sha256:bf65e5e372be792e52b097ca759209ccdb250d36e0f7801a4fda38e7b2316764
-generated: "2022-02-11T01:47:17.520412+02:00"
+digest: sha256:a92f2a7496b7ecfa2b1062c9e21f1d38b0d67e0681dddd2393a6b372b67639f4
+generated: "2022-03-10T18:05:36.25911+02:00"

--- a/stable/mlrun-kit/requirements.yaml
+++ b/stable/mlrun-kit/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
 - name: nuclio
-  version: "0.11.2"
+  version: "0.11.11"
   repository: "https://nuclio.github.io/nuclio/charts"
 - name: mlrun
-  version: "0.7.3"
+  version: "0.7.6"
   repository: "https://v3io.github.io/helm-charts/stable"
 - name: nfs-server-provisioner
   version: "1.1.1"

--- a/stable/mlrun-kit/values.yaml
+++ b/stable/mlrun-kit/values.yaml
@@ -58,7 +58,7 @@ mlrun:
   api:
     fullnameOverride: mlrun-api
     image:
-      tag: 0.9.3
+      tag: 0.10.0
     service:
       type: NodePort
       nodePort: 30070
@@ -90,7 +90,7 @@ mlrun:
       type: NodePort
       nodePort: 30060
     image:
-      tag: 0.9.3
+      tag: 0.10.0
 
 # mlrun persistency resources creation can be disabled if the user would like to provide their own PVC
 mlrunPersistency:
@@ -115,7 +115,7 @@ jupyterNotebook:
     nodePort: 30040
   image:
     repository: quay.io/mlrun/jupyter
-    tag: 0.9.3
+    tag: 0.10.0
     pullPolicy: IfNotPresent
   # use this to override mlrunUIURL, by default it will be auto-resolved to externalHostAddress and
   # mlrun UI's node port

--- a/stable/mlrun-kit/values.yaml
+++ b/stable/mlrun-kit/values.yaml
@@ -17,12 +17,12 @@ nuclio:
   controller:
     enabled: true
     image:
-      tag: 1.7.4-amd64
+      tag: 1.7.11-amd64
   dashboard:
     enabled: true
     # nodePort - taken from global.nuclio.dashboard.nodePort for re-usability
     image:
-      tag: 1.7.4-amd64
+      tag: 1.7.11-amd64
   autoscaler:
     enabled: false
   dlx:


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
https://github.com/v3io/helm-charts/pull/701 and https://github.com/v3io/helm-charts/pull/703 were done to support k8s 1.18 to be compatible with the k8s we have in katacoda, but apparently that change mean we don't support k8s 1.19+
So bumped Nuclio and MLRun to support k8s 1.19+ and bumped the mlrun-kit chart minor version to 0.2.0 so in katacoda we'll just pin to 0.1.x