### PR TITLE
[MLRun] Retain the DSN configuration within a secret

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.10.2
+version: 0.10.3
 appVersion: 1.7.1
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/_helpers.tpl
+++ b/stable/mlrun/templates/_helpers.tpl
@@ -408,3 +408,16 @@ Resolve the nuclio api address (for mlrun-kit)
 {{- printf "http://%s:8070" (include "mlrun.nuclio.dashboardName" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Resolve the MLRun DB DSN
+- If overrideDsn is set, use the external DB (overrideDsn).
+- If overrideDsn is not set, use the internal DB (dsn).
+*/}}
+{{- define "mlrun.dsn" -}}
+  {{- if .Values.httpDB.overrideDsn -}}
+    {{- printf .Values.httpDB.overrideDsn -}}
+  {{- else -}}
+    {{- printf .Values.httpDB.dsn -}}
+  {{- end -}}
+{{- end -}}

--- a/stable/mlrun/templates/alerts-deployment.yaml
+++ b/stable/mlrun/templates/alerts-deployment.yaml
@@ -76,9 +76,15 @@ spec:
             value: {{ template "mlrun.defaultDockerRegistry.imagePullSecretName" . }}
           {{- end }}
           - name: MLRUN_HTTPDB__DSN
-            value: {{ .Values.httpDB.dsn }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "mlrun.db.fullname" . }}
+                key: dsn
           - name: MLRUN_HTTPDB__OLD_DSN
-            value: {{ .Values.httpDB.oldDsn }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "mlrun.db.fullname" . }}
+                key: oldDsn
           {{- if .Values.v3io.enabled }}
           - name: V3IO_ACCESS_KEY
             valueFrom:

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -85,9 +85,15 @@ spec:
             value: {{ template "mlrun.defaultDockerRegistry.imagePullSecretName" . }}
           {{- end }}
           - name: MLRUN_HTTPDB__DSN
-            value: {{ .Values.httpDB.dsn }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "mlrun.db.fullname" . }}
+                key: dsn
           - name: MLRUN_HTTPDB__OLD_DSN
-            value: {{ .Values.httpDB.oldDsn }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "mlrun.db.fullname" . }}
+                key: oldDsn
           {{- if .Values.v3io.enabled }}
           - name: V3IO_ACCESS_KEY
             valueFrom:

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -79,9 +79,15 @@ spec:
             value: {{ template "mlrun.defaultDockerRegistry.imagePullSecretName" . }}
           {{- end }}
           - name: MLRUN_HTTPDB__DSN
-            value: {{ .Values.httpDB.dsn }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "mlrun.db.fullname" . }}
+                key: dsn
           - name: MLRUN_HTTPDB__OLD_DSN
-            value: {{ .Values.httpDB.oldDsn }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "mlrun.db.fullname" . }}
+                key: oldDsn
           {{- if .Values.v3io.enabled }}
           - name: V3IO_ACCESS_KEY
             valueFrom:

--- a/stable/mlrun/templates/db-secret.yaml
+++ b/stable/mlrun/templates/db-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mlrun.db.fullname" . }}
+  labels:
+    {{- include "mlrun.db.labels" . | nindent 4 }}
+data:
+  dsn: {{ include "mlrun.dsn" . | b64enc }}
+  oldDsn: {{ toYaml .Values.httpDB.oldDsn | b64enc }}

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -664,6 +664,9 @@ httpDB:
   # sqlite database dsn from which to migrate if using mysql database
   oldDsn: ""
 
+  # for external db
+  overrideDsn:
+
   # Values to insert if mysql database is needed
   # dsn: "mysql+pymysql://root@mlrun-db:3306/mlrun"
   # oldDsn: "sqlite:////mlrun/db/mlrun.db?check_same_thread=false"


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

Saving the DSN and old DSN in a secret instead of in the deployment.
Additionally, adding `overrideDsn` to support external DBs:
If overrideDsn is set, use the external DB (overrideDsn).
If overrideDsn is not set, use the internal DB (dsn).

https://iguazio.atlassian.net/browse/IG-23233
https://iguazio.atlassian.net/browse/ML-8219
