### PR TITLE
[spark-operator] Re-add `.Value.priorityClassName`

### DIFF
--- a/stable/spark-operator/Chart.yaml
+++ b/stable/spark-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator.
-version: 2.0.10
+version: 2.0.11
 appVersion: 2.0.2
 keywords:
 - apache spark

--- a/stable/spark-operator/templates/controller/deployment.yaml
+++ b/stable/spark-operator/templates/controller/deployment.yaml
@@ -165,7 +165,7 @@ spec:
       tolerations:
       {{- toYaml . | nindent 6 }}
       {{- end }}
-      {{- with .Values.controller.priorityClassName }}
+      {{- with (.Values.controller.priorityClassName | default .Values.priorityClassName) }}
       priorityClassName: {{ . }}
       {{- end }}
       serviceAccountName: {{ include "spark-operator.controller.serviceAccountName" . }}

--- a/stable/spark-operator/templates/webhook/deployment.yaml
+++ b/stable/spark-operator/templates/webhook/deployment.yaml
@@ -138,7 +138,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.webhook.priorityClassName }}
+      {{- with (.Values.webhook.priorityClassName | default .Values.priorityClassName) }}
       priorityClassName: {{ . }}
       {{- end }}
       serviceAccountName: {{ include "spark-operator.webhook.serviceAccountName" . }}

--- a/stable/spark-operator/values.yaml
+++ b/stable/spark-operator/values.yaml
@@ -51,6 +51,8 @@ image:
 
 ingressUrlFormat: ""
 
+priorityClassName: ""
+
 controller:
   # -- Number of replicas of controller.
   replicas: 1


### PR DESCRIPTION
Because provazio sets this value and doesn't set `.Value.controller.priorityClassName` and `.Value.webhook.priorityClassName`.

Fixes [IG-23414](https://iguazio.atlassian.net/browse/IG-23414).

### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

[IG-23414]: https://iguazio.atlassian.net/browse/IG-23414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ