### PR TITLE
[Presto] Change spill hostPath type

### DIFF
--- a/stable/presto/Chart.yaml
+++ b/stable/presto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: Presto is a distributed SQL query engine for big data
 name: presto
-version: 0.15.3
+version: 0.15.4
 home: https://prestosql.io/
 icon: https://prestosql.io/assets/presto.png
 sources:

--- a/stable/presto/templates/worker-deployment.yaml
+++ b/stable/presto/templates/worker-deployment.yaml
@@ -42,7 +42,7 @@ spec:
         - name: spill-disk
           hostPath:
             path: {{ .Values.server.properties.spillPath }}
-            type: DirectoryOrCreate
+            type: Directory
 {{- end }}
 {{- if .Values.server.properties.https }}
         - name: java-cert


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Change presto spill hostPath volume type to Directory, so that the host directory will not be created by k8s as the root user, and a directory with the right permissions will have to exist.