### PR TITLE
[mlrun] Support chief/worker deployment [Backport integ_3.2]

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.6.24
+version: 0.6.25
 appVersion: 0.7.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/_helpers.tpl
+++ b/stable/mlrun/templates/_helpers.tpl
@@ -41,6 +41,32 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+
+{{/*
+Create a fully qualified api chief name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "mlrun.api.chief.fullname" -}}
+{{- if .Values.api.chief.fullnameOverride -}}
+{{- .Values.api.chief.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-chief" (include "mlrun.api.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified api worker name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "mlrun.api.worker.fullname" -}}
+{{- if .Values.api.worker.fullnameOverride -}}
+{{- .Values.api.worker.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-worker" (include "mlrun.api.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+
 {{/*
 Create a fully qualified api opa name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
@@ -182,11 +208,43 @@ API labels
 {{- end -}}
 
 {{/*
+API chief labels
+*/}}
+{{- define "mlrun.api.chief.labels" -}}
+{{ include "mlrun.common.labels" . }}
+{{ include "mlrun.api.chief.selectorLabels" . }}
+{{- end -}}
+
+{{/*
+API worker labels
+*/}}
+{{- define "mlrun.api.worker.labels" -}}
+{{ include "mlrun.common.labels" . }}
+{{ include "mlrun.api.worker.selectorLabels" . }}
+{{- end -}}
+
+{{/*
 API selector labels
 */}}
 {{- define "mlrun.api.selectorLabels" -}}
 {{ include "mlrun.common.selectorLabels" . }}
 app.kubernetes.io/component: {{ .Values.api.name | quote }}
+{{- end -}}
+
+{{/*
+API chief selector labels
+*/}}
+{{- define "mlrun.api.chief.selectorLabels" -}}
+{{ include "mlrun.api.selectorLabels" . }}
+app.kubernetes.io/sub-component: "chief"
+{{- end -}}
+
+{{/*
+API worker selector labels
+*/}}
+{{- define "mlrun.api.worker.selectorLabels" -}}
+{{ include "mlrun.api.selectorLabels" . }}
+app.kubernetes.io/sub-component: "worker"
 {{- end -}}
 
 {{/*

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -1,18 +1,24 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "mlrun.api.fullname" . }}
+  name: {{ include "mlrun.api.chief.fullname" . }}
   labels:
-    {{- include "mlrun.api.labels" . | nindent 4 }}
+    {{- include "mlrun.api.chief.labels" . | nindent 4 }}
 spec:
+  # .api.chief.minReplicas replaced .api.replicaCount, keeping support for backwards compatibility
+  # kindIs is the way to differentiate between empty and 0 (if replicaCount is 0 we do want to use it)
+  {{- if not (kindIs "invalid" .Values.api.replicaCount) }}
   replicas: {{ .Values.api.replicaCount }}
+  {{- else }}
+  replicas: {{ .Values.api.chief.minReplicas }}
+  {{- end }}
   selector:
     matchLabels:
-      {{- include "mlrun.api.selectorLabels" . | nindent 6 }}
+      {{- include "mlrun.api.chief.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "mlrun.api.selectorLabels" . | nindent 8 }}
+        {{- include "mlrun.api.chief.selectorLabels" . | nindent 8 }}
     spec:
     {{- with .Values.api.image.pullSecrets }}
       imagePullSecrets:
@@ -40,6 +46,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: MLRUN_HTTPDB__CLUSTERIZATION__ROLE
+            value: "chief"
           - name: MLRUN_LOG_LEVEL
             value: {{ .Values.api.logLevel }}
           - name: MLRUN_HTTPDB__DB_TYPE

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -182,9 +182,22 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.api.affinity }}
+    {{- if .Values.api.chief.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.api.chief.affinity | nindent 8 }}
+    {{- else if .Values.api.affinity }}
+      affinity:
+        {{- toYaml .Values.api.affinity | nindent 8 }}
+    {{- else }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    {{- include "mlrun.api.selectorLabels" . | nindent 20 }}
+                topologyKey: "kubernetes.io/hostname"
     {{- end }}
     {{- with .Values.api.tolerations }}
       tolerations:

--- a/stable/mlrun/templates/api-chief-ingress.yaml
+++ b/stable/mlrun/templates/api-chief-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.api.worker.minReplicas -}}
 {{- if .Values.api.chief.ingress.enabled -}}
 {{- $fullName := include "mlrun.api.chief.fullname" . -}}
 {{- $svcPort := .Values.api.chief.service.port -}}
@@ -38,4 +39,5 @@ spec:
               servicePort: {{ $svcPort }}
         {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/stable/mlrun/templates/api-chief-ingress.yaml
+++ b/stable/mlrun/templates/api-chief-ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.api.chief.ingress.enabled -}}
+{{- $fullName := include "mlrun.api.chief.fullname" . -}}
+{{- $svcPort := .Values.api.chief.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "mlrun.api.chief.labels" . | nindent 4 }}
+  {{- with .Values.api.chief.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.api.chief.ingress.tls }}
+  tls:
+  {{- range .Values.api.chief.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.api.chief.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/stable/mlrun/templates/api-chief-service.yaml
+++ b/stable/mlrun/templates/api-chief-service.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.api.worker.minReplicas -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mlrun.api.chief.fullname" . }}
+  labels:
+    {{- include "mlrun.api.chief.labels" . | nindent 4 }}
+spec:
+{{- if (or (eq .Values.api.chief.service.type "ClusterIP") (empty .Values.api.chief.service.type)) }}
+  type: ClusterIP
+  {{- if .Values.api.chief.service.clusterIP }}
+  clusterIP: {{ .Values.api.chief.service.clusterIP }}
+  {{end}}
+{{- else if eq .Values.api.chief.service.type "LoadBalancer" }}
+  type: {{ .Values.api.chief.service.type }}
+  {{- if .Values.api.chief.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.api.chief.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.api.chief.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.api.chief.service.loadBalancerSourceRanges | indent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.api.chief.service.type }}
+{{- end }}
+{{- if .Values.api.chief.service.externalIPs }}
+  externalIPs:
+{{ toYaml .Values.api.chief.service.externalIPs | indent 4 }}
+{{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.api.chief.service.port }}
+      protocol: TCP
+      targetPort: http
+{{ if (and (eq .Values.api.chief.service.type "NodePort") (not (empty .Values.api.chief.service.nodePort))) }}
+      nodePort: {{.Values.api.chief.service.nodePort}}
+{{ end }}
+  selector:
+    {{- include "mlrun.api.chief.selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -1,0 +1,191 @@
+{{- if .Values.api.worker.minReplicas -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mlrun.api.worker.fullname" . }}
+  labels:
+    {{- include "mlrun.api.worker.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.api.worker.minReplicas }}
+  selector:
+    matchLabels:
+      {{- include "mlrun.api.worker.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mlrun.api.worker.selectorLabels" . | nindent 8 }}
+    spec:
+    {{- with .Values.api.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "mlrun.serviceAccountName.api" . }}
+      securityContext:
+        {{- toYaml .Values.api.podSecurityContext | nindent 8 }}
+      {{- if .Values.api.extraInitContainers }}
+      initContainers:
+        {{- toYaml .Values.api.extraInitContainers | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ template "mlrun.name" . }}-{{ .Values.api.name }}
+          securityContext:
+            {{- toYaml .Values.api.securityContext | nindent 12 }}
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+          - name: MLRUN_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: MLRUN_HTTPDB__CLUSTERIZATION__ROLE
+            value: "worker"
+          - name: MLRUN_LOG_LEVEL
+            value: {{ .Values.api.logLevel }}
+          - name: MLRUN_HTTPDB__DB_TYPE
+            {{- if or (eq .Values.httpDB.dbType "mysql") (eq .Values.httpDB.dbType "sqlite") }}
+            value: "sqldb"
+            {{- else }}
+            value: "filedb"
+            {{- end }}
+          - name: MLRUN_HTTPDB__API_URL
+            value: http://{{ include "mlrun.api.fullname" . }}:{{ .Values.api.service.port }}
+          - name: MLRUN_HTTPDB__DIRPATH
+            value: {{ .Values.httpDB.dirPath }}
+          # DEFAULT_DOCKER_REGISTRY & DEFAULT_DOCKER_SECRET are for BC to run 0.5.x chart with 0.5.x MLRun
+          # When mlrun-kit starts using 0.6.x MLRun this can be removed
+          - name: DEFAULT_DOCKER_REGISTRY
+            value: {{ template "mlrun.defaultDockerRegistry.url" . }}
+          - name: DEFAULT_DOCKER_SECRET
+            value: {{ template "mlrun.defaultDockerRegistry.secretName" . }}
+          - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
+            value: {{ template "mlrun.defaultDockerRegistry.url" . }}
+          - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET
+            value: {{ template "mlrun.defaultDockerRegistry.secretName" . }}
+          - name: MLRUN_HTTPDB__DSN
+            value: {{ .Values.httpDB.dsn }}
+          - name: MLRUN_HTTPDB__OLD_DSN
+            value: {{ .Values.httpDB.oldDsn }}
+          {{- if .Values.v3io.enabled }}
+          - name: V3IO_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Release.Name }}-v3io-fuse
+                key: accessKey
+          - name: V3IO_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Release.Name }}-v3io-fuse
+                key: username
+          {{- end }}
+          - name: MLRUN_NUCLIO_MODE
+            value: {{ .Values.nuclio.mode }}
+          {{- if eq .Values.nuclio.mode "enabled" }}
+          - name: MLRUN_NUCLIO_DASHBOARD_URL
+            value: {{ template "mlrun.nuclio.apiURL" . }}
+          {{- end }}
+          {{- if .Values.api.extraEnv }}
+          {{ toYaml .Values.api.extraEnv | nindent 10 }}
+          {{- end }}
+          {{- if .Values.api.extraEnvKeyValue }}
+          {{- range $name, $value := .Values.api.extraEnvKeyValue }}
+          - name: {{ $name }}
+            value: {{ $value | quote }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.api.envFrom }}
+          envFrom:
+          {{ toYaml .Values.api.envFrom | nindent 10 }}
+          {{- end }}
+          {{- if .Values.api.livenessProbe }}
+          livenessProbe:
+            {{ toYaml .Values.api.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.api.readinessProbe }}
+          readinessProbe:
+            {{ toYaml .Values.api.readinessProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+          volumeMounts:
+            - name: storage
+              mountPath: {{ .Values.httpDB.dirPath }}
+            {{- range .Values.api.extraPersistentVolumeMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath | default "" }}
+              readOnly: {{ .readOnly }}
+            {{- end }}
+        {{- if .Values.api.opa.enabled }}
+        - name: {{ template "mlrun.name" . }}-{{ .Values.api.opa.name }}
+          securityContext:
+            {{- toYaml .Values.api.opa.securityContext | nindent 12 }}
+          image: "{{ .Values.api.opa.image.repository }}:{{ .Values.api.opa.image.tag }}"
+          imagePullPolicy: {{ .Values.api.opa.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8181
+          {{- if .Values.api.opa.livenessProbe }}
+          livenessProbe:
+            {{ toYaml .Values.api.opa.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.api.opa.readinessProbe }}
+          readinessProbe:
+            {{ toYaml .Values.api.opa.readinessProbe | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.api.opa.resources | nindent 12 }}
+          args:
+            - "run"
+            - "--server"
+            - "--config-file=/config/config.yaml"
+            - "--log-level={{ .Values.api.opa.logLevel }}"
+            - "--log-format={{ .Values.api.opa.logFormat }}"
+            - "--ignore=.*"
+          volumeMounts:
+            - readOnly: true
+              mountPath: /config
+              name: config
+        {{- end }}
+      volumes:
+        - name: storage
+          {{- if .Values.api.volumes.storageOverride }}
+          {{- toYaml .Values.api.volumes.storageOverride | nindent 10 }}
+          {{- else }}
+          flexVolume:
+            driver: "v3io/fuse"
+            options:
+              container: users
+              subPath: /{{ .Values.v3io.username }}/.mlrun
+            secretRef:
+              name: {{ .Release.Name }}-v3io-fuse
+          {{- end }}
+        {{- range .Values.api.extraPersistentVolumeMounts }}
+        - name: {{ .name }}
+          persistentVolumeClaim:
+            claimName: {{ .existingClaim }}
+        {{- end }}
+        {{- if .Values.api.opa.enabled }}
+        - name: config
+          secret:
+            secretName: {{ template "mlrun.api.opa.fullname" . }}
+        {{- end }}
+      {{- with .Values.api.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.api.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.api.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- if .Values.api.priorityClassName }}
+      priorityClassName: {{ .Values.api.priorityClassName | quote }}
+    {{- end }}
+{{- end -}}

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -177,9 +177,22 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.api.affinity }}
+    {{- if .Values.api.worker.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.api.worker.affinity | nindent 8 }}
+    {{- else if .Values.api.affinity }}
+      affinity:
+        {{- toYaml .Values.api.affinity | nindent 8 }}
+    {{- else }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    {{- include "mlrun.api.selectorLabels" . | nindent 20 }}
+                topologyKey: "kubernetes.io/hostname"
     {{- end }}
     {{- with .Values.api.tolerations }}
       tolerations:

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -8,11 +8,36 @@ api:
 
   logLevel: INFO
 
-  replicaCount: 1
+  chief:
+    fullnameOverride:
+    # auto-scaling is currently not supported and the min value is treated as the fixed value
+    minReplicas: 1
+
+    service:
+      type: ClusterIP
+      port: 8080
+      targetPort: 8080
+
+    ingress:
+      enabled: false
+      annotations: { }
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+      hosts:
+        - host: chart-example.local
+          paths: [ ]
+      tls: [ ]
+      #  - secretName: chart-example-tls
+      #    hosts:
+      #      - chart-example.local
+  worker:
+    fullnameOverride:
+    # auto-scaling is currently not supported and the min value is treated as the fixed value
+    minReplicas: 0
 
   image:
     repository: mlrun/mlrun-api
-    tag: 0.7.0
+    tag: 1.0.1
     pullPolicy: IfNotPresent
     pullSecrets: []
 
@@ -343,7 +368,7 @@ ui:
 
   image:
     repository: mlrun/mlrun-ui
-    tag: 0.7.0
+    tag: 1.0.1
     pullPolicy: IfNotPresent
     pullSecrets: []
 

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -33,7 +33,7 @@ api:
   worker:
     fullnameOverride:
     # auto-scaling is currently not supported and the min value is treated as the fixed value
-    minReplicas: 0
+    minReplicas: 1
 
   image:
     repository: mlrun/mlrun-api

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -30,14 +30,31 @@ api:
       #  - secretName: chart-example-tls
       #    hosts:
       #      - chart-example.local
+
+    ## Affinity for pod assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ##
+    # Setting the affinity here has precedence over api.affinity
+    # Note that by default we're assigning affinity to make the chief/worker pods to run on different nodes, if you're
+    # overriding the affinity it's your responsibility to keep applying this behavior
+    affinity: { }
+
   worker:
     fullnameOverride:
     # auto-scaling is currently not supported and the min value is treated as the fixed value
     minReplicas: 1
 
+    ## Affinity for pod assignment
+    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ##
+    # Setting the affinity here has precedence over api.affinity
+    # Note that by default we're assigning affinity to make the chief/worker pods to run on different nodes, if you're
+    # overriding the affinity it's your responsibility to keep applying this behavior
+    affinity: { }
+
   image:
     repository: mlrun/mlrun-api
-    tag: 1.0.1
+    tag: 1.0.4
     pullPolicy: IfNotPresent
     pullSecrets: []
 
@@ -99,6 +116,10 @@ api:
   ## Affinity for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ##
+  # Setting the affinity here will apply to both the chief and worker deployments, the specific affinity fields
+  # (api.chief/worker.affinity) has precedence over this on.
+  # Note that by default we're assigning affinity to make the chief/worker pods to run on different nodes, if you're
+  # overriding the affinity it's your responsibility to keep applying this behavior
   affinity: {}
 
   priorityClassName: ""
@@ -368,7 +389,7 @@ ui:
 
   image:
     repository: mlrun/mlrun-ui
-    tag: 1.0.1
+    tag: 1.0.4
     pullPolicy: IfNotPresent
     pullSecrets: []
 

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -54,7 +54,7 @@ api:
 
   image:
     repository: mlrun/mlrun-api
-    tag: 1.0.4
+    tag: 0.7.0
     pullPolicy: IfNotPresent
     pullSecrets: []
 
@@ -389,7 +389,7 @@ ui:
 
   image:
     repository: mlrun/mlrun-ui
-    tag: 1.0.4
+    tag: 0.7.0
     pullPolicy: IfNotPresent
     pullSecrets: []
 


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Backport of:
* https://github.com/v3io/helm-charts/pull/738
* https://github.com/v3io/helm-charts/pull/743
* https://github.com/v3io/helm-charts/pull/778

Plus setting the default min replicas to 1 (since it can't be configured from `app_services.yaml` in 3.2.x)