### PR TITLE
[Presto] remove 'coordinator' booleans in configmaps [integ_3.4]

### DIFF
--- a/stable/presto/Chart.yaml
+++ b/stable/presto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: Presto is a distributed SQL query engine for big data
 name: presto
-version: 0.14.9
+version: 0.14.10
 home: https://prestosql.io/
 icon: https://prestosql.io/assets/presto.png
 sources:

--- a/stable/presto/templates/coordinator-configmap.yaml
+++ b/stable/presto/templates/coordinator-configmap.yaml
@@ -37,7 +37,6 @@ data:
   config.properties: |
 {{- if .Values.server.properties.coordinator.config.custom }}
 {{ .Values.server.properties.coordinator.config.custom | indent 4 }}
-{{- println "coordinator=true" }}
 {{- else }}
     coordinator=true
 {{- if gt (int .Values.server.workers) 0 }}

--- a/stable/presto/templates/worker-configmap.yaml
+++ b/stable/presto/templates/worker-configmap.yaml
@@ -38,7 +38,6 @@ data:
   config.properties: |
 {{- if .Values.server.properties.worker.config.custom }}
 {{ .Values.server.properties.worker.config.custom | indent 4 }}
-{{- println "coordinator=false" }}
 {{- else }}
     coordinator=false
     http-server.http.port={{ .Values.server.properties.http.port }}


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Remove the additions of `coordinator=true` and `coordinator=false` in the coordiantor's and worker's configmap, as this is already present in the config files.

Related JIRA: https://jira.iguazeng.com/browse/IG-14262

Back port of #769 