### PR TITLE
[spark-operator] Disable prometheus metrics

### DIFF
--- a/stable/spark-operator/Chart.yaml
+++ b/stable/spark-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator.
-version: 2.0.5
+version: 2.0.6
 appVersion: 2.0.2
 keywords:
 - apache spark

--- a/stable/spark-operator/templates/deployment.yaml
+++ b/stable/spark-operator/templates/deployment.yaml
@@ -61,9 +61,10 @@ spec:
         - --enable-batch-scheduler={{ .Values.batchScheduler.enable }}
         {{- if .Values.metrics.enable }}
         - --enable-metrics=true
-        - --metrics-labels=app_type
         - --metrics-bind-address=:{{ .Values.metrics.port }}
         - --metrics-endpoint={{ .Values.metrics.endpoint }}
+        - --metrics-labels=app_type
+        - --metrics-prefix={{ .Values.prometheus.metrics.prefix }}
         {{- end }}
         {{- if gt (int .Values.replicaCount) 1 }}
         - --leader-election=true

--- a/stable/spark-operator/values.yaml
+++ b/stable/spark-operator/values.yaml
@@ -110,7 +110,8 @@ webhook:
 
 metrics:
   # -- Enable prometheus metric scraping
-  enable: true
+  # TODO: IG-23248
+  enable: false
   # -- Metrics port
   port: 10254
   # -- Metrics port name


### PR DESCRIPTION
Due to [IG-23248](https://iguazio.atlassian.net/browse/IG-23248).

Also add missing `--metrics-prefix` parameter.

### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

[IG-23248]: https://iguazio.atlassian.net/browse/IG-23248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ