### PR TITLE
[Presto] Add host path volume support [integ_3.4]

### DIFF
--- a/stable/presto/Chart.yaml
+++ b/stable/presto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: ">=2.0.0"
 description: Presto is a distributed SQL query engine for big data
 name: presto
-version: 0.14.9
+version: 0.14.10
 home: https://prestosql.io/
 icon: https://prestosql.io/assets/presto.png
 sources:

--- a/stable/presto/templates/worker-deployment.yaml
+++ b/stable/presto/templates/worker-deployment.yaml
@@ -38,6 +38,16 @@ spec:
         - name: third-party-volume
           hostPath:
             path: "/home/iguazio/igz/bigdata/libs/third-party"
+{{- if .Values.server.properties.hostPathVolumes }}
+{{- $i := 0 | int }}
+{{- range $hostPath, $mountPath := .Values.server.properties.hostPathVolumes}}
+        - name: {{ $volumeName := print "host-path-volume-" $i }}{{ $volumeName }}
+          hostPath:
+            path: {{ $hostPath }}
+            type: Directory
+{{- $i = add1 $i }}
+{{- end }}
+{{- end }}
 {{- if .Values.server.properties.spillPath }}
 {{- $spillPaths := splitList "," .Values.server.properties.spillPath }}
 {{- range $index, $path := $spillPaths}}
@@ -96,6 +106,14 @@ spec:
 {{- if .Values.server.properties.https }}
             - mountPath: /var/run/iguazio/java/cert
               name: java-cert
+{{- end }}
+{{- if .Values.server.properties.hostPathVolumes }}
+{{- $i := 0 | int }}
+{{- range $hostPath, $mountPath := .Values.server.properties.hostPathVolumes}}
+            - mountPath: {{ $mountPath }}
+              name: {{ $mountName := print "host-path-volume-" $i }}{{ $mountName }}
+{{- $i = add1 $i }}
+{{- end }}
 {{- end }}
 {{- if .Values.server.properties.spillPath }}
 {{- $spillMountPaths := splitList "," .Values.server.properties.spillMountPath }}

--- a/stable/presto/values.yaml
+++ b/stable/presto/values.yaml
@@ -61,6 +61,8 @@ server:
       maxTotalMemoryPerNode: "4GB"
     spillPath: ""
     spillMountPath: ""
+#    hostPathVolumes:
+#      pathOnHost: pathOnContainer
   catalog:
 hive:
   hostname: hive


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Add support of host path volume map in Trino:
Create hostPath volumes in trino's worker deployment, according the the values in hostPathVolumes.

Related PRs:
Schemas: https://github.com/iguazio/zebo/pull/5929
Zebo: https://github.com/iguazio/zebo/pull/5929
Provazio: https://github.com/iguazio/provazio/pull/2534

JIRA: https://jira.iguazeng.com/browse/IG-20849