### PR TITLE
[presto] fix configmap name resolution

### DIFF
--- a/stable/presto/templates/coordinator-deployment.yaml
+++ b/stable/presto/templates/coordinator-deployment.yaml
@@ -30,7 +30,7 @@ spec:
             name: {{ template "presto.coordinator" . }}
         - name: catalog-config-volume
           configMap:
-            name: presto-catalog
+            name: {{ template "presto.catalog" . }}
         - name: daemon-health
           emptyDir: {}
         - name: third-party-volume

--- a/stable/presto/templates/worker-deployment.yaml
+++ b/stable/presto/templates/worker-deployment.yaml
@@ -32,7 +32,7 @@ spec:
             name: {{ template "presto.worker" . }}
         - name: catalog-config-volume
           configMap:
-            name: presto-catalog
+            name: {{ template "presto.catalog" . }}
         - name: daemon-health
           emptyDir: {}
         - name: third-party-volume


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
configmap was hardcoded and not a reference