### PR TITLE
[Jupyter] Add shared volume between jupyter and sidecar-proxy containers [integ_3.5]

### DIFF
--- a/stable/jupyter/Chart.yaml
+++ b/stable/jupyter/Chart.yaml
@@ -1,4 +1,4 @@
-version: 0.13.23
+version: 0.13.24
 apiVersion: v1
 appVersion: 3.4.8
 name: jupyter

--- a/stable/jupyter/templates/jupyter-deployment.yaml
+++ b/stable/jupyter/templates/jupyter-deployment.yaml
@@ -148,9 +148,9 @@ spec:
             - mountPath: /var/run/iguazio/secrets/ssh
               readOnly: true
               name: ssh-authorized-keys
-            - mountPath: /intercontainer/opensshconnection
-              name: inter-container-ssh
 {{- end }}
+            - mountPath: /intercontainer
+              name: inter-container
             - mountPath: /User/v3io
               name: v3io-fuse
             - mountPath: /etc/config/jupyter
@@ -187,20 +187,18 @@ spec:
           ports:
             - containerPort: {{ .Values.proxy.servicePort }}
               name: sidecar-proxy
-{{- if .Values.sshServer.enabled }}
           volumeMounts:
-            - mountPath: /intercontainer/opensshconnection
-              name: inter-container-ssh
-{{- end }}
+            - mountPath: /intercontainer
+              name: inter-container
       volumes:
 {{- if .Values.sshServer.enabled }}
         - name: ssh-authorized-keys
           secret:
             defaultMode: 420
             secretName: {{ template "jupyter.fullname" . }}-ssh-key
-        - name: inter-container-ssh
-          emptyDir: {}
 {{- end }}
+        - name: inter-container
+          emptyDir: {}
         - name: config-volume
           configMap:
             name: {{ template "jupyter.fullname" . }}

--- a/stable/jupyter/templates/jupyter-deployment.yaml
+++ b/stable/jupyter/templates/jupyter-deployment.yaml
@@ -187,11 +187,11 @@ spec:
           ports:
             - containerPort: {{ .Values.proxy.servicePort }}
               name: sidecar-proxy
-{{ - if .Values.sshServer.enabled }}
+{{- if .Values.sshServer.enabled }}
           volumeMounts:
             - mountPath: /intercontainer/opensshconnection
               name: inter-container-ssh
-{{ - end }}
+{{- end }}
       volumes:
 {{- if .Values.sshServer.enabled }}
         - name: ssh-authorized-keys

--- a/stable/jupyter/templates/jupyter-deployment.yaml
+++ b/stable/jupyter/templates/jupyter-deployment.yaml
@@ -148,6 +148,8 @@ spec:
             - mountPath: /var/run/iguazio/secrets/ssh
               readOnly: true
               name: ssh-authorized-keys
+            - mountPath: /intercontainer/opensshconnection
+              name: inter-container-ssh
 {{- end }}
             - mountPath: /User/v3io
               name: v3io-fuse
@@ -185,12 +187,19 @@ spec:
           ports:
             - containerPort: {{ .Values.proxy.servicePort }}
               name: sidecar-proxy
+{{ - if .Values.sshServer.enabled }}
+          volumeMounts:
+            - mountPath: /intercontainer/opensshconnection
+              name: inter-container-ssh
+{{ - end }}
       volumes:
 {{- if .Values.sshServer.enabled }}
         - name: ssh-authorized-keys
           secret:
             defaultMode: 420
             secretName: {{ template "jupyter.fullname" . }}-ssh-key
+        - name: inter-container-ssh
+          emptyDir: {}
 {{- end }}
         - name: config-volume
           configMap:


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description
The shared volume will be used for marking ssh open connection, and prevent the service from scaling to zero.

Implementing https://jira.iguazeng.com/browse/IG-21529
