### PR TITLE
[MLRun] Change api-chief's deployment strategy to Recreate [integ_3.5]

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.8.22
+version: 0.8.23
 appVersion: 1.1.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -12,6 +12,8 @@ spec:
   {{- else }}
   replicas: {{ .Values.api.chief.minReplicas }}
   {{- end }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "mlrun.api.chief.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description
When the deployment strategy is "rolling update" (the default), it means that there could be more than 1 chief at a time, which is against the design of having single chief at a time to avoid race conditions and such.

To resolve such cases, this PR changes the deployment strategy to "recreate" to ensure there would be only one chief at a specific time.

Fixes https://jira.iguazeng.com/browse/IG-21609