### PR TITLE
[v3io-webapi] IG-21069: remove TLSv1.1 support [integ_3.5]

### DIFF
--- a/stable/v3io-webapi/Chart.yaml
+++ b/stable/v3io-webapi/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.12.0
+version: 0.12.1
 appVersion: "~1.7.0"
 name: v3io-webapi
 description: v3io WebAPI

--- a/stable/v3io-webapi/templates/v3io-webapi-configmap.yaml
+++ b/stable/v3io-webapi/templates/v3io-webapi-configmap.yaml
@@ -71,7 +71,7 @@ data:
 
             ssl_certificate        {{ .Values.installationPath }}/crt/iguazio-nginx.crt;
             ssl_certificate_key    {{ .Values.installationPath }}/crt/iguazio-nginx.key;
-            ssl_protocols 		   TLSv1.1 TLSv1.2;
+            ssl_protocols 		   TLSv1.2;
 
             client_body_buffer_size   10M;
             client_max_body_size      5G;


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

[v3io-webapi] IG-21069: remove TLSv1.1 support
