### PR TITLE
[Jupyter] Upgrade pip in align mlrun script

### DIFF
--- a/stable/jupyter/Chart.yaml
+++ b/stable/jupyter/Chart.yaml
@@ -1,4 +1,4 @@
-version: 0.13.9
+version: 0.13.10
 apiVersion: v1
 appVersion: ">=2.0.0"
 name: jupyter

--- a/stable/jupyter/templates/jupyter-configmap.yaml
+++ b/stable/jupyter/templates/jupyter-configmap.yaml
@@ -56,7 +56,11 @@ data:
     ALIGN_MLRUN_SCRIPT="${HOME}/align_mlrun.sh"
     if [ ! -e ${ALIGN_MLRUN_SCRIPT} ]; then
       touch ${ALIGN_MLRUN_SCRIPT}
-      echo "$CONDA_HOME/bin/pip install --upgrade pip~=22.3.1" >> ${ALIGN_MLRUN_SCRIPT}
+      echo "PIP_VERSION=\`pip --version | awk '{print \$2}'\`" >> ${ALIGN_MLRUN_SCRIPT}
+      echo "if [ \"\${PIP_VERSION}\" == \"\" ] || dpkg --compare-versions \"\${PIP_VERSION}\" \"lt\" \"22.0.4\" ; then" >> ${ALIGN_MLRUN_SCRIPT}
+      echo "  echo \"Upgrading pip to 22.0.4 ...\"" >> ${ALIGN_MLRUN_SCRIPT}
+      echo "  conda install https://anaconda.org/conda-forge/pip/22.0.4/download/noarch/pip-22.0.4-pyhd8ed1ab_0.tar.bz2;" >> ${ALIGN_MLRUN_SCRIPT}
+      echo "fi" >> ${ALIGN_MLRUN_SCRIPT}
       echo "CLIENT_MLRUN_VERSION=\`pip show mlrun | grep Version | awk '{print \$2}'\`" >> ${ALIGN_MLRUN_SCRIPT}
       echo "SERVER_MLRUN_VERSION=\`curl -s \${IGZ_MLRUN_API_ENDPOINT}/api/healthz | python3 -c \"import sys, json; print(json.load(sys.stdin)['version'])\"\`" >> ${ALIGN_MLRUN_SCRIPT}
       echo "if [ \"\${CLIENT_MLRUN_VERSION}\" = \"\${SERVER_MLRUN_VERSION}\" ] || [ \"\${CLIENT_MLRUN_VERSION}\" = \"\${SERVER_MLRUN_VERSION//-}\" ]; then" >> ${ALIGN_MLRUN_SCRIPT}

--- a/stable/jupyter/templates/jupyter-configmap.yaml
+++ b/stable/jupyter/templates/jupyter-configmap.yaml
@@ -56,6 +56,7 @@ data:
     ALIGN_MLRUN_SCRIPT="${HOME}/align_mlrun.sh"
     if [ ! -e ${ALIGN_MLRUN_SCRIPT} ]; then
       touch ${ALIGN_MLRUN_SCRIPT}
+      echo "$CONDA_HOME/bin/pip install --upgrade pip~=22.3.1" >> ${ALIGN_MLRUN_SCRIPT}
       echo "CLIENT_MLRUN_VERSION=\`pip show mlrun | grep Version | awk '{print \$2}'\`" >> ${ALIGN_MLRUN_SCRIPT}
       echo "SERVER_MLRUN_VERSION=\`curl -s \${IGZ_MLRUN_API_ENDPOINT}/api/healthz | python3 -c \"import sys, json; print(json.load(sys.stdin)['version'])\"\`" >> ${ALIGN_MLRUN_SCRIPT}
       echo "if [ \"\${CLIENT_MLRUN_VERSION}\" = \"\${SERVER_MLRUN_VERSION}\" ] || [ \"\${CLIENT_MLRUN_VERSION}\" = \"\${SERVER_MLRUN_VERSION//-}\" ]; then" >> ${ALIGN_MLRUN_SCRIPT}

--- a/stable/jupyter/templates/jupyter-configmap.yaml
+++ b/stable/jupyter/templates/jupyter-configmap.yaml
@@ -273,6 +273,12 @@ data:
     export IGZ_ORIG_PYTHONPATH="${PIP_USER_PATH}/lib/python3.7/site-packages:${PYTHONPATH}"
     export PATH="${PATH}:${PIP_USER_PATH}/bin"
 
+    # Prevent git from failing on fuse mount (not owned by iguazio user)
+    # https://stackoverflow.com/questions/72978485/ubuntu-20-04-git-submodule-update-failed-with-fatal-detected-dubious-ownershi
+    if [ "$(git config --global --get safe.directory)" != "*" ]; then
+      git config --global --add safe.directory '*'
+    fi
+
     if [ "$(grep --count 'JUPYTER TERMINAL PATH SUPPORT' ${HOME}/.bashrc)" == "0" ]; then
       echo "# ----- JUPYTER TERMINAL PATH SUPPORT -----" >> ${HOME}/.bashrc
       echo 'if [ ! -z $JUPYTER_SERVER_ROOT ]; then' >> ${HOME}/.bashrc


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

Old pip versions do not resolve the dependency tree correctly.
We give a specific pip build because we want conda to install only this build and not update any other requirements, also this will make resolving the environment faster.
We have to install via conda because of a bug where a user has multiple jupyter services, all of them will have the same `bashrc` file and the same `PATH` env var.
Therefore, installing pip via pip will end with the pip binary installed in a path that is not in the PATH env var.
This bug is resolved in the new jupyter image to be released with iguazio 3.6.0. 
