### PR TITLE
[MLRun] Add ingressClassName to Ingress manifests

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.10.4
+version: 0.10.5
 appVersion: 1.7.2
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/api-chief-ingress.yaml
+++ b/stable/mlrun/templates/api-chief-ingress.yaml
@@ -14,6 +14,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: {{ .Values.api.chief.ingress.ingressClassName | default "" }}
 {{- if .Values.api.chief.ingress.tls }}
   tls:
   {{- range .Values.api.chief.ingress.tls }}

--- a/stable/mlrun/templates/api-ingress.yaml
+++ b/stable/mlrun/templates/api-ingress.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: {{ .Values.api.ingress.ingressClassName | default "" }}
 {{- if .Values.api.ingress.tls }}
   tls:
   {{- range .Values.api.ingress.tls }}

--- a/stable/mlrun/templates/ui-ingress.yaml
+++ b/stable/mlrun/templates/ui-ingress.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: {{ .Values.ui.ingress.ingressClassName | default "" }}
 {{- if .Values.ui.ingress.tls }}
   tls:
   {{- range .Values.ui.ingress.tls }}

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -73,6 +73,7 @@ api:
 
     ingress:
       enabled: false
+      ingressClassName: ""
       annotations: { }
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
@@ -125,6 +126,7 @@ api:
   ingress:
     enabled: false
     annotations: {}
+    ingressClassName: ""
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     hosts:
@@ -581,6 +583,7 @@ ui:
   ingress:
     enabled: false
     annotations: {}
+    ingressClassName: ""
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     hosts:


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

Since the ingressClass steering through annotations is deprecated, the ingressClassName field is now added to Ingress templates and exposed via Values to set the desired ingressClass. Default is an empty string for compatibility.
