### PR TITLE
[Presto] Add custom spill disk volumeMounts

### DIFF
--- a/stable/presto/Chart.yaml
+++ b/stable/presto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: Presto is a distributed SQL query engine for big data
 name: presto
-version: 0.15.1
+version: 0.15.2
 home: https://prestosql.io/
 icon: https://prestosql.io/assets/presto.png
 sources:

--- a/stable/presto/templates/coordinator-deployment.yaml
+++ b/stable/presto/templates/coordinator-deployment.yaml
@@ -36,13 +36,11 @@ spec:
         - name: third-party-volume
           hostPath:
             path: "/home/iguazio/igz/bigdata/libs/third-party"
-        - name: spill-disk
 {{- if .Values.server.properties.spillPath }}
+        - name: spill-disk
           hostPath:
             path: {{ .Values.server.properties.spillPath }}
             type: DirectoryOrCreate
-{{- else }}
-          emptyDir: {}
 {{- end }}
 {{- if .Values.server.properties.https }}
         - name: java-cert
@@ -91,6 +89,10 @@ spec:
 {{- if .Values.server.properties.https }}
             - mountPath: /var/run/iguazio/java/cert
               name: java-cert
+{{- end }}
+{{- if .Values.server.properties.spillPath }}
+            - mountPath: {{ .Values.server.properties.spillMountPath }}
+              name: spill-disk
 {{- end }}
 {{- if .Values.server.properties.coordinator.volumes }}
 {{ include .Values.server.properties.coordinator.volumes.volumeMountsTemplate . | indent 12 }}

--- a/stable/presto/templates/worker-deployment.yaml
+++ b/stable/presto/templates/worker-deployment.yaml
@@ -38,13 +38,11 @@ spec:
         - name: third-party-volume
           hostPath:
             path: "/home/iguazio/igz/bigdata/libs/third-party"
-        - name: spill-disk
 {{- if .Values.server.properties.spillPath }}
+        - name: spill-disk
           hostPath:
             path: {{ .Values.server.properties.spillPath }}
             type: DirectoryOrCreate
-{{- else }}
-          emptyDir: {}
 {{- end }}
 {{- if .Values.server.properties.https }}
         - name: java-cert
@@ -95,6 +93,10 @@ spec:
 {{- if .Values.server.properties.https }}
             - mountPath: /var/run/iguazio/java/cert
               name: java-cert
+{{- end }}
+{{- if .Values.server.properties.spillPath }}
+            - mountPath: {{ .Values.server.properties.spillMountPath }}
+              name: spill-disk
 {{- end }}
 {{- if .Values.server.properties.worker.volumes }}
 {{ include .Values.server.properties.worker.volumes.volumeMountsTemplate . | indent 12 }}

--- a/stable/presto/values.yaml
+++ b/stable/presto/values.yaml
@@ -60,6 +60,7 @@ server:
       maxMemoryPerNode: "3GB"
       maxTotalMemoryPerNode: "4GB"
     spillPath: ""
+    spillMountPath: ""
   catalog:
 hive:
   hostname: hive


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
In addition to the presto spill path, a custom spill mount path is be used for the pod's volumeMount.

A follow-up to #736 

JIRA: https://jira.iguazeng.com/browse/IG-19588