### PR TITLE
[MLRun] Fix MLRun DB pod affinity

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.10.7
+version: 0.10.8
 appVersion: 1.7.2
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/db-deployment.yaml
+++ b/stable/mlrun/templates/db-deployment.yaml
@@ -146,13 +146,19 @@ spec:
         podAffinity:
           {{- if eq .Values.db.defaultAffinityType "preferred" }}
           preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    {{- include "mlrun.db.selectorLabels" . | nindent 18 }}
+                topologyKey: "kubernetes.io/hostname"
           {{- else }}
           requiredDuringSchedulingIgnoredDuringExecution:
-          {{- end }}
             - labelSelector:
                 matchLabels:
-                  {{- include "mlrun.api.selectorLabels" . | nindent 18 }}
+                  {{- include "mlrun.db.selectorLabels" . | nindent 16 }}
               topologyKey: "kubernetes.io/hostname"
+          {{- end }}
     {{- end }}
     {{- with .Values.db.tolerations }}
       tolerations:

--- a/stable/mlrun/templates/db-deployment.yaml
+++ b/stable/mlrun/templates/db-deployment.yaml
@@ -150,13 +150,13 @@ spec:
               podAffinityTerm:
                 labelSelector:
                   matchLabels:
-                    {{- include "mlrun.db.selectorLabels" . | nindent 18 }}
+                    {{- include "mlrun.api.selectorLabels" . | nindent 18 }}
                 topologyKey: "kubernetes.io/hostname"
           {{- else }}
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchLabels:
-                  {{- include "mlrun.db.selectorLabels" . | nindent 16 }}
+                  {{- include "mlrun.api.selectorLabels" . | nindent 16 }}
               topologyKey: "kubernetes.io/hostname"
           {{- end }}
     {{- end }}


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

The changes introduced in https://github.com/v3io/helm-charts/pull/1066 were not aligned to the format of each pod affinity type:
`preferredDuringSchedulingIgnoredDuringExecution` expects list items with `weight` and `podAffinityTerm`, while `requiredDuringSchedulingIgnoredDuringExecution` expects a list with the contents of the preferred's `podAffinityTerm`.

Reference: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/

https://iguazio.atlassian.net/browse/ML-9624
