### PR TITLE
[Presto] Remove spill disk volume from coordinator [integ_3.4]

### DIFF
--- a/stable/presto/Chart.yaml
+++ b/stable/presto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: Presto is a distributed SQL query engine for big data
 name: presto
-version: 0.14.6
+version: 0.14.7
 home: https://prestosql.io/
 icon: https://prestosql.io/assets/presto.png
 sources:

--- a/stable/presto/templates/coordinator-deployment.yaml
+++ b/stable/presto/templates/coordinator-deployment.yaml
@@ -36,12 +36,6 @@ spec:
         - name: third-party-volume
           hostPath:
             path: "/home/iguazio/igz/bigdata/libs/third-party"
-{{- if .Values.server.properties.spillPath }}
-        - name: spill-disk
-          hostPath:
-            path: {{ .Values.server.properties.spillPath }}
-            type: DirectoryOrCreate
-{{- end }}
 {{- if .Values.server.properties.https }}
         - name: java-cert
           emptyDir: {}
@@ -89,10 +83,6 @@ spec:
 {{- if .Values.server.properties.https }}
             - mountPath: /var/run/iguazio/java/cert
               name: java-cert
-{{- end }}
-{{- if .Values.server.properties.spillPath }}
-            - mountPath: {{ .Values.server.properties.spillMountPath }}
-              name: spill-disk
 {{- end }}
 {{- if .Values.server.properties.coordinator.volumes }}
 {{ include .Values.server.properties.coordinator.volumes.volumeMountsTemplate . | indent 12 }}


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
The presto spill to disk feature only requires a volume in the worker, and not the coordinator. 