### PR TITLE
[mlrun-kit] Fix Multiple Env Var for jupyter `MLRUN_ARTIFACT_PATH`

### DIFF
--- a/stable/mlrun-kit/Chart.yaml
+++ b/stable/mlrun-kit/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.5.0-rc.4
+version: 0.5.0-rc.5
 name: mlrun-kit
 description: MLRUn Open Source Stack
 home: https://iguazio.com

--- a/stable/mlrun-kit/templates/jupyter-notebook/deployment.yaml
+++ b/stable/mlrun-kit/templates/jupyter-notebook/deployment.yaml
@@ -47,8 +47,6 @@ spec:
           value: {{ template "mlrun-kit.jupyter.mlrunUIURL" . }}
         - name: MLRUN_MPIJOB_CRD_VERSION
           value: {{ index .Values "mpi-operator" "crd" "version" }}
-        - name: MLRUN_ARTIFACT_PATH
-          value: "/home/jovyan/data"
 {{- if  .Values.jupyterNotebook.persistence.enabled }}
         - name: MLRUN_PVC_MOUNT
           value: {{ printf "%s:/home/jovyan/data" (include "mlrun-kit.jupyter.fullname" .) }}


### PR DESCRIPTION
### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description:
`MLRUN_ARTIFACT_PATH` for jupyter is now set in the `values.yml`. removing it from the deployment as it is a duplicate.