### PR TITLE
[mlrun] Add resolution for ui deployment port and validation for chief & worker

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.8.7
+version: 0.8.8
 appVersion: 1.0.4
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/_helpers.tpl
+++ b/stable/mlrun/templates/_helpers.tpl
@@ -202,6 +202,16 @@ DB run user
 {{- end -}}
 {{- end -}}
 
+{{/*
+UI container port
+*/}}
+{{- define "mlrun.ui.HTTPContainerPort" -}}
+{{- if semverCompare ">1.0.4" .Values.ui.image.tag -}}
+{{- print "8090" -}}
+{{- else -}}
+{{- print "80" -}}
+{{- end -}}
+{{- end -}}
 
 {{/*
 Common selector labels

--- a/stable/mlrun/templates/api-chief-ingress.yaml
+++ b/stable/mlrun/templates/api-chief-ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.api.worker.minReplicas -}}
+{{- if semverCompare ">=1.1.0" .Values.api.image.tag -}}
 {{- if .Values.api.chief.ingress.enabled -}}
 {{- $fullName := include "mlrun.api.chief.fullname" . -}}
 {{- $svcPort := .Values.api.chief.service.port -}}
@@ -39,5 +40,6 @@ spec:
               servicePort: {{ $svcPort }}
         {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/stable/mlrun/templates/api-chief-service.yaml
+++ b/stable/mlrun/templates/api-chief-service.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.api.worker.minReplicas -}}
+{{- if semverCompare ">=1.1.0" .Values.api.image.tag -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -37,4 +38,5 @@ spec:
 {{ end }}
   selector:
     {{- include "mlrun.api.chief.selectorLabels" . | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.api.worker.minReplicas -}}
+{{- if semverCompare ">=1.1.0" .Values.api.image.tag -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -205,4 +206,5 @@ spec:
     {{- if .Values.api.priorityClassName }}
       priorityClassName: {{ .Values.api.priorityClassName | quote }}
     {{- end }}
+{{- end -}}
 {{- end -}}

--- a/stable/mlrun/templates/ui-deployment.yaml
+++ b/stable/mlrun/templates/ui-deployment.yaml
@@ -32,7 +32,7 @@ spec:
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.ui.ports.HTTPContainerPort }}
               protocol: TCP
           env:
           - name: MLRUN_API_PROXY_URL

--- a/stable/mlrun/templates/ui-deployment.yaml
+++ b/stable/mlrun/templates/ui-deployment.yaml
@@ -32,7 +32,7 @@ spec:
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.ui.ports.HTTPContainerPort }}
+              containerPort: {{ include "mlrun.ui.HTTPContainerPort" . }}
               protocol: TCP
           env:
           - name: MLRUN_API_PROXY_URL

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -474,6 +474,9 @@ ui:
   # runAsUser: 101
   # runAsGroup: 101
 
+  ports:
+    HTTPContainerPort: 80
+
   securityContext: {}
     # capabilities:
     #   drop:

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -474,9 +474,6 @@ ui:
   # runAsUser: 101
   # runAsGroup: 101
 
-  ports:
-    HTTPContainerPort: 80
-
   securityContext: {}
     # capabilities:
     #   drop:


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
From mlrun 1.0.5 we are adding the option for mlrun to run as non root user which comes with constraints such as we can't expose port between 0-1024. So I've added self resolution for which port to expose depending on the mlrun version.

Also from 1.1.0 we are introducing chief-worker architecture, part of it we are creating deployments for chief and worker where the default is 1 worker 1 chief, I found a bug which when we were running with versions greater than igz 3.5 with 1.0.4 version by default ( because 1.1.0 is not released yet ) the helm chart created both chief and worker which is problematic because chief-worker support was added in MLRun itself only in 1.1.0. So I've added another validation which checks if the version is greater or equal than 1.1.0 