### PR TITLE
[mlrun] Fix chief ingress to be created only when there are workers

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.8.1
+version: 0.8.2
 appVersion: 1.0.1
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/api-chief-ingress.yaml
+++ b/stable/mlrun/templates/api-chief-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.api.worker.minReplicas -}}
 {{- if .Values.api.chief.ingress.enabled -}}
 {{- $fullName := include "mlrun.api.chief.fullname" . -}}
 {{- $svcPort := .Values.api.chief.service.port -}}
@@ -38,4 +39,5 @@ spec:
               servicePort: {{ $svcPort }}
         {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Fix following https://github.com/v3io/helm-charts/pull/738