### PR TITLE
[mlrun] Support chief/worker deployment

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mlrun
-version: 0.8.0
-appVersion: 0.10.0
+version: 0.8.1
+appVersion: 1.0.1
 description: Machine Learning automation and tracking
 sources:
   - https://github.com/mlrun/mlrun

--- a/stable/mlrun/templates/_helpers.tpl
+++ b/stable/mlrun/templates/_helpers.tpl
@@ -41,6 +41,20 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+
+{{/*
+Create a fully qualified api chief name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "mlrun.api.chief.fullname" -}}
+{{- if .Values.api.chief.fullnameOverride -}}
+{{- .Values.api.chief.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-chief" (include "mlrun.api.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+
 {{/*
 Create a fully qualified api opa name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
@@ -182,11 +196,43 @@ API labels
 {{- end -}}
 
 {{/*
+API chief labels
+*/}}
+{{- define "mlrun.api.chief.labels" -}}
+{{ include "mlrun.common.labels" . }}
+{{ include "mlrun.api.chief.selectorLabels" . }}
+{{- end -}}
+
+{{/*
+API worker labels
+*/}}
+{{- define "mlrun.api.worker.labels" -}}
+{{ include "mlrun.common.labels" . }}
+{{ include "mlrun.api.worker.selectorLabels" . }}
+{{- end -}}
+
+{{/*
 API selector labels
 */}}
 {{- define "mlrun.api.selectorLabels" -}}
 {{ include "mlrun.common.selectorLabels" . }}
 app.kubernetes.io/component: {{ .Values.api.name | quote }}
+{{- end -}}
+
+{{/*
+API chief selector labels
+*/}}
+{{- define "mlrun.api.chief.selectorLabels" -}}
+{{ include "mlrun.api.selectorLabels" . }}
+app.kubernetes.io/sub-component: "chief"
+{{- end -}}
+
+{{/*
+API worker selector labels
+*/}}
+{{- define "mlrun.api.worker.selectorLabels" -}}
+{{ include "mlrun.api.selectorLabels" . }}
+app.kubernetes.io/sub-component: "worker"
 {{- end -}}
 
 {{/*

--- a/stable/mlrun/templates/_helpers.tpl
+++ b/stable/mlrun/templates/_helpers.tpl
@@ -54,6 +54,18 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+{{/*
+Create a fully qualified api worker name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "mlrun.api.worker.fullname" -}}
+{{- if .Values.api.worker.fullnameOverride -}}
+{{- .Values.api.worker.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-worker" (include "mlrun.api.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
 
 {{/*
 Create a fully qualified api opa name.

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -5,12 +5,12 @@ metadata:
   labels:
     {{- include "mlrun.api.chief.labels" . | nindent 4 }}
 spec:
-  # .api.chief.minReplicaCount replaced .api.replicaCount, keeping support for backwards compatibility
+  # .api.chief.minReplicas replaced .api.replicaCount, keeping support for backwards compatibility
   # kindIs is the way to differentiate between empty and 0 (if replicaCount is 0 we do want to use it)
   {{- if not (kindIs "invalid" .Values.api.replicaCount) }}
   replicas: {{ .Values.api.replicaCount }}
   {{- else }}
-  replicas: {{ .Values.api.chief.minReplicaCount }}
+  replicas: {{ .Values.api.chief.minReplicas }}
   {{- end }}
   selector:
     matchLabels:

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -1,0 +1,195 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mlrun.api.chief.fullname" . }}
+  labels:
+    {{- include "mlrun.api.chief.labels" . | nindent 4 }}
+spec:
+  # .api.chief.minReplicaCount replaced .api.replicaCount, keeping support for backwards compatibility
+  # kindIs is the way to differentiate between empty and 0 (if replicaCount is 0 we do want to use it)
+  {{- if not (kindIs "invalid" .Values.api.replicaCount) }}
+  replicas: {{ .Values.api.replicaCount }}
+  {{- else }}
+  replicas: {{ .Values.api.chief.minReplicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "mlrun.api.chief.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mlrun.api.chief.selectorLabels" . | nindent 8 }}
+    spec:
+    {{- with .Values.api.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "mlrun.serviceAccountName.api" . }}
+      securityContext:
+        {{- toYaml .Values.api.podSecurityContext | nindent 8 }}
+      {{- if .Values.api.extraInitContainers }}
+      initContainers:
+        {{- toYaml .Values.api.extraInitContainers | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ template "mlrun.name" . }}-{{ .Values.api.name }}
+          securityContext:
+            {{- toYaml .Values.api.securityContext | nindent 12 }}
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+          - name: MLRUN_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: MLRUN_HTTPDB__CLUSTERIZATION__ROLE
+            value: "chief"
+          - name: MLRUN_LOG_LEVEL
+            value: {{ .Values.api.logLevel }}
+          - name: MLRUN_HTTPDB__DB_TYPE
+            {{- if or (eq .Values.httpDB.dbType "mysql") (eq .Values.httpDB.dbType "sqlite") }}
+            value: "sqldb"
+            {{- else }}
+            value: "filedb"
+            {{- end }}
+          - name: MLRUN_HTTPDB__API_URL
+            value: http://{{ include "mlrun.api.fullname" . }}:{{ .Values.api.service.port }}
+          - name: MLRUN_HTTPDB__DIRPATH
+            value: {{ .Values.httpDB.dirPath }}
+          # DEFAULT_DOCKER_REGISTRY & DEFAULT_DOCKER_SECRET are for BC to run 0.5.x chart with 0.5.x MLRun
+          # When mlrun-kit starts using 0.6.x MLRun this can be removed
+          - name: DEFAULT_DOCKER_REGISTRY
+            value: {{ template "mlrun.defaultDockerRegistry.url" . }}
+          - name: DEFAULT_DOCKER_SECRET
+            value: {{ template "mlrun.defaultDockerRegistry.secretName" . }}
+          - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
+            value: {{ template "mlrun.defaultDockerRegistry.url" . }}
+          - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET
+            value: {{ template "mlrun.defaultDockerRegistry.secretName" . }}
+          - name: MLRUN_HTTPDB__DSN
+            value: {{ .Values.httpDB.dsn }}
+          - name: MLRUN_HTTPDB__OLD_DSN
+            value: {{ .Values.httpDB.oldDsn }}
+          {{- if .Values.v3io.enabled }}
+          - name: V3IO_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Release.Name }}-v3io-fuse
+                key: accessKey
+          - name: V3IO_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Release.Name }}-v3io-fuse
+                key: username
+          {{- end }}
+          - name: MLRUN_NUCLIO_MODE
+            value: {{ .Values.nuclio.mode }}
+          {{- if eq .Values.nuclio.mode "enabled" }}
+          - name: MLRUN_NUCLIO_DASHBOARD_URL
+            value: {{ template "mlrun.nuclio.apiURL" . }}
+          {{- end }}
+          {{- if .Values.api.extraEnv }}
+          {{ toYaml .Values.api.extraEnv | nindent 10 }}
+          {{- end }}
+          {{- if .Values.api.extraEnvKeyValue }}
+          {{- range $name, $value := .Values.api.extraEnvKeyValue }}
+          - name: {{ $name }}
+            value: {{ $value | quote }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.api.envFrom }}
+          envFrom:
+          {{ toYaml .Values.api.envFrom | nindent 10 }}
+          {{- end }}
+          {{- if .Values.api.livenessProbe }}
+          livenessProbe:
+            {{ toYaml .Values.api.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.api.readinessProbe }}
+          readinessProbe:
+            {{ toYaml .Values.api.readinessProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+          volumeMounts:
+            - name: storage
+              mountPath: {{ .Values.httpDB.dirPath }}
+            {{- range .Values.api.extraPersistentVolumeMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath | default "" }}
+              readOnly: {{ .readOnly }}
+            {{- end }}
+        {{- if .Values.api.opa.enabled }}
+        - name: {{ template "mlrun.name" . }}-{{ .Values.api.opa.name }}
+          securityContext:
+            {{- toYaml .Values.api.opa.securityContext | nindent 12 }}
+          image: "{{ .Values.api.opa.image.repository }}:{{ .Values.api.opa.image.tag }}"
+          imagePullPolicy: {{ .Values.api.opa.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8181
+          {{- if .Values.api.opa.livenessProbe }}
+          livenessProbe:
+            {{ toYaml .Values.api.opa.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.api.opa.readinessProbe }}
+          readinessProbe:
+            {{ toYaml .Values.api.opa.readinessProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.api.opa.resources | nindent 12 }}
+          args:
+            - "run"
+            - "--server"
+            - "--config-file=/config/config.yaml"
+            - "--log-level={{ .Values.api.opa.logLevel }}"
+            - "--log-format={{ .Values.api.opa.logFormat }}"
+            - "--ignore=.*"
+          volumeMounts:
+            - readOnly: true
+              mountPath: /config
+              name: config
+        {{- end }}
+      volumes:
+        - name: storage
+          {{- if .Values.api.volumes.storageOverride }}
+          {{- toYaml .Values.api.volumes.storageOverride | nindent 10 }}
+          {{- else }}
+          flexVolume:
+            driver: "v3io/fuse"
+            options:
+              container: users
+              subPath: /{{ .Values.v3io.username }}/.mlrun
+            secretRef:
+              name: {{ .Release.Name }}-v3io-fuse
+          {{- end }}
+        {{- range .Values.api.extraPersistentVolumeMounts }}
+        - name: {{ .name }}
+          persistentVolumeClaim:
+            claimName: {{ .existingClaim }}
+        {{- end }}
+        {{- if .Values.api.opa.enabled }}
+        - name: config
+          secret:
+            secretName: {{ template "mlrun.api.opa.fullname" . }}
+        {{- end }}
+      {{- with .Values.api.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.api.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.api.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- if .Values.api.priorityClassName }}
+      priorityClassName: {{ .Values.api.priorityClassName | quote }}
+    {{- end }}

--- a/stable/mlrun/templates/api-chief-ingress.yaml
+++ b/stable/mlrun/templates/api-chief-ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.api.chief.ingress.enabled -}}
+{{- $fullName := include "mlrun.api.chief.fullname" . -}}
+{{- $svcPort := .Values.api.chief.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "mlrun.api.chief.labels" . | nindent 4 }}
+  {{- with .Values.api.chief.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.api.chief.ingress.tls }}
+  tls:
+  {{- range .Values.api.chief.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.api.chief.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/stable/mlrun/templates/api-chief-service.yaml
+++ b/stable/mlrun/templates/api-chief-service.yaml
@@ -6,34 +6,34 @@ metadata:
   labels:
     {{- include "mlrun.api.chief.labels" . | nindent 4 }}
 spec:
-{{- if (or (eq .Values.api.service.type "ClusterIP") (empty .Values.api.service.type)) }}
+{{- if (or (eq .Values.api.chief.service.type "ClusterIP") (empty .Values.api.chief.service.type)) }}
   type: ClusterIP
-  {{- if .Values.api.service.clusterIP }}
-  clusterIP: {{ .Values.api.service.clusterIP }}
+  {{- if .Values.api.chief.service.clusterIP }}
+  clusterIP: {{ .Values.api.chief.service.clusterIP }}
   {{end}}
-{{- else if eq .Values.api.service.type "LoadBalancer" }}
-  type: {{ .Values.api.service.type }}
-  {{- if .Values.api.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.api.service.loadBalancerIP }}
+{{- else if eq .Values.api.chief.service.type "LoadBalancer" }}
+  type: {{ .Values.api.chief.service.type }}
+  {{- if .Values.api.chief.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.api.chief.service.loadBalancerIP }}
   {{- end }}
-  {{- if .Values.api.service.loadBalancerSourceRanges }}
+  {{- if .Values.api.chief.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
-{{ toYaml .Values.api.service.loadBalancerSourceRanges | indent 4 }}
+{{ toYaml .Values.api.chief.service.loadBalancerSourceRanges | indent 4 }}
   {{- end -}}
 {{- else }}
-  type: {{ .Values.api.service.type }}
+  type: {{ .Values.api.chief.service.type }}
 {{- end }}
-{{- if .Values.api.service.externalIPs }}
+{{- if .Values.api.chief.service.externalIPs }}
   externalIPs:
-{{ toYaml .Values.api.service.externalIPs | indent 4 }}
+{{ toYaml .Values.api.chief.service.externalIPs | indent 4 }}
 {{- end }}
   ports:
     - name: http
-      port: {{ .Values.api.service.port }}
+      port: {{ .Values.api.chief.service.port }}
       protocol: TCP
       targetPort: http
-{{ if (and (eq .Values.api.service.type "NodePort") (not (empty .Values.api.service.nodePort))) }}
-      nodePort: {{.Values.api.service.nodePort}}
+{{ if (and (eq .Values.api.chief.service.type "NodePort") (not (empty .Values.api.chief.service.nodePort))) }}
+      nodePort: {{.Values.api.chief.service.nodePort}}
 {{ end }}
   selector:
     {{- include "mlrun.api.chief.selectorLabels" . | nindent 4 }}

--- a/stable/mlrun/templates/api-chief-service.yaml
+++ b/stable/mlrun/templates/api-chief-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.api.worker.minReplicaCount -}}
+{{- if .Values.api.worker.minReplicas -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/stable/mlrun/templates/api-chief-service.yaml
+++ b/stable/mlrun/templates/api-chief-service.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.api.worker.minReplicaCount -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mlrun.api.chief.fullname" . }}
+  labels:
+    {{- include "mlrun.api.chief.labels" . | nindent 4 }}
+spec:
+{{- if (or (eq .Values.api.service.type "ClusterIP") (empty .Values.api.service.type)) }}
+  type: ClusterIP
+  {{- if .Values.api.service.clusterIP }}
+  clusterIP: {{ .Values.api.service.clusterIP }}
+  {{end}}
+{{- else if eq .Values.api.service.type "LoadBalancer" }}
+  type: {{ .Values.api.service.type }}
+  {{- if .Values.api.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.api.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.api.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.api.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.api.service.type }}
+{{- end }}
+{{- if .Values.api.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.api.service.externalIPs | indent 4 }}
+{{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.api.service.port }}
+      protocol: TCP
+      targetPort: http
+{{ if (and (eq .Values.api.service.type "NodePort") (not (empty .Values.api.service.nodePort))) }}
+      nodePort: {{.Values.api.service.nodePort}}
+{{ end }}
+  selector:
+    {{- include "mlrun.api.chief.selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.api.worker.minReplicaCount -}}
+{{- if .Values.api.worker.minReplicas -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "mlrun.api.worker.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.api.worker.minReplicaCount }}
+  replicas: {{ .Values.api.worker.minReplicas }}
   selector:
     matchLabels:
       {{- include "mlrun.api.worker.selectorLabels" . | nindent 6 }}

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "mlrun.api.fullname" . }}
+  name: {{ include "mlrun.api.worker.fullname" . }}
   labels:
     {{- include "mlrun.api.worker.labels" . | nindent 4 }}
 spec:

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -1,18 +1,19 @@
+{{- if .Values.api.worker.minReplicaCount -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "mlrun.api.fullname" . }}
   labels:
-    {{- include "mlrun.api.labels" . | nindent 4 }}
+    {{- include "mlrun.api.worker.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.api.replicaCount }}
+  replicas: {{ .Values.api.worker.minReplicaCount }}
   selector:
     matchLabels:
-      {{- include "mlrun.api.selectorLabels" . | nindent 6 }}
+      {{- include "mlrun.api.worker.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "mlrun.api.selectorLabels" . | nindent 8 }}
+        {{- include "mlrun.api.worker.selectorLabels" . | nindent 8 }}
     spec:
     {{- with .Values.api.image.pullSecrets }}
       imagePullSecrets:
@@ -40,6 +41,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: MLRUN_HTTPDB__CLUSTERIZATION__ROLE
+            value: "worker"
           - name: MLRUN_LOG_LEVEL
             value: {{ .Values.api.logLevel }}
           - name: MLRUN_HTTPDB__DB_TYPE
@@ -185,3 +188,4 @@ spec:
     {{- if .Values.api.priorityClassName }}
       priorityClassName: {{ .Values.api.priorityClassName | quote }}
     {{- end }}
+{{- end -}}

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -11,7 +11,7 @@ api:
   chief:
     fullnameOverride:
     # auto-scaling is currently not supported and the min value is treated as the fixed value
-    minReplicaCount: 1
+    minReplicas: 1
 
     service:
       type: ClusterIP
@@ -33,7 +33,7 @@ api:
   worker:
     fullnameOverride:
     # auto-scaling is currently not supported and the min value is treated as the fixed value
-    minReplicaCount: 0
+    minReplicas: 0
 
   image:
     repository: mlrun/mlrun-api

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -18,7 +18,7 @@ api:
 
   image:
     repository: mlrun/mlrun-api
-    tag: 0.7.0
+    tag: 1.0.1
     pullPolicy: IfNotPresent
     pullSecrets: []
 
@@ -349,7 +349,7 @@ ui:
 
   image:
     repository: mlrun/mlrun-ui
-    tag: 0.7.0
+    tag: 1.0.1
     pullPolicy: IfNotPresent
     pullSecrets: []
 

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -12,7 +12,26 @@ api:
     fullnameOverride:
     # auto-scaling is currently not supported and the min value is treated as the fixed value
     minReplicaCount: 1
+
+    service:
+      type: ClusterIP
+      port: 8080
+      targetPort: 8080
+
+    ingress:
+      enabled: false
+      annotations: { }
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+      hosts:
+        - host: chart-example.local
+          paths: [ ]
+      tls: [ ]
+      #  - secretName: chart-example-tls
+      #    hosts:
+      #      - chart-example.local
   worker:
+    fullnameOverride:
     # auto-scaling is currently not supported and the min value is treated as the fixed value
     minReplicaCount: 0
 

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -8,7 +8,13 @@ api:
 
   logLevel: INFO
 
-  replicaCount: 1
+  chief:
+    fullnameOverride:
+    # auto-scaling is currently not supported and the min value is treated as the fixed value
+    minReplicaCount: 1
+  worker:
+    # auto-scaling is currently not supported and the min value is treated as the fixed value
+    minReplicaCount: 0
 
   image:
     repository: mlrun/mlrun-api


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Related to https://github.com/mlrun/mlrun/pull/1960
The `app.kubernetes.io/sub-component` (`chief/worker`) label I added is not from the [k8s recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) but something I invented
I had to keep the `app.kubernetes.io/component` set to `api` for both the chief and the workers so I would be able to identify (service selector) both the chief and the workers from the API k8s svc (but not the UI) and in addition to have a way to identify only the chief API for the chief api k8s svc
Unfortunately k8s svc does not support [set based requirements](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement) which would made this much easier