### PR TITLE
[spark-operator] Add more permissions

### DIFF
--- a/stable/spark-operator/Chart.yaml
+++ b/stable/spark-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator.
-version: 2.0.4
+version: 2.0.5
 appVersion: 2.0.2
 keywords:
 - apache spark

--- a/stable/spark-operator/templates/rbac.yaml
+++ b/stable/spark-operator/templates/rbac.yaml
@@ -61,8 +61,12 @@ rules:
   - create
   - get
   - list
-  - delete
+  - watch
+  - create
   - update
+  - patch
+  - delete
+  - deletecollection
 - apiGroups:
   - extensions
   - networking.k8s.io


### PR DESCRIPTION
As per [upstream](https://github.com/kubeflow/spark-operator/blob/v2.0.2/charts/spark-operator-chart/templates/spark/rbac.yaml#L42).

[IG-23245](https://iguazio.atlassian.net/browse/IG-23245)

### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)


[IG-23245]: https://iguazio.atlassian.net/browse/IG-23245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ