### PR TITLE
[Jupyter] Allow creating secrets

### DIFF
--- a/stable/jupyter/Chart.yaml
+++ b/stable/jupyter/Chart.yaml
@@ -1,4 +1,4 @@
-version: 0.13.2
+version: 0.13.3
 apiVersion: v1
 appVersion: ">=2.0.0"
 name: jupyter

--- a/stable/jupyter/Chart.yaml
+++ b/stable/jupyter/Chart.yaml
@@ -1,4 +1,4 @@
-version: 0.13.3
+version: 0.14.0
 apiVersion: v1
 appVersion: ">=2.0.0"
 name: jupyter

--- a/stable/jupyter/templates/jupyter-basic-job-executor-role.yaml
+++ b/stable/jupyter/templates/jupyter-basic-job-executor-role.yaml
@@ -23,3 +23,8 @@ rules:
 - apiGroups: ["extensions"]
   resources: ["ingresses"]
   verbs: ["list", "get"]
+  
+#  allow users to create secrets from the jupter shell as shell service is deprecated
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

Currently we instruct customers to create k8s secrets via shell, but only very few people have shell and we want to deprecate it.

This PR enables creating k8s secrets via Jupyter.

JIRA: https://jira.iguazeng.com/browse/IG-21116

Porting #847 
