### PR TITLE
[CI] Finish Publish Helm Chart Workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,7 @@
 [Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]
 - [ ] Chart Version bumped
 - [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
+- [ ] **If the PR adds a new chart requirement**, the requirement is added to `./hack/scripts/ci/helm_repo_add.sh`
 
 ### Description:
 [Please add a description of the change request.]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,12 @@ jobs:
 
       - uses: actions/checkout@v2
 
+      - name: Get latest chart dependencies
+        run: |
+          cd stable/${{ github.event.inputs.chart_name }}
+          helm dependency update
+          cd -
+
       - name: Build & push to github pages
         run: |
           CHART_NAME=${{ github.event.inputs.chart_name }} make helm-publish-stable-specific-v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Configure Git
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
+          git config --global user.name "${{ github.actor }}"
 
       - name: Get latest chart dependencies
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,11 +29,6 @@ jobs:
           helm dependency update
           cd -
 
-      - name: Configure Git
-        run: |
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-
       - name: Build & push to github pages
         run: |
-          CHART_NAME=${{ github.event.inputs.chart_name }} make helm-publish-stable-specific-v2
+          CHART_NAME=${{ github.event.inputs.chart_name }} PUBLISH_CREDS=${{ github.actor }}:${{ github.token }} make helm-publish-stable-specific-v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,11 @@ jobs:
           chmod +x "${GITHUB_WORKSPACE}/hack/scripts/ci/helm_repo_add.sh"
           "${GITHUB_WORKSPACE}/hack/scripts/ci/helm_repo_add.sh"
 
+      - name: Configure Git
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
       - name: Get latest chart dependencies
         run: |
           cd stable/${{ github.event.inputs.chart_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,22 +18,18 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Add helm repos
+      - name: Add Helm Repos
         run: |
           chmod +x "${GITHUB_WORKSPACE}/hack/scripts/ci/helm_repo_add.sh"
           "${GITHUB_WORKSPACE}/hack/scripts/ci/helm_repo_add.sh"
 
-      - name: Configure Git
+      - name: Configure Git Author as Workflow Actor
         run: |
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
           git config --global user.name "${{ github.actor }}"
 
-      - name: Get latest chart dependencies
+      - name: Build Helm Chart & Push to Github Pages
         run: |
-          cd stable/${{ github.event.inputs.chart_name }}
-          helm dependency update
-          cd -
-
-      - name: Build & push to github pages
-        run: |
-          CHART_NAME=${{ github.event.inputs.chart_name }} PUBLISH_CREDS=${{ github.actor }}:${{ github.token }} make helm-publish-stable-specific-v2
+          export CHART_NAME=${{ github.event.inputs.chart_name }}
+          export PUBLISH_CREDS=${{ github.actor }}:${{ github.token }}
+          make helm-publish-stable-specific-v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,11 @@ jobs:
           helm dependency update
           cd -
 
+      - name: Configure Git
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
       - name: Build & push to github pages
         run: |
           CHART_NAME=${{ github.event.inputs.chart_name }} make helm-publish-stable-specific-v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,11 @@ jobs:
 
       - uses: actions/checkout@v2
 
+      - name: Add helm repos
+        run: |
+          chmod +x "${GITHUB_WORKSPACE}/hack/scripts/ci/helm_repo_add.sh"
+          "${GITHUB_WORKSPACE}/hack/scripts/ci/helm_repo_add.sh"
+
       - name: Get latest chart dependencies
         run: |
           cd stable/${{ github.event.inputs.chart_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
           git config --global user.name "${{ github.actor }}"
 
       - name: Get latest chart dependencies

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ helm-publish-incubator-specific: cleanup-tmp-workspace
 .PHONY: helm-publish-stable-specific-v2
 helm-publish-stable-specific-v2: cleanup-tmp-workspace
 helm-publish-stable-specific-v2:
-	@echo "Preparing to release a new stable index for $(CHART_NAME) from $(GITHUB_BRANCH)"
+	@echo "Preparing to release a new stable index for $(CHART_NAME) from $(GITHUB_BRANCH) ($(PUBLISH_REPO))"
 	@git clone -b gh-pages --single-branch $(PUBLISH_REPO) /tmp/v3io-helm-charts
 	@INDEX_DIR=/tmp/v3io-helm-charts HELM_PACKAGE_ARGS="-d /tmp/v3io-helm-charts/stable" make stable-specific
 	@REF_SHA=$$(git rev-parse HEAD) && \

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ helm-publish-incubator-specific: cleanup-tmp-workspace
 .PHONY: helm-publish-stable-specific-v2
 helm-publish-stable-specific-v2: cleanup-tmp-workspace
 helm-publish-stable-specific-v2:
-	@echo "Preparing to release a new stable index for $(CHART_NAME) from $(GITHUB_BRANCH) ($(PUBLISH_REPO))"
+	@echo "Preparing to release a new stable index for $(CHART_NAME) from $(GITHUB_BRANCH)"
 	@git clone -b gh-pages --single-branch $(PUBLISH_REPO) /tmp/v3io-helm-charts
 	@INDEX_DIR=/tmp/v3io-helm-charts HELM_PACKAGE_ARGS="-d /tmp/v3io-helm-charts/stable" make stable-specific
 	@REF_SHA=$$(git rev-parse HEAD) && \

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ helm-publish-incubator-specific: cleanup-tmp-workspace
 helm-publish-stable-specific-v2: cleanup-tmp-workspace
 helm-publish-stable-specific-v2:
 	@echo "Preparing to release a new stable index for $(CHART_NAME) from $(GITHUB_BRANCH)"
-	@git clone -b gh-pages --single-branch git@github.com:v3io/helm-charts /tmp/v3io-helm-charts
+	@git clone -b gh-pages --single-branch https://github.com/quaark/helm-charts.git /tmp/v3io-helm-charts
 	@INDEX_DIR=/tmp/v3io-helm-charts HELM_PACKAGE_ARGS="-d /tmp/v3io-helm-charts/stable" make stable-specific
 	@REF_SHA=$$(git rev-parse HEAD) && \
 		cd /tmp/v3io-helm-charts && \

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ INDEX_DIR ?=
 HELM_REPO := $(HELM_REPO_ROOT)/$(WORKDIR)
 CHART_NAME := $(if $(CHART_NAME),$(CHART_NAME),chart-name)
 CHART_VERSION_OVERRIDE := $(if $(CHART_VERSION_OVERRIDE),$(CHART_VERSION_OVERRIDE),none)
+PUBLISH_REPO := $(if $(PUBLISH_CREDS),https://$(PUBLISH_CREDS)@github.com/quaark/helm-charts.git,git@github.com:v3io/helm-charts)
 
 
 #### Some examples:
@@ -151,7 +152,7 @@ helm-publish-incubator-specific: cleanup-tmp-workspace
 helm-publish-stable-specific-v2: cleanup-tmp-workspace
 helm-publish-stable-specific-v2:
 	@echo "Preparing to release a new stable index for $(CHART_NAME) from $(GITHUB_BRANCH)"
-	@git clone -b gh-pages --single-branch https://github.com/quaark/helm-charts.git /tmp/v3io-helm-charts
+	@git clone -b gh-pages --single-branch $(PUBLISH_REPO) /tmp/v3io-helm-charts
 	@INDEX_DIR=/tmp/v3io-helm-charts HELM_PACKAGE_ARGS="-d /tmp/v3io-helm-charts/stable" make stable-specific
 	@REF_SHA=$$(git rev-parse HEAD) && \
 		cd /tmp/v3io-helm-charts && \

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ INDEX_DIR ?=
 HELM_REPO := $(HELM_REPO_ROOT)/$(WORKDIR)
 CHART_NAME := $(if $(CHART_NAME),$(CHART_NAME),chart-name)
 CHART_VERSION_OVERRIDE := $(if $(CHART_VERSION_OVERRIDE),$(CHART_VERSION_OVERRIDE),none)
-PUBLISH_REPO := $(if $(PUBLISH_CREDS),https://$(PUBLISH_CREDS)@github.com/quaark/helm-charts.git,git@github.com:v3io/helm-charts)
+PUBLISH_REPO := $(if $(PUBLISH_CREDS),https://$(PUBLISH_CREDS)@github.com/v3io/helm-charts.git,git@github.com:v3io/helm-charts)
 
 
 #### Some examples:

--- a/hack/scripts/ci/helm_repo_add.sh
+++ b/hack/scripts/ci/helm_repo_add.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/bash
 
 declare -A REPOS=(
   [helm]=https://charts.helm.sh/stable

--- a/hack/scripts/ci/helm_repo_add.sh
+++ b/hack/scripts/ci/helm_repo_add.sh
@@ -8,5 +8,5 @@ declare -A REPOS=(
 )
 
 for repo in "${!REPOS[@]}"; do
-  echo helm repo add "$repo" "${REPOS[$repo]}"
+  helm repo add "$repo" "${REPOS[$repo]}"
 done

--- a/hack/scripts/ci/helm_repo_add.sh
+++ b/hack/scripts/ci/helm_repo_add.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+declare -A REPOS=(
+  [helm]=https://charts.helm.sh/stable
+  [nuclio]=https://nuclio.github.io/nuclio/charts
+  [v3io-stable]=https://v3io.github.io/helm-charts/stable
+  [minio]=https://charts.min.io/
+)
+
+for repo in "${!REPOS[@]}"; do
+  echo helm repo add "$repo" "${REPOS[$repo]}"
+done

--- a/stable/mlrun-kit/Chart.yaml
+++ b/stable/mlrun-kit/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.5.0-rc.6
+version: 0.5.0-rc.5
 name: mlrun-kit
 description: MLRUn Open Source Stack
 home: https://iguazio.com

--- a/stable/mlrun-kit/Chart.yaml
+++ b/stable/mlrun-kit/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.5.0-rc.5
+version: 0.5.0-rc.6
 name: mlrun-kit
 description: MLRUn Open Source Stack
 home: https://iguazio.com


### PR DESCRIPTION
- Add script (`hack/scripts/ci/helm_repo_add.sh`) to add all the helm requirements' repos before build
- Add to PR template: **If the PR adds a new chart requirement**, the requirement is added to `./hack/scripts/ci/helm_repo_add.sh`
- `make helm-publish-stable-specific-v2` uses https (instead of ssh) if given `PUBLISH_CREDS` env var in the form of `gh-user:gh-token`
- Workflow configures git and sets `PUBLISH_CREDS` env var using `${{ github.actor }}` and `${{ github.token }}`