### PR TITLE
[k8s-pod-headless-service-operator] Introducing chart

### DIFF
--- a/stable/k8s-pod-headless-service-operator/.helmignore
+++ b/stable/k8s-pod-headless-service-operator/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/stable/k8s-pod-headless-service-operator/Chart.yaml
+++ b/stable/k8s-pod-headless-service-operator/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for k8s-pod-headless-service-operator
+name: k8s-pod-headless-service-operator
+version: 0.2.0
+home: https://github.com/src-d/k8s-pod-headless-service-operator
+maintainers:
+- email: liranb@iguazio.com
+  name: Liran BG
+- email: infra@sourced.tech
+  name: Infrastructure Team

--- a/stable/k8s-pod-headless-service-operator/templates/_helpers.tpl
+++ b/stable/k8s-pod-headless-service-operator/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "k8s-pod-headless-service-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "k8s-pod-headless-service-operator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "k8s-pod-headless-service-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/stable/k8s-pod-headless-service-operator/templates/deployment.yaml
+++ b/stable/k8s-pod-headless-service-operator/templates/deployment.yaml
@@ -1,0 +1,49 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: {{ template "k8s-pod-headless-service-operator.fullname" . }}
+  labels:
+    app: {{ template "k8s-pod-headless-service-operator.name" . }}
+    chart: {{ template "k8s-pod-headless-service-operator.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "k8s-pod-headless-service-operator.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "k8s-pod-headless-service-operator.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      priorityClassName: {{ .Values.priorityClassName }}
+      serviceAccountName: {{ template "k8s-pod-headless-service-operator.fullname" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ required "missing image.tag" .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- if  .Values.app.podAnnotation }}
+            - name: POD_ANNOTATION
+              value: {{ .Values.app.podAnnotation }}
+            {{- end }}
+            {{- if  .Values.app.namespace }}
+            - name: NAMESPACE
+              value: {{ .Values.app.namespace }}
+            {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/stable/k8s-pod-headless-service-operator/templates/rbac.yaml
+++ b/stable/k8s-pod-headless-service-operator/templates/rbac.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.rbac.enabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "k8s-pod-headless-service-operator.fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "k8s-pod-headless-service-operator.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "k8s-pod-headless-service-operator.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "k8s-pod-headless-service-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/k8s-pod-headless-service-operator/templates/serviceaccount.yaml
+++ b/stable/k8s-pod-headless-service-operator/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "k8s-pod-headless-service-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}

--- a/stable/k8s-pod-headless-service-operator/values.yaml
+++ b/stable/k8s-pod-headless-service-operator/values.yaml
@@ -1,0 +1,34 @@
+# Taken from https://github.com/src-d/charts
+
+# Default values for kubernetes-local-pv-provisioner
+image:
+  repository: srcd/k8s-pod-headless-service-operator
+  # tag: latest
+  pullPolicy: IfNotPresent
+
+app: {}
+  # podAnnotation:
+  # namespace:
+
+rbac:
+  enabled: true
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+priorityClassName: ""


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Introducing `k8s-pod-headless-service-operator` chart and fix its RBAC api version to be k8s 1.22 compatible