### PR TITLE
[Presto] Add spill-disk hostPath volume

### DIFF
--- a/stable/presto/Chart.yaml
+++ b/stable/presto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: Presto is a distributed SQL query engine for big data
 name: presto
-version: 0.15.0
+version: 0.15.1
 home: https://prestosql.io/
 icon: https://prestosql.io/assets/presto.png
 sources:

--- a/stable/presto/templates/coordinator-deployment.yaml
+++ b/stable/presto/templates/coordinator-deployment.yaml
@@ -36,6 +36,14 @@ spec:
         - name: third-party-volume
           hostPath:
             path: "/home/iguazio/igz/bigdata/libs/third-party"
+        - name: spill-disk
+{{- if .Values.server.properties.spillPath }}
+          hostPath:
+            path: {{ .Values.server.properties.spillPath }}
+            type: DirectoryOrCreate
+{{- else }}
+          emptyDir: {}
+{{- end }}
 {{- if .Values.server.properties.https }}
         - name: java-cert
           emptyDir: {}

--- a/stable/presto/templates/worker-deployment.yaml
+++ b/stable/presto/templates/worker-deployment.yaml
@@ -38,6 +38,14 @@ spec:
         - name: third-party-volume
           hostPath:
             path: "/home/iguazio/igz/bigdata/libs/third-party"
+        - name: spill-disk
+{{- if .Values.server.properties.spillPath }}
+          hostPath:
+            path: {{ .Values.server.properties.spillPath }}
+            type: DirectoryOrCreate
+{{- else }}
+          emptyDir: {}
+{{- end }}
 {{- if .Values.server.properties.https }}
         - name: java-cert
           emptyDir: {}

--- a/stable/presto/values.yaml
+++ b/stable/presto/values.yaml
@@ -59,6 +59,7 @@ server:
       maxMemory: "12GB"
       maxMemoryPerNode: "3GB"
       maxTotalMemoryPerNode: "4GB"
+    spillPath: ""
   catalog:
 hive:
   hostname: hive


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Support spill-disk hostPath in Presto's coordinator and worker deployment.
If a spill-path is not given, use emptyDir.

Part of https://jira.iguazeng.com/browse/IG-20642