### PR TITLE
[Jupyter] Default spark driver memory to 2GB

### DIFF
--- a/stable/jupyter/Chart.yaml
+++ b/stable/jupyter/Chart.yaml
@@ -1,4 +1,4 @@
-version: 0.14.35
+version: 0.14.36
 apiVersion: v1
 appVersion: 3.4.8
 name: jupyter

--- a/stable/jupyter/templates/jupyter-configmap.yaml
+++ b/stable/jupyter/templates/jupyter-configmap.yaml
@@ -121,6 +121,7 @@ data:
     cat << EOF >> ${SPARK_HOME}/conf/spark-defaults.conf
     spark.master=spark://{{ .Values.spark.hostname }}:{{ .Values.spark.port }}
     spark.driver.host=$(hostname -i)
+    spark.driver.memory={{ .Values.spark.driverMemory }}
     spark.executor.cores={{ .Values.spark.executorCores }}
     spark.executor.memory={{ .Values.spark.executorMemory }}
     spark.cores.max={{ .Values.spark.maxApplicationCores }}

--- a/stable/jupyter/values.yaml
+++ b/stable/jupyter/values.yaml
@@ -1,6 +1,7 @@
 spark:
   hostname: spark-master
   port: 7077
+  driverMemory: 2G
   executorCores: 1
   executorMemory: 2G
   maxApplicationCores: 4


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

[IG-22439](https://jira.iguazeng.com/browse/IG-22439)

Raise spark driver memory to 2GB when running inside Jupyter.