### PR TITLE
[MLRun] Fix global docker registry secret name

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.9.9
+version: 0.9.10
 appVersion: 1.1.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/_helpers.tpl
+++ b/stable/mlrun/templates/_helpers.tpl
@@ -348,15 +348,15 @@ Create the name of the service account to use
 Resolve the effective docker registry url and secret Name allowing for global values
 */}}
 {{- define "mlrun.defaultDockerRegistry.url" -}}
-{{ default .Values.defaultDockerRegistryURL .Values.global.registry.url }}
+{{ coalesce .Values.defaultDockerRegistryURL .Values.global.registry.url }}
 {{- end -}}
 
 {{- define "mlrun.defaultDockerRegistry.builderSecretName" -}}
-{{ default .Values.defaultDockerRegistrySecretName .Values.global.registry.secretName }}
+{{ coalesce .Values.defaultDockerRegistrySecretName .Values.global.registry.secretName }}
 {{- end -}}
 
 {{- define "mlrun.defaultDockerRegistry.imagePullSecretName" -}}
-{{ default .Values.api.function.spec.image_pull_secret.default .Values.global.registry.secretName }}
+{{ coalesce .Values.api.function.spec.image_pull_secret.default .Values.global.registry.secretName }}
 {{- end -}}
 
 {{/*

--- a/stable/mlrun/templates/_helpers.tpl
+++ b/stable/mlrun/templates/_helpers.tpl
@@ -352,7 +352,7 @@ Resolve the effective docker registry url and secret Name allowing for global va
 {{- end -}}
 
 {{- define "mlrun.defaultDockerRegistry.secretName" -}}
-{{ default .Values.defaultDockerRegistrySecretName .Values.global.registry.secretName }}
+{{ default .Values.api.function.spec.image_pull_secret.default .Values.global.registry.secretName }}
 {{- end -}}
 
 {{/*

--- a/stable/mlrun/templates/_helpers.tpl
+++ b/stable/mlrun/templates/_helpers.tpl
@@ -351,7 +351,11 @@ Resolve the effective docker registry url and secret Name allowing for global va
 {{ default .Values.defaultDockerRegistryURL .Values.global.registry.url }}
 {{- end -}}
 
-{{- define "mlrun.defaultDockerRegistry.secretName" -}}
+{{- define "mlrun.defaultDockerRegistry.builderSecretName" -}}
+{{ default .Values.defaultDockerRegistrySecretName .Values.global.registry.secretName }}
+{{- end -}}
+
+{{- define "mlrun.defaultDockerRegistry.imagePullSecretName" -}}
 {{ default .Values.api.function.spec.image_pull_secret.default .Values.global.registry.secretName }}
 {{- end -}}
 

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -72,7 +72,7 @@ spec:
           - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET
             value: {{ template "mlrun.defaultDockerRegistry.builderSecretName" . }}
           {{- end }}
-          {{- if or .Values.defaultDockerRegistrySecretName .Values.global.registry.secretName }}
+          {{- if or .Values.api.function.spec.image_pull_secret.default .Values.global.registry.secretName }}
           - name: MLRUN_FUNCTION__SPEC__IMAGE_PULL_SECRET__DEFAULT
             value: {{ template "mlrun.defaultDockerRegistry.imagePullSecretName" . }}
           {{- end }}

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -69,9 +69,9 @@ spec:
           - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
             value: {{ template "mlrun.defaultDockerRegistry.url" . }}
           - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET
-            value: {{ .Values.defaultDockerRegistrySecretName | quote }}
+            value: {{ template "mlrun.defaultDockerRegistry.builderSecretName" . }}
           - name: MLRUN_FUNCTION__SPEC__IMAGE_PULL_SECRET__DEFAULT
-            value: {{ template "mlrun.defaultDockerRegistry.secretName" . }}
+            value: {{ template "mlrun.defaultDockerRegistry.imagePullSecretName" . }}
           - name: MLRUN_HTTPDB__DSN
             value: {{ .Values.httpDB.dsn }}
           - name: MLRUN_HTTPDB__OLD_DSN

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -66,20 +66,12 @@ spec:
             value: http://{{ include "mlrun.api.fullname" . }}:{{ .Values.api.service.port }}
           - name: MLRUN_HTTPDB__DIRPATH
             value: {{ .Values.httpDB.dirPath }}
-          # DEFAULT_DOCKER_REGISTRY & DEFAULT_DOCKER_SECRET are for BC to run 0.5.x chart with 0.5.x MLRun
-          # When mlrun-kit starts using 0.6.x MLRun this can be removed
-          - name: DEFAULT_DOCKER_REGISTRY
-            value: {{ template "mlrun.defaultDockerRegistry.url" . }}
-          - name: DEFAULT_DOCKER_SECRET
-            value: {{ template "mlrun.defaultDockerRegistry.secretName" . }}
           - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
             value: {{ template "mlrun.defaultDockerRegistry.url" . }}
           - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET
-            value: {{ template "mlrun.defaultDockerRegistry.secretName" . }}
-          {{- if .Values.api.function.spec.image_pull_secret.default }}
+            value: {{ .Values.defaultDockerRegistrySecretName | quote }}
           - name: MLRUN_FUNCTION__SPEC__IMAGE_PULL_SECRET__DEFAULT
-            value: {{ .Values.api.function.spec.image_pull_secret.default | quote }}
-          {{- end }}
+            value: {{ template "mlrun.defaultDockerRegistry.secretName" . }}
           - name: MLRUN_HTTPDB__DSN
             value: {{ .Values.httpDB.dsn }}
           - name: MLRUN_HTTPDB__OLD_DSN

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -68,10 +68,14 @@ spec:
             value: {{ .Values.httpDB.dirPath }}
           - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
             value: {{ template "mlrun.defaultDockerRegistry.url" . }}
+          {{- if or .Values.defaultDockerRegistrySecretName .Values.global.registry.secretName }}
           - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET
             value: {{ template "mlrun.defaultDockerRegistry.builderSecretName" . }}
+          {{- end }}
+          {{- if or .Values.defaultDockerRegistrySecretName .Values.global.registry.secretName }}
           - name: MLRUN_FUNCTION__SPEC__IMAGE_PULL_SECRET__DEFAULT
             value: {{ template "mlrun.defaultDockerRegistry.imagePullSecretName" . }}
+          {{- end }}
           - name: MLRUN_HTTPDB__DSN
             value: {{ .Values.httpDB.dsn }}
           - name: MLRUN_HTTPDB__OLD_DSN

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -62,10 +62,14 @@ spec:
             value: {{ .Values.httpDB.dirPath }}
           - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
             value: {{ template "mlrun.defaultDockerRegistry.url" . }}
+          {{- if or .Values.defaultDockerRegistrySecretName .Values.global.registry.secretName }}
           - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET
             value: {{ template "mlrun.defaultDockerRegistry.builderSecretName" . }}
+          {{- end }}
+          {{- if or .Values.defaultDockerRegistrySecretName .Values.global.registry.secretName }}
           - name: MLRUN_FUNCTION__SPEC__IMAGE_PULL_SECRET__DEFAULT
             value: {{ template "mlrun.defaultDockerRegistry.imagePullSecretName" . }}
+          {{- end }}
           - name: MLRUN_HTTPDB__DSN
             value: {{ .Values.httpDB.dsn }}
           - name: MLRUN_HTTPDB__OLD_DSN

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -60,20 +60,12 @@ spec:
             value: http://{{ include "mlrun.api.fullname" . }}:{{ .Values.api.service.port }}
           - name: MLRUN_HTTPDB__DIRPATH
             value: {{ .Values.httpDB.dirPath }}
-          # DEFAULT_DOCKER_REGISTRY & DEFAULT_DOCKER_SECRET are for BC to run 0.5.x chart with 0.5.x MLRun
-          # When mlrun-kit starts using 0.6.x MLRun this can be removed
-          - name: DEFAULT_DOCKER_REGISTRY
-            value: {{ template "mlrun.defaultDockerRegistry.url" . }}
-          - name: DEFAULT_DOCKER_SECRET
-            value: {{ template "mlrun.defaultDockerRegistry.secretName" . }}
           - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
             value: {{ template "mlrun.defaultDockerRegistry.url" . }}
           - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET
-            value: {{ template "mlrun.defaultDockerRegistry.secretName" . }}
-          {{- if .Values.api.function.spec.image_pull_secret.default }}
+            value: {{ .Values.defaultDockerRegistrySecretName | quote }}
           - name: MLRUN_FUNCTION__SPEC__IMAGE_PULL_SECRET__DEFAULT
-            value: {{ .Values.api.function.spec.image_pull_secret.default | quote }}
-          {{- end }}
+            value: {{ template "mlrun.defaultDockerRegistry.secretName" . }}
           - name: MLRUN_HTTPDB__DSN
             value: {{ .Values.httpDB.dsn }}
           - name: MLRUN_HTTPDB__OLD_DSN

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -66,7 +66,7 @@ spec:
           - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET
             value: {{ template "mlrun.defaultDockerRegistry.builderSecretName" . }}
           {{- end }}
-          {{- if or .Values.defaultDockerRegistrySecretName .Values.global.registry.secretName }}
+          {{- if or .Values.api.function.spec.image_pull_secret.default .Values.global.registry.secretName }}
           - name: MLRUN_FUNCTION__SPEC__IMAGE_PULL_SECRET__DEFAULT
             value: {{ template "mlrun.defaultDockerRegistry.imagePullSecretName" . }}
           {{- end }}

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -63,9 +63,9 @@ spec:
           - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
             value: {{ template "mlrun.defaultDockerRegistry.url" . }}
           - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET
-            value: {{ .Values.defaultDockerRegistrySecretName | quote }}
+            value: {{ template "mlrun.defaultDockerRegistry.builderSecretName" . }}
           - name: MLRUN_FUNCTION__SPEC__IMAGE_PULL_SECRET__DEFAULT
-            value: {{ template "mlrun.defaultDockerRegistry.secretName" . }}
+            value: {{ template "mlrun.defaultDockerRegistry.imagePullSecretName" . }}
           - name: MLRUN_HTTPDB__DSN
             value: {{ .Values.httpDB.dsn }}
           - name: MLRUN_HTTPDB__OLD_DSN

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -591,6 +591,7 @@ global:
   externalHostAddress:
   registry:
     url:
+    # default image pull secret
     secretName:
   nuclio:
     dashboard:

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -591,7 +591,6 @@ global:
   externalHostAddress:
   registry:
     url:
-    # default image pull secret
     secretName:
   nuclio:
     dashboard:


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

Set the global docker registry secret name as the default function image pull secret instead of builder secret name.
This fix is for mlrun ce where mlrun is used as a subchart.
Also removed a couple of unused deprecated fields.
The `coalesce` function takes a list of values and returns the first non-empty one.
