### PR TITLE
[MLRun] Bump default image to 1.6.4

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mlrun
-version: 0.9.25
-appVersion: 1.6.2
+version: 0.9.26
+appVersion: 1.6.4
 description: Machine Learning automation and tracking
 sources:
   - https://github.com/mlrun/mlrun

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -64,7 +64,7 @@ api:
 
   image:
     repository: mlrun/mlrun-api
-    tag: 1.5.2
+    tag: 1.6.4
     pullPolicy: IfNotPresent
     pullSecrets: []
 
@@ -297,7 +297,7 @@ api:
 
       image:
         repository: mlrun/log-collector
-        tag: 1.5.2
+        tag: 1.6.4
         pullPolicy: IfNotPresent
         pullSecrets: []
 
@@ -511,7 +511,7 @@ ui:
 
   image:
     repository: mlrun/mlrun-ui
-    tag: 1.5.2
+    tag: 1.6.4
     pullPolicy: IfNotPresent
     pullSecrets: []
 


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description
Align with the latest GA MLRun version