### PR TITLE
[MLRun] Fix global docker registry secret name [integ_3.5]

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.8.23
+version: 0.8.24
 appVersion: 1.1.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/_helpers.tpl
+++ b/stable/mlrun/templates/_helpers.tpl
@@ -348,11 +348,15 @@ Create the name of the service account to use
 Resolve the effective docker registry url and secret Name allowing for global values
 */}}
 {{- define "mlrun.defaultDockerRegistry.url" -}}
-{{ default .Values.defaultDockerRegistryURL .Values.global.registry.url }}
+{{ coalesce .Values.defaultDockerRegistryURL .Values.global.registry.url }}
 {{- end -}}
 
-{{- define "mlrun.defaultDockerRegistry.secretName" -}}
-{{ default .Values.defaultDockerRegistrySecretName .Values.global.registry.secretName }}
+{{- define "mlrun.defaultDockerRegistry.builderSecretName" -}}
+{{ coalesce .Values.defaultDockerRegistrySecretName .Values.global.registry.secretName }}
+{{- end -}}
+
+{{- define "mlrun.defaultDockerRegistry.imagePullSecretName" -}}
+{{ coalesce .Values.api.function.spec.image_pull_secret.default .Values.global.registry.secretName }}
 {{- end -}}
 
 {{/*

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -66,19 +66,15 @@ spec:
             value: http://{{ include "mlrun.api.fullname" . }}:{{ .Values.api.service.port }}
           - name: MLRUN_HTTPDB__DIRPATH
             value: {{ .Values.httpDB.dirPath }}
-          # DEFAULT_DOCKER_REGISTRY & DEFAULT_DOCKER_SECRET are for BC to run 0.5.x chart with 0.5.x MLRun
-          # When mlrun-kit starts using 0.6.x MLRun this can be removed
-          - name: DEFAULT_DOCKER_REGISTRY
-            value: {{ template "mlrun.defaultDockerRegistry.url" . }}
-          - name: DEFAULT_DOCKER_SECRET
-            value: {{ template "mlrun.defaultDockerRegistry.secretName" . }}
           - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
             value: {{ template "mlrun.defaultDockerRegistry.url" . }}
+          {{- if or .Values.defaultDockerRegistrySecretName .Values.global.registry.secretName }}
           - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET
-            value: {{ template "mlrun.defaultDockerRegistry.secretName" . }}
-          {{- if .Values.api.function.spec.image_pull_secret.default }}
+            value: {{ template "mlrun.defaultDockerRegistry.builderSecretName" . }}
+          {{- end }}
+          {{- if or .Values.api.function.spec.image_pull_secret.default .Values.global.registry.secretName }}
           - name: MLRUN_FUNCTION__SPEC__IMAGE_PULL_SECRET__DEFAULT
-            value: {{ .Values.api.function.spec.image_pull_secret.default | quote }}
+            value: {{ template "mlrun.defaultDockerRegistry.imagePullSecretName" . }}
           {{- end }}
           - name: MLRUN_HTTPDB__DSN
             value: {{ .Values.httpDB.dsn }}

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -60,19 +60,15 @@ spec:
             value: http://{{ include "mlrun.api.fullname" . }}:{{ .Values.api.service.port }}
           - name: MLRUN_HTTPDB__DIRPATH
             value: {{ .Values.httpDB.dirPath }}
-          # DEFAULT_DOCKER_REGISTRY & DEFAULT_DOCKER_SECRET are for BC to run 0.5.x chart with 0.5.x MLRun
-          # When mlrun-kit starts using 0.6.x MLRun this can be removed
-          - name: DEFAULT_DOCKER_REGISTRY
-            value: {{ template "mlrun.defaultDockerRegistry.url" . }}
-          - name: DEFAULT_DOCKER_SECRET
-            value: {{ template "mlrun.defaultDockerRegistry.secretName" . }}
           - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY
             value: {{ template "mlrun.defaultDockerRegistry.url" . }}
+          {{- if or .Values.defaultDockerRegistrySecretName .Values.global.registry.secretName }}
           - name: MLRUN_HTTPDB__BUILDER__DOCKER_REGISTRY_SECRET
-            value: {{ template "mlrun.defaultDockerRegistry.secretName" . }}
-          {{- if .Values.api.function.spec.image_pull_secret.default }}
+            value: {{ template "mlrun.defaultDockerRegistry.builderSecretName" . }}
+          {{- end }}
+          {{- if or .Values.api.function.spec.image_pull_secret.default .Values.global.registry.secretName }}
           - name: MLRUN_FUNCTION__SPEC__IMAGE_PULL_SECRET__DEFAULT
-            value: {{ .Values.api.function.spec.image_pull_secret.default | quote }}
+            value: {{ template "mlrun.defaultDockerRegistry.imagePullSecretName" . }}
           {{- end }}
           - name: MLRUN_HTTPDB__DSN
             value: {{ .Values.httpDB.dsn }}


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

backports https://github.com/v3io/helm-charts/pull/937