### PR TITLE
[MLRun] Support different buffer sizes for log collector [integ_3.5]

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.8.20
+version: 0.8.21
 appVersion: 1.1.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -105,8 +105,8 @@ spec:
             value: {{ .Values.api.sidecars.logCollector.mode }}
           - name: MLRUN_LOG_COLLECTOR__ADDRESS
             value: {{ include "mlrun.api.sidecars.logCollector.internalAddress" . }}
-          - name: MLRUN_LOG_COLLECTOR__BUFFER_SIZE_BYTES
-            value: {{ .Values.api.sidecars.logCollector.bufferSizeBytes | quote }}
+          - name: MLRUN_LOG_COLLECTOR__GET_LOGS_BUFFER_SIZE_BYTES
+            value: {{ .Values.api.sidecars.logCollector.getLogsBufferSizeBytes | quote }}
           {{- end }}
           {{- if .Values.api.extraEnv }}
           {{ toYaml .Values.api.extraEnv | nindent 10 }}

--- a/stable/mlrun/templates/api-log-collector-config.yaml
+++ b/stable/mlrun/templates/api-log-collector-config.yaml
@@ -13,5 +13,6 @@ data:
   MLRUN_LOG_COLLECTOR__MONITORING_INTERVAL: "{{ .Values.api.sidecars.logCollector.monitoringInterval }}"
   MLRUN_LOG_COLLECTOR__LOG_COLLECTION_BUFFER_POOL_SIZE: "{{ .Values.api.sidecars.logCollector.logCollectionBufferPoolSize }}"
   MLRUN_LOG_COLLECTOR__GET_LOGS_BUFFER_POOL_SIZE: "{{ .Values.api.sidecars.logCollector.getLogsBufferPoolSize }}"
-  MLRUN_LOG_COLLECTOR__BUFFER_SIZE_BYTES: "{{ .Values.api.sidecars.logCollector.bufferSizeBytes }}"
+  MLRUN_LOG_COLLECTOR__LOG_COLLECTION_BUFFER_SIZE_BYTES: "{{ .Values.api.sidecars.logCollector.logCollectionBufferSizeBytes }}"
+  MLRUN_LOG_COLLECTOR__GET_LOGS_BUFFER_SIZE_BYTES: "{{ .Values.api.sidecars.logCollector.getLogsBufferSizeBytes }}"
 {{- end }}

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -101,8 +101,8 @@ spec:
             value: {{ .Values.api.sidecars.logCollector.mode }}
           - name: MLRUN_LOG_COLLECTOR__ADDRESS
             value: {{ include "mlrun.api.sidecars.logCollector.internalAddress" . }}
-          - name: MLRUN_LOG_COLLECTOR__BUFFER_SIZE_BYTES
-            value: {{ .Values.api.sidecars.logCollector.bufferSizeBytes | quote }}
+          - name: MLRUN_LOG_COLLECTOR__GET_LOGS_BUFFER_SIZE_BYTES
+            value: {{ .Values.api.sidecars.logCollector.getLogsBufferSizeBytes | quote }}
           {{- end }}
           {{- if .Values.api.extraEnv }}
           {{ toYaml .Values.api.extraEnv | nindent 10 }}

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -253,9 +253,11 @@ api:
       fullnameOverride:
 
       # 10MiB ( 10 * 1024 * 1024 = 10485760 )
-      bufferSizeBytes: "10485760"
-      getLogsBufferPoolSize: 512
+      logCollectionBufferSizeBytes: "10485760"
+      # 3.75MiB ( 3.75 * 1024 * 1024 = 3932160 )
+      getLogsBufferSizeBytes: "3932160"
       logCollectionBufferPoolSize: 512
+      getLogsBufferPoolSize: 512
 
       readLogWaitTime: "3s"
       stateFileUpdateInterval: "10s"


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description
Log collector supports different buffer sizes for `StartLog` and `GetLogs`.
Follow up to https://github.com/mlrun/mlrun/pull/3044 