### PR TITLE
[Webapi] Disable ssl container port when disabling hostNetwork [integ_3.5]

### DIFF
--- a/stable/v3io-webapi/Chart.yaml
+++ b/stable/v3io-webapi/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.12.4
+version: 0.12.5
 appVersion: "~1.7.0"
 name: v3io-webapi
 description: v3io WebAPI

--- a/stable/v3io-webapi/templates/v3io-webapi-daemonset.yaml
+++ b/stable/v3io-webapi/templates/v3io-webapi-daemonset.yaml
@@ -46,8 +46,10 @@ spec:
           ports:
             - containerPort: {{ .Values.hostPort }}
               name: v3io-webapi
+{{- if .Values.useHostNetwork }}
             - containerPort: {{ .Values.sslHostPort }}
               name: v3io-webapi-ssl
+{{- end }}
           livenessProbe:
             tcpSocket:
               port: {{ .Values.hostPort }}


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

Followup to https://github.com/v3io/helm-charts/pull/871
Disabling `hostNetwork` does not block access to the webapi pods when using `<node-ip>:<ssl-port>`, so in this PR we remove the ssl port from the container as well if `hostNetwork` is disabled.

Fixes https://jira.iguazeng.com/browse/IG-21416
