### PR TITLE
[Jupyter] Allow creating secrets [integ 3.5]

### DIFF
--- a/stable/jupyter/Chart.yaml
+++ b/stable/jupyter/Chart.yaml
@@ -1,4 +1,4 @@
-version: 0.13.1
+version: 0.13.2
 apiVersion: v1
 appVersion: ">=2.0.0"
 name: jupyter

--- a/stable/jupyter/templates/jupyter-basic-job-executor-role.yaml
+++ b/stable/jupyter/templates/jupyter-basic-job-executor-role.yaml
@@ -23,3 +23,8 @@ rules:
 - apiGroups: ["extensions"]
   resources: ["ingresses"]
   verbs: ["list", "get"]
+  
+#  allow users to create secrets from the jupter shell as shell service is deprecated
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

Currently we instruct customers to create k8s secrets via shell, but only very few people have shell and we want to deprecate it.

This PR enables creating k8s secrets via Jupyter.

JIRA: https://jira.iguazeng.com/browse/IG-21116

Example from jupyter's terminal:
![image](https://user-images.githubusercontent.com/90552140/187917616-815fa3a8-dedb-4751-aa3f-b2c2db1fab56.png)
