### PR TITLE
[label-studio] fix app version

### DIFF
--- a/stable/label-studio/Chart.yaml
+++ b/stable/label-studio/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 0.9.1
+appVersion: 0.8.2
 description: A swiss army knife of data labeling and annotation tools
 name: label-studio
-version: 0.3.0
+version: 0.3.1
 home: https://labelstud.io/
 icon: https://labelstud.io/images/ls_logo.png
 sources:

--- a/stable/label-studio/Chart.yaml
+++ b/stable/label-studio/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
+version: 0.3.1
 appVersion: 0.8.2
 description: A swiss army knife of data labeling and annotation tools
 name: label-studio
-version: 0.3.1
 home: https://labelstud.io/
 icon: https://labelstud.io/images/ls_logo.png
 sources:


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
There were a few cases were the app version was bumped instead of the chart version.
The app (label-studio) version we use is 0.8.2.