### PR TITLE
[MLRun] Tweak grpc timeouts

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mlrun
-version: 0.9.21
-appVersion: 1.5.2
+version: 0.9.22
+appVersion: 1.6.2
 description: Machine Learning automation and tracking
 sources:
   - https://github.com/mlrun/mlrun

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -310,16 +310,14 @@ api:
       resources:
 
       readinessProbe:
-        initialDelaySeconds: 10
-        timeoutSeconds: 10
-        periodSeconds: 15
-        failureThreshold: 4
+        timeoutSeconds: 3
+        periodSeconds: 10
+        failureThreshold: 3
 
       livenessProbe:
-        initialDelaySeconds: 10
-        timeoutSeconds: 10
-        periodSeconds: 15
-        failureThreshold: 4
+        timeoutSeconds: 3
+        periodSeconds: 10
+        failureThreshold: 3
 
 db:
   name: db


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

Tweak grpc timeouts - seems that AKS doesnt like our old defaults
bumped mlrun default application version

https://iguazio.atlassian.net/browse/IG-22741