### PR TITLE
[mlrun] Fix runAsUser in DB and Fix ui service to use .values

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.8.5
+version: 0.8.6
 appVersion: 1.0.4
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.8.4
+version: 0.8.5
 appVersion: 1.0.4
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/_helpers.tpl
+++ b/stable/mlrun/templates/_helpers.tpl
@@ -192,6 +192,18 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{/*
+DB run user
+*/}}
+{{- define "mlrun.db.DBRunUser" -}}
+{{- if .Values.db.podSecurityContext.runAsUser }}
+{{- .Values.db.podSecurityContext.runAsUser -}}
+{{- else -}}
+{{- print "root" -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
 Common selector labels
 */}}
 {{- define "mlrun.common.selectorLabels" -}}

--- a/stable/mlrun/templates/db-configmap.yaml
+++ b/stable/mlrun/templates/db-configmap.yaml
@@ -11,8 +11,8 @@ data:
     mysql -u root -S /var/run/mysqld/mysql.sock -e 'SELECT 1'
 
   graceful_shutdown.sh: |
-    mysql -S /var/run/mysqld/mysql.sock -e 'SET GLOBAL innodb_fast_shutdown = 0; FLUSH TABLES WITH READ LOCK;'
-    mysqladmin -S /var/run/mysqld/mysql.sock shutdown
+    mysql -u root -S /var/run/mysqld/mysql.sock -e 'SET GLOBAL innodb_fast_shutdown = 0; FLUSH TABLES WITH READ LOCK;'
+    mysqladmin -u root -S /var/run/mysqld/mysql.sock shutdown
 
   init-v3io-mysql.sh: |
     #!/usr/bin/env bash
@@ -26,7 +26,7 @@ data:
     else
       echo "Initializing MySQL..."
 
-      mysqld --initialize-insecure --user={{- .Values.db.securityContext.runAsUser }} --basedir=/usr --datadir=/tmp/mysql
+      mysqld --initialize-insecure --user={{- include "mlrun.db.DBRunUser" . }} --basedir=/usr --datadir=/tmp/mysql
       # and then copy the init files into real working directory (on Fuse mount)
       cp -R /tmp/mysql /var/lib/
 
@@ -46,7 +46,7 @@ data:
     
     # TODO: review the innodb flags, they might not be needed anymore
     mysqld \
-      --user={{- .Values.db.securityContext.runAsUser }} \
+      --user={{- include "mlrun.db.DBRunUser" . }} \
       --sql_mode="" \
       --init-file=$INIT_SCRIPT \
       --innodb-adaptive-hash-index=0 \

--- a/stable/mlrun/templates/ui-service.yaml
+++ b/stable/mlrun/templates/ui-service.yaml
@@ -30,7 +30,7 @@ spec:
     - name: http
       port: {{ .Values.ui.service.port }}
       protocol: TCP
-      targetPort: http
+      targetPort: {{ .Values.ui.service.targetPort }}
 {{ if (and (eq .Values.ui.service.type "NodePort") (not (empty .Values.ui.service.nodePort))) }}
       nodePort: {{.Values.ui.service.nodePort}}
 {{ end }}

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -124,8 +124,8 @@ api:
 
   priorityClassName: ""
 
-  podSecurityContext: {}
-  # fsGroup: 2000
+  podSecurityContext:
+    runAsUser: 1000
 
   securityContext: {}
     # capabilities:
@@ -287,11 +287,10 @@ db:
 
   priorityClassName: ""
 
-  podSecurityContext: {}
-  # fsGroup: 2000
-
-  securityContext:
+  podSecurityContext:
     runAsUser: 1001
+
+  securityContext: {}
     # capabilities:
     #   drop:
     #   - ALL
@@ -401,7 +400,7 @@ ui:
   service:
     type: ClusterIP
     port: 80
-    targetPort: 8080
+    targetPort: http
 
   ingress:
     enabled: false
@@ -447,8 +446,11 @@ ui:
 
   priorityClassName: ""
 
-  podSecurityContext: {}
-  # fsGroup: 2000
+  podSecurityContext:
+    # default UID & GID of unprivileged nginx image
+    # https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-alpine.template
+    runAsUser: 101
+    runAsGroup: 101
 
   securityContext: {}
     # capabilities:

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -124,9 +124,10 @@ api:
 
   priorityClassName: ""
 
-  securityContext: {}
-
   podSecurityContext: {}
+  # runAsUser: 1000
+
+  securityContext: {}
     # capabilities:
     #   drop:
     #   - ALL
@@ -445,15 +446,13 @@ ui:
 
   priorityClassName: ""
 
-
-  securityContext: {}
-
   podSecurityContext: {}
     # default UID & GID of unprivileged nginx image
     # https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-alpine.template
     # runAsUser: 101
     # runAsGroup: 101
 
+  securityContext: {}
     # capabilities:
     #   drop:
     #   - ALL

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -447,10 +447,10 @@ ui:
   priorityClassName: ""
 
   podSecurityContext: {}
-    # default UID & GID of unprivileged nginx image
-    # https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-alpine.template
-    # runAsUser: 101
-    # runAsGroup: 101
+  # default UID & GID of unprivileged nginx image
+  # https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-alpine.template
+  # runAsUser: 101
+  # runAsGroup: 101
 
   securityContext: {}
     # capabilities:

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -124,10 +124,9 @@ api:
 
   priorityClassName: ""
 
-  podSecurityContext:
-    runAsUser: 1000
-
   securityContext: {}
+
+  podSecurityContext: {}
     # capabilities:
     #   drop:
     #   - ALL
@@ -446,13 +445,15 @@ ui:
 
   priorityClassName: ""
 
-  podSecurityContext:
-    # default UID & GID of unprivileged nginx image
-    # https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-alpine.template
-    runAsUser: 101
-    runAsGroup: 101
 
   securityContext: {}
+
+  podSecurityContext: {}
+    # default UID & GID of unprivileged nginx image
+    # https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-alpine.template
+    # runAsUser: 101
+    # runAsGroup: 101
+
     # capabilities:
     #   drop:
     #   - ALL

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -401,7 +401,7 @@ ui:
   service:
     type: ClusterIP
     port: 80
-    targetPort: 80
+    targetPort: 8080
 
   ingress:
     enabled: false


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
Added security context for each deployment
Changed ui deployment ports