### PR TITLE
[Presto] Support multiple spill paths

### DIFF
--- a/stable/presto/Chart.yaml
+++ b/stable/presto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: Presto is a distributed SQL query engine for big data
 name: presto
-version: 0.15.4
+version: 0.15.5
 home: https://prestosql.io/
 icon: https://prestosql.io/assets/presto.png
 sources:

--- a/stable/presto/templates/worker-deployment.yaml
+++ b/stable/presto/templates/worker-deployment.yaml
@@ -39,10 +39,13 @@ spec:
           hostPath:
             path: "/home/iguazio/igz/bigdata/libs/third-party"
 {{- if .Values.server.properties.spillPath }}
-        - name: spill-disk
+{{- $spillPaths := splitList "," .Values.server.properties.spillPath }}
+{{- range $index, $path := $spillPaths}}
+        - name: {{ $volumeName := print "spill-disk-" $index }}{{ $volumeName }}
           hostPath:
-            path: {{ .Values.server.properties.spillPath }}
+            path: {{ $path }}
             type: Directory
+{{- end }}
 {{- end }}
 {{- if .Values.server.properties.https }}
         - name: java-cert
@@ -95,8 +98,11 @@ spec:
               name: java-cert
 {{- end }}
 {{- if .Values.server.properties.spillPath }}
-            - mountPath: {{ .Values.server.properties.spillMountPath }}
-              name: spill-disk
+{{- $spillMountPaths := splitList "," .Values.server.properties.spillMountPath }}
+{{- range $index, $path := $spillMountPaths}}
+            - mountPath: {{ $path }}
+              name: {{ $mountName := print "spill-disk-" $index }}{{ $mountName }}
+{{- end }}
 {{- end }}
 {{- if .Values.server.properties.worker.volumes }}
 {{ include .Values.server.properties.worker.volumes.volumeMountsTemplate . | indent 12 }}


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Presto supports multiple spill paths that are given as a comma-separated string.
We range over the split string and create a volume and volumeMount for each path.

Porting #764 
JIRA - https://jira.iguazeng.com/browse/IG-20765