### PR TITLE
[MLRun] Configurable DB Pod Default Affinity Type

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.10.6
+version: 0.10.7
 appVersion: 1.7.2
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/db-deployment.yaml
+++ b/stable/mlrun/templates/db-deployment.yaml
@@ -144,7 +144,11 @@ spec:
     {{- else }}
       affinity:
         podAffinity:
+          {{- if eq .Values.db.defaultAffinityType "preferred" }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+          {{- else }}
           requiredDuringSchedulingIgnoredDuringExecution:
+          {{- end }}
             - labelSelector:
                 matchLabels:
                   {{- include "mlrun.api.selectorLabels" . | nindent 18 }}

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -430,6 +430,10 @@ db:
   ##
   affinity: {}
 
+  # When using the default affinity (run db pod on the api pod's node) and not overriding the above affinity value,
+  # choose whether the affinity is required or preferred
+  defaultAffinityType: "preferred"
+
   priorityClassName: ""
 
   podSecurityContext:


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

https://iguazio.atlassian.net/browse/ML-9518

- When using the default db pod affinity (run db pod on the api pod's node) and not overriding the above affinity value, allow configuring whether the affinity is required or preferred
- Default is now preferred

