### PR TITLE
[mlrun-kit] Bump default mlrun version to 1.0.3

### DIFF
--- a/stable/mlrun-kit/Chart.yaml
+++ b/stable/mlrun-kit/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.3.2
+version: 0.3.3
 name: mlrun-kit
 description: MLRUn Open Source Stack
 home: https://iguazio.com

--- a/stable/mlrun-kit/values.yaml
+++ b/stable/mlrun-kit/values.yaml
@@ -58,7 +58,7 @@ mlrun:
   api:
     fullnameOverride: mlrun-api
     image:
-      tag: 0.10.0
+      tag: 1.0.3
     service:
       type: NodePort
       nodePort: 30070
@@ -90,7 +90,7 @@ mlrun:
       type: NodePort
       nodePort: 30060
     image:
-      tag: 0.10.0
+      tag: 1.0.3
 
 # mlrun persistency resources creation can be disabled if the user would like to provide their own PVC
 mlrunPersistency:
@@ -131,7 +131,7 @@ jupyterNotebook:
     #      - chart-example.local
   image:
     repository: quay.io/mlrun/jupyter
-    tag: 0.10.0
+    tag: 1.0.3
     pullPolicy: IfNotPresent
   # use this to override mlrunUIURL, by default it will be auto-resolved to externalHostAddress and
   # mlrun UI's node port


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Don't merge until 1.0.3 is actually released