### PR TITLE
[spark-operator] Rename UI Ingress URL format for provazio bwc

### DIFF
--- a/stable/spark-operator/Chart.yaml
+++ b/stable/spark-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator.
-version: 2.0.9
+version: 2.0.10
 appVersion: 2.0.2
 keywords:
 - apache spark

--- a/stable/spark-operator/templates/controller/deployment.yaml
+++ b/stable/spark-operator/templates/controller/deployment.yaml
@@ -70,7 +70,7 @@ spec:
         - --enable-ui-service=true
         {{- end }}
         {{- if .Values.controller.uiIngress.enable }}
-        {{- with .Values.controller.uiIngress.urlFormat }}
+        {{- with .Values.ingressUrlFormat }}
         - --ingress-url-format={{ . }}
         {{- end }}
         {{- end }}

--- a/stable/spark-operator/values.yaml
+++ b/stable/spark-operator/values.yaml
@@ -49,6 +49,8 @@ image:
   pullSecrets: []
   # - name: <secret-name>
 
+ingressUrlFormat: ""
+
 controller:
   # -- Number of replicas of controller.
   replicas: 1
@@ -69,6 +71,7 @@ controller:
     enable: true
     # -- Ingress URL format.
     # Required if `controller.uiIngress.enable` is true.
+    # Use ingressUrlFormat instead for provazio backward compatibility
     urlFormat: ""
 
   batchScheduler:


### PR DESCRIPTION
Together with #1060, this fixes [IG-23317](https://iguazio.atlassian.net/browse/IG-23317).

### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)


[IG-23317]: https://iguazio.atlassian.net/browse/IG-23317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ