### PR TITLE
[jupyter] Use mlrun correct endpoint to resolve server version

### DIFF
--- a/stable/jupyter/Chart.yaml
+++ b/stable/jupyter/Chart.yaml
@@ -1,4 +1,4 @@
-version: 0.14.28
+version: 0.14.29
 apiVersion: v1
 appVersion: 3.4.8
 name: jupyter

--- a/stable/jupyter/templates/jupyter-configmap.yaml
+++ b/stable/jupyter/templates/jupyter-configmap.yaml
@@ -509,7 +509,7 @@ data:
       fi
     done
     CLIENT_MLRUN_VERSION=\$(pip show mlrun | grep Version | awk '{print \$2}')
-    SERVER_MLRUN_VERSION=\$(curl -s \${IGZ_MLRUN_API_ENDPOINT}/api/healthz | python3 -c "import sys, json; print(json.load(sys.stdin)['version'])")
+    SERVER_MLRUN_VERSION=\$(curl -s \${IGZ_MLRUN_API_ENDPOINT}/api/v1/client-spec | python3 -c "import sys, json; print(json.load(sys.stdin)['version'])")
     if [ "\${CLIENT_MLRUN_VERSION}" = "\${SERVER_MLRUN_VERSION}" ] || [ "\${CLIENT_MLRUN_VERSION}" = "\${SERVER_MLRUN_VERSION//-}" ]; then
       echo "Both server & client are aligned (\${CLIENT_MLRUN_VERSION})."
     else
@@ -545,7 +545,7 @@ data:
         cp /tmp/update-tutorials.ipynb ${HOME}
         cp /tmp/update-demos.sh ${HOME}
       fi
-      if ! bash /tmp/update-demos.sh --mlrun-ver `curl -s ${IGZ_MLRUN_API_ENDPOINT}/api/healthz | python3 -c "import sys, json; print(json.load(sys.stdin)['version'])"`; then
+      if ! bash /tmp/update-demos.sh --mlrun-ver `curl -s ${IGZ_MLRUN_API_ENDPOINT}/api/v1/client-spec | python3 -c "import sys, json; print(json.load(sys.stdin)['version'])"`; then
         mkdir -p ${HOME}/demos
         tar -C ${HOME}/demos -xvf /tmp/mlrun-demos  --strip-components=1
         rm -f /tmp/mlrun-demos


### PR DESCRIPTION
Porting https://github.com/v3io/helm-charts/pull/970 to development

### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

