### PR TITLE
[mlrun] Fix Duplications Between `extraEnv` and `extraEnvKeyVal` [integ_3.5]

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.8.28
+version: 0.8.29
 appVersion: 1.4.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -107,7 +107,12 @@ spec:
             value: {{ .Values.api.sidecars.logCollector.getLogsBufferSizeBytes | quote }}
           {{- end }}
           {{- if .Values.api.extraEnv }}
-          {{ toYaml .Values.api.extraEnv | nindent 10 }}
+          {{- range .Values.api.extraEnv }}
+          {{- if not (hasKey $.Values.api.extraEnvKeyValue .name) }}
+          - name: {{ .name }}
+            value: {{ .value }}
+          {{- end }}
+          {{- end }}
           {{- end }}
           {{- if .Values.api.extraEnvKeyValue }}
           {{- range $name, $value := .Values.api.extraEnvKeyValue }}

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -101,7 +101,12 @@ spec:
             value: {{ .Values.api.sidecars.logCollector.getLogsBufferSizeBytes | quote }}
           {{- end }}
           {{- if .Values.api.extraEnv }}
-          {{ toYaml .Values.api.extraEnv | nindent 10 }}
+          {{- range .Values.api.extraEnv }}
+          {{- if not (hasKey $.Values.api.extraEnvKeyValue .name) }}
+          - name: {{ .name }}
+            value: {{ .value }}
+          {{- end }}
+          {{- end }}
           {{- end }}
           {{- if .Values.api.extraEnvKeyValue }}
           {{- range $name, $value := .Values.api.extraEnvKeyValue }}


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

BP - https://github.com/v3io/helm-charts/pull/999
