### PR TITLE
[Keycloak] Fix generated passwords may have whitespaces when secret already exists

### DIFF
--- a/stable/v3io-keycloak/Chart.yaml
+++ b/stable/v3io-keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: v3io-keycloak
-version: 0.1.5
+version: 0.1.6
 appVersion: 20.0.5
 description: Keycloak With V3IO MySQL Database
 maintainers:

--- a/stable/v3io-keycloak/templates/db-creds.yaml
+++ b/stable/v3io-keycloak/templates/db-creds.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   # for mysql
   DB_USER: {{ include "v3io-keycloak.dbUser" . | b64enc }}
-  DB_PASSWORD: {{ $password | b64enc }}
+  DB_PASSWORD: {{ $password | trim | b64enc }}
 
   # for keycloak
-  db-password: {{ $password | b64enc }}
+  db-password: {{ $password | trim | b64enc }}

--- a/stable/v3io-keycloak/templates/master-creds.yaml
+++ b/stable/v3io-keycloak/templates/master-creds.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     {{ include "v3io-keycloak.labels" . | nindent 4 }}
 data:
-  masterPassword: {{ include "v3io-keycloak.masterPassword" . | b64enc }}
+  masterPassword: {{ include "v3io-keycloak.masterPassword" . | trim | b64enc }}
 {{- end }}

--- a/stable/v3io-mysql/Chart.yaml
+++ b/stable/v3io-mysql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: v3io-mysql
-version: 0.1.2
+version: 0.1.1
 appVersion: "8.0"
 description: MySQL Database With V3IO Storage
 maintainers:

--- a/stable/v3io-mysql/Chart.yaml
+++ b/stable/v3io-mysql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: v3io-mysql
-version: 0.1.1
+version: 0.1.2
 appVersion: "8.0"
 description: MySQL Database With V3IO Storage
 maintainers:


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

For the db password and master password, the password itself is generated once and stored in a secret. The secret isn't deleted and so if the app service restarts, the helm template gets the password from the existing secret. This resulted in a prefixed newline in the password. Added trimming to make sure this doesn't happen.