### PR TITLE
[MLRun] Use new gRPC probing for k8s >= 1.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,6 +332,6 @@ repo-add:
 	helm repo add nuclio https://nuclio.github.io/nuclio/charts
 	helm repo add v3io-stable https://v3io.github.io/helm-charts/stable
 	helm repo add minio https://charts.min.io/
-	helm repo add spark-operator https://googlecloudplatform.github.io/spark-on-k8s-operator
+	helm repo add spark-operator https://kubeflow.github.io/spark-operator
 	helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 	helm repo add bitnami https://charts.bitnami.com/bitnami

--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.9.20
+version: 0.9.21
 appVersion: 1.5.2
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -207,14 +207,24 @@ spec:
           {{- end }}
           {{- if .Values.api.sidecars.logCollector.livenessProbe }}
           livenessProbe:
+          {{- if semverCompare ">=1.24-0" .Capabilities.KubeVersion.GitVersion }}
+            grpc:
+              port: {{ .Values.api.sidecars.logCollector.listenPort }}
+          {{- else }}
             exec:
               command: [ "/grpc_health_probe", "-addr=:{{ .Values.api.sidecars.logCollector.listenPort }}" ]
+          {{- end }}
             {{ toYaml .Values.api.sidecars.logCollector.livenessProbe | nindent 12 }}
           {{- end }}
           {{- if .Values.api.sidecars.logCollector.readinessProbe }}
           readinessProbe:
+          {{- if semverCompare ">=1.24-0" .Capabilities.KubeVersion.GitVersion }}
+            grpc:
+              port: {{ .Values.api.sidecars.logCollector.listenPort }}
+          {{- else }}
             exec:
               command: [ "/grpc_health_probe", "-addr=:{{ .Values.api.sidecars.logCollector.listenPort }}" ]
+          {{- end }}
             {{ toYaml .Values.api.sidecars.logCollector.readinessProbe | nindent 12 }}
           {{- end }}
           resources:


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description
In k8s >= 1.24 there is a built in gRPC probe, instead of using the previous `grpc_health_probe` script.
See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-grpc-liveness-probe

Resolves https://iguazio.atlassian.net/browse/IG-22741