### PR TITLE
[Webapi] Condition usage of hostNetwork in daemonset

### DIFF
--- a/stable/v3io-webapi/Chart.yaml
+++ b/stable/v3io-webapi/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.13.0
+version: 0.13.1
 appVersion: "~1.7.0"
 name: v3io-webapi
 description: v3io WebAPI

--- a/stable/v3io-webapi/templates/v3io-webapi-daemonset.yaml
+++ b/stable/v3io-webapi/templates/v3io-webapi-daemonset.yaml
@@ -26,7 +26,11 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/v3io-webapi-configmap.yaml") . | sha256sum }}
     spec:
       hostPID: true
+{{- if .Values.useHostNetwork }}
       hostNetwork: true
+{{- else }}
+      hostNetwork: false
+{{- end }}
       securityContext:
         runAsUser: 0
         fsGroup: 0

--- a/stable/v3io-webapi/values.yaml
+++ b/stable/v3io-webapi/values.yaml
@@ -47,6 +47,7 @@ serviceSSLHostPort: 8443
 workerRlimit : 8192
 workerProcesses: auto
 workerConnections: 1024
+useHostNetwork: false
 
 nginxV3ioConfig:
   jsonConf:


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description
To avoid certificate issues an exposing unwanted port, we do not expose the webapi https port by default.
In this PR we condition using the https port on a value from the service configuration.

https://jira.iguazeng.com/browse/IG-21070

Porting #871