### PR TITLE
[mlrun-kit] MLRun CE Bug Fixes + Added Extra Info

### DIFF
--- a/stable/mlrun-kit/Chart.yaml
+++ b/stable/mlrun-kit/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.5.0-rc.3
+version: 0.5.0-rc.4
 name: mlrun-kit
 description: MLRUn Open Source Stack
 home: https://iguazio.com
@@ -8,3 +8,5 @@ sources: []
 maintainers:
   - name: Adam Melnick
     email: adamm@iguazio.com
+  - name: Eliyahu Noach
+    email: eliyahun@iguazio.com

--- a/stable/mlrun-kit/requirements.lock
+++ b/stable/mlrun-kit/requirements.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 0.14.0
 - name: mlrun
   repository: https://v3io.github.io/helm-charts/stable
-  version: 0.8.7
+  version: 0.9.0
 - name: mpi-operator
   repository: https://v3io.github.io/helm-charts/stable
   version: 0.6.0
 - name: minio
   repository: https://charts.min.io/
   version: 4.0.2
-digest: sha256:b142275b04d47310ad79446cff2acc3aea55a81ddeca624d12afb7158b77572c
-generated: "2022-07-14T16:32:49.61652203+03:00"
+digest: sha256:94f294dab7138494c11c8d3392df89274d53c9bcda2a6f8e7c2f6815a7a070ec
+generated: "2022-07-20T19:22:11.429372+03:00"

--- a/stable/mlrun-kit/requirements.yaml
+++ b/stable/mlrun-kit/requirements.yaml
@@ -3,7 +3,7 @@ dependencies:
   version: "0.14.0"
   repository: "https://nuclio.github.io/nuclio/charts"
 - name: mlrun
-  version: "0.8.7"
+  version: "0.9.0"
   repository: "https://v3io.github.io/helm-charts/stable"
 - name: mpi-operator
   version: "0.6.0"

--- a/stable/mlrun-kit/templates/NOTES.txt
+++ b/stable/mlrun-kit/templates/NOTES.txt
@@ -20,5 +20,9 @@ You're up and running !
 6. Minio UI is available at:
   http://{{ .Values.global.externalHostAddress }}:{{ .Values.minio.consoleService.nodePort }}
 
+  Credentials:
+    username: {{ .Values.minio.rootUser }}
+    password: {{ .Values.minio.rootPassword }}
+
 {{- end }}
 Happy MLOPSing !!! :]

--- a/stable/mlrun-kit/templates/jupyter-notebook/deployment.yaml
+++ b/stable/mlrun-kit/templates/jupyter-notebook/deployment.yaml
@@ -57,6 +57,9 @@ spec:
           value: "yes"
         - name: CHOWN_HOME_OPTS
           value: "-R"
+        {{- if .Values.jupyterNotebook.extraEnv }}
+        {{ toYaml .Values.jupyterNotebook.extraEnv | nindent 8 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /home/jovyan/data
           name: notebooks

--- a/stable/mlrun-kit/values.yaml
+++ b/stable/mlrun-kit/values.yaml
@@ -174,6 +174,11 @@ jupyterNotebook:
   # use this to override mlrunUIURL, by default it will be auto-resolved to externalHostAddress and
   # mlrun UI's node port
   mlrunUIURL:
+
+  extraEnv:
+    - name: MLRUN_ARTIFACT_PATH
+      value: s3://mlrun/
+
   persistence:
     enabled: true
     existingClaim:


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
- Pull latest MLRun chart to fix mlrun-ui being inaccessible
- Added `MLRUN_ARTIFACT_PATH` to jupyter env, so it will point correctly to the minio
- Printing Minio Credentials when installing the helm chart so user can know how to access it
- Added @eliyahu77 as maintainer of the chart