### PR TITLE
[mlrun] Add default pod anti affinity to prefer not running 2 API pods on the same node

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mlrun
 version: 0.8.3
-appVersion: 1.0.1
+appVersion: 1.0.4
 description: Machine Learning automation and tracking
 sources:
   - https://github.com/mlrun/mlrun

--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.8.2
+version: 0.8.3
 appVersion: 1.0.1
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -192,10 +192,12 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  {{- include "mlrun.api.selectorLabels" . | nindent 18 }}
-              topologyKey: "kubernetes.io/hostname"
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    {{- include "mlrun.api.selectorLabels" . | nindent 20 }}
+                topologyKey: "kubernetes.io/hostname"
     {{- end }}
     {{- with .Values.api.tolerations }}
       tolerations:

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -182,9 +182,20 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.api.affinity }}
+    {{- if .Values.api.chief.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.api.chief.affinity | nindent 8 }}
+    {{- else if .Values.api.affinity }}
+      affinity:
+        {{- toYaml .Values.api.affinity | nindent 8 }}
+    {{- else }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  {{- include "mlrun.api.selectorLabels" . | nindent 18 }}
+              topologyKey: "kubernetes.io/hostname"
     {{- end }}
     {{- with .Values.api.tolerations }}
       tolerations:

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -187,10 +187,12 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  {{- include "mlrun.api.selectorLabels" . | nindent 18 }}
-              topologyKey: "kubernetes.io/hostname"
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    {{- include "mlrun.api.selectorLabels" . | nindent 20 }}
+                topologyKey: "kubernetes.io/hostname"
     {{- end }}
     {{- with .Values.api.tolerations }}
       tolerations:

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -177,9 +177,20 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.api.affinity }}
+    {{- if .Values.api.worker.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.api.worker.affinity | nindent 8 }}
+    {{- else if .Values.api.affinity }}
+      affinity:
+        {{- toYaml .Values.api.affinity | nindent 8 }}
+    {{- else }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  {{- include "mlrun.api.selectorLabels" . | nindent 18 }}
+              topologyKey: "kubernetes.io/hostname"
     {{- end }}
     {{- with .Values.api.tolerations }}
       tolerations:

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -30,10 +30,27 @@ api:
       #  - secretName: chart-example-tls
       #    hosts:
       #      - chart-example.local
+
+    ## Affinity for pod assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ##
+    # Setting the affinity here has precedence over api.affinity
+    # Note that by default we're assigning affinity to make the chief/worker pods to run on different nodes, if you're
+    # overriding the affinity it's your responsibility to keep applying this behavior
+    affinity: { }
+
   worker:
     fullnameOverride:
     # auto-scaling is currently not supported and the min value is treated as the fixed value
     minReplicas: 0
+
+    ## Affinity for pod assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ##
+    # Setting the affinity here has precedence over api.affinity
+    # Note that by default we're assigning affinity to make the chief/worker pods to run on different nodes, if you're
+    # overriding the affinity it's your responsibility to keep applying this behavior
+    affinity: { }
 
   image:
     repository: mlrun/mlrun-api
@@ -99,6 +116,10 @@ api:
   ## Affinity for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ##
+  # Setting the affinity here will apply to both the chief and worker deployments, the specific affinity fields
+  # (api.chief/worker.affinity) has precedence over this on.
+  # Note that by default we're assigning affinity to make the chief/worker pods to run on different nodes, if you're
+  # overriding the affinity it's your responsibility to keep applying this behavior
   affinity: {}
 
   priorityClassName: ""

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -54,7 +54,7 @@ api:
 
   image:
     repository: mlrun/mlrun-api
-    tag: 1.0.1
+    tag: 1.0.4
     pullPolicy: IfNotPresent
     pullSecrets: []
 
@@ -389,7 +389,7 @@ ui:
 
   image:
     repository: mlrun/mlrun-ui
-    tag: 1.0.1
+    tag: 1.0.4
     pullPolicy: IfNotPresent
     pullSecrets: []
 


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Also bumped the default app version and added option to configure specific affinity for the chief/worker pods