### PR TITLE
fix bufferSizeBytes value in mlrun api worker deployment

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.9.6
+version: 0.9.7
 appVersion: 1.1.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -102,7 +102,7 @@ spec:
           - name: MLRUN_LOG_COLLECTOR__ADDRESS
             value: {{ include "mlrun.api.sidecars.logCollector.internalAddress" . }}
           - name: MLRUN_LOG_COLLECTOR__BUFFER_SIZE_BYTES
-            value: { { .Values.api.sidecars.logCollector.bufferSizeBytes | quote } }
+            value: {{ .Values.api.sidecars.logCollector.bufferSizeBytes | quote }}
           {{- end }}
           {{- if .Values.api.extraEnv }}
           {{ toYaml .Values.api.extraEnv | nindent 10 }}


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

fixing error:
```
Error: YAML parse error on mlrun/templates/api-worker-deployment.yaml: error converting YAML to JSON: yaml: invalid map key: map[interface {}]interface {}{".Values.api.sidecars.logCollector.bufferSizeBytes | quote":interface {}(nil)}
```

backport pr https://github.com/v3io/helm-charts/pull/915
https://jira.iguazeng.com/browse/IG-21528