### PR TITLE
[mlrun] Add model monitoring db

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.9.15
+version: 0.9.16
 appVersion: 1.4.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/db-configmap-init.yaml
+++ b/stable/mlrun/templates/db-configmap-init.yaml
@@ -13,6 +13,6 @@ data:
     FLUSH PRIVILEGES;
     CREATE DATABASE IF NOT EXISTS mlrun;
     {{- if not .Values.modelMonitoring.dsn }}
-    CREATE DATABASE IF NOT EXISTS mlrun_monitoring;
+    CREATE DATABASE IF NOT EXISTS mlrun_model_monitoring;
     {{- end }}
 {{- end }}

--- a/stable/mlrun/templates/db-configmap-init.yaml
+++ b/stable/mlrun/templates/db-configmap-init.yaml
@@ -12,4 +12,7 @@ data:
     GRANT ALL PRIVILEGES ON *.* TO 'root'@'%';
     FLUSH PRIVILEGES;
     CREATE DATABASE IF NOT EXISTS mlrun;
+    {{- if and .Values.modelMonitoring.enabled (not .Values.modelMonitoring.dsn)}}
+    CREATE DATABASE IF NOT EXISTS monitoring;
+    {{- end }}
 {{- end }}

--- a/stable/mlrun/templates/db-configmap-init.yaml
+++ b/stable/mlrun/templates/db-configmap-init.yaml
@@ -12,7 +12,7 @@ data:
     GRANT ALL PRIVILEGES ON *.* TO 'root'@'%';
     FLUSH PRIVILEGES;
     CREATE DATABASE IF NOT EXISTS mlrun;
-    {{- if and .Values.modelMonitoring.provisionDB (not .Values.modelMonitoring.dsn)}}
+    {{- if not .Values.modelMonitoring.dsn }}
     CREATE DATABASE IF NOT EXISTS mlrun_monitoring;
     {{- end }}
 {{- end }}

--- a/stable/mlrun/templates/db-configmap-init.yaml
+++ b/stable/mlrun/templates/db-configmap-init.yaml
@@ -12,7 +12,7 @@ data:
     GRANT ALL PRIVILEGES ON *.* TO 'root'@'%';
     FLUSH PRIVILEGES;
     CREATE DATABASE IF NOT EXISTS mlrun;
-    {{- if and .Values.modelMonitoring.enabled (not .Values.modelMonitoring.dsn)}}
-    CREATE DATABASE IF NOT EXISTS monitoring;
+    {{- if and .Values.modelMonitoring.provisionDB (not .Values.modelMonitoring.dsn)}}
+    CREATE DATABASE IF NOT EXISTS mlrun_monitoring;
     {{- end }}
 {{- end }}

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -606,7 +606,7 @@ httpDB:
   # oldDsn: "sqlite:////mlrun/db/mlrun.db?check_same_thread=false"
 
 modelMonitoring:
-  enabled: disabled
+  enabled: false
   # If enabled and no dsn has been provided, will initiate monitoring database under mlrun-db service:
   # mysql+pymysql://root@mlrun-db:3306/monitoring
   dsn:

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -605,6 +605,12 @@ httpDB:
   # dsn: "mysql+pymysql://root@mlrun-db:3306/mlrun"
   # oldDsn: "sqlite:////mlrun/db/mlrun.db?check_same_thread=false"
 
+modelMonitoring:
+  enabled: true
+  # If enabled and no dsn has been provided, will initiate monitoring database under mlrun-db service:
+  # mysql+pymysql://root@mlrun-db:3306/monitoring
+  dsn:
+
 defaultDockerRegistryURL: ""
 defaultDockerRegistrySecretName: ""
 

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -606,7 +606,7 @@ httpDB:
   # oldDsn: "sqlite:////mlrun/db/mlrun.db?check_same_thread=false"
 
 modelMonitoring:
-  enabled: true
+  enabled: disabled
   # If enabled and no dsn has been provided, will initiate monitoring database under mlrun-db service:
   # mysql+pymysql://root@mlrun-db:3306/monitoring
   dsn:

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -607,7 +607,7 @@ httpDB:
 
 modelMonitoring:
   # If no dsn has been provided, will initiate monitoring database under mlrun-db service:
-  # mysql+pymysql://root@mlrun-db:3306/mlrun_monitoring
+  # mysql+pymysql://root@mlrun-db:3306/mlrun_model_monitoring
   dsn:
 
 defaultDockerRegistryURL: ""

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -608,7 +608,7 @@ httpDB:
 modelMonitoring:
   provisionDB: false
   # If provisionDB is true and no dsn has been provided, will initiate monitoring database under mlrun-db service:
-  # mysql+pymysql://root@mlrun-db:3306/mlrun-monitoring
+  # mysql+pymysql://root@mlrun-db:3306/mlrun_monitoring
   dsn:
 
 defaultDockerRegistryURL: ""

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -606,9 +606,8 @@ httpDB:
   # oldDsn: "sqlite:////mlrun/db/mlrun.db?check_same_thread=false"
 
 modelMonitoring:
-  provisionDB: false
-  # If provisionDB is true and no dsn has been provided, will initiate monitoring database under mlrun-db service:
-  # mysql+pymysql://root@mlrun-db:3306/mlrun_monitoring
+  # If no dsn has been provided, will initiate monitoring database under mlrun-db service:
+  # mysql+pymysql://root@mlrun-db:3306/mlrun-monitoring
   dsn:
 
 defaultDockerRegistryURL: ""

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -607,7 +607,7 @@ httpDB:
 
 modelMonitoring:
   # If no dsn has been provided, will initiate monitoring database under mlrun-db service:
-  # mysql+pymysql://root@mlrun-db:3306/mlrun-monitoring
+  # mysql+pymysql://root@mlrun-db:3306/mlrun_monitoring
   dsn:
 
 defaultDockerRegistryURL: ""

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -606,9 +606,9 @@ httpDB:
   # oldDsn: "sqlite:////mlrun/db/mlrun.db?check_same_thread=false"
 
 modelMonitoring:
-  enabled: false
-  # If enabled and no dsn has been provided, will initiate monitoring database under mlrun-db service:
-  # mysql+pymysql://root@mlrun-db:3306/monitoring
+  provisionDB: false
+  # If provisionDB is true and no dsn has been provided, will initiate monitoring database under mlrun-db service:
+  # mysql+pymysql://root@mlrun-db:3306/mlrun-monitoring
   dsn:
 
 defaultDockerRegistryURL: ""


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

Adding a new value called `modelMonitoring` that at the moment includes a single field:
- `dsn`: Model monitoring DSN database.  

Please note that if and no DSN has been provided (and `provisionDB=true`), we will initiate a new monitoring database under `mlrun-db` service: `mysql+pymysql://root@mlrun-db:3306/mlrun_model_monitoring`

A related JIRA - https://jira.iguazeng.com/browse/CEML-106
