### PR TITLE
[MLRun] Support custom service account name

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.9.1
+version: 0.9.2
 appVersion: 1.0.4
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -24,7 +24,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .Values.serviceAccounts.serviceAccountName}}
+      serviceAccountName: {{ .Values.serviceAccounts.serviceAccountName }}
+    {{- else }}
       serviceAccountName: {{ include "mlrun.serviceAccountName.api" . }}
+    {{- end }}
       securityContext:
         {{- toYaml .Values.api.podSecurityContext | nindent 8 }}
       {{- if .Values.api.extraInitContainers }}

--- a/stable/mlrun/templates/api-rolebinding.yaml
+++ b/stable/mlrun/templates/api-rolebinding.yaml
@@ -12,4 +12,8 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "mlrun.serviceAccountName.api" . }}
+{{- if .Values.serviceAccounts.serviceAccountName }}
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccounts.serviceAccountName }}
+{{- end }}
 {{- end -}}

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -20,7 +20,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .Values.serviceAccounts.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccounts.serviceAccountName }}
+    {{- else }}
       serviceAccountName: {{ include "mlrun.serviceAccountName.api" . }}
+    {{- end }}
       securityContext:
         {{- toYaml .Values.api.podSecurityContext | nindent 8 }}
       {{- if .Values.api.extraInitContainers }}


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description
Some customers are using custom service account and bind them manually to MLRun using annotations.
The issue is that upon restart, the iguazio configuration is restored and the annotations are removed.

This PR adds an option to provide MLRun with a service account name to be used in the deployment.
If not given, default to an empty string.
Note that the given service account must exist and created by the user.

JIRA: https://jira.iguazeng.com/browse/IG-21167