### PR TITLE
[spark-operator] Set `hostNetwork` to true to resolve EKS issue

### DIFF
--- a/stable/spark-operator/Chart.yaml
+++ b/stable/spark-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator.
-version: 2.0.11
+version: 2.0.12
 appVersion: 2.0.2
 keywords:
 - apache spark

--- a/stable/spark-operator/templates/controller/deployment.yaml
+++ b/stable/spark-operator/templates/controller/deployment.yaml
@@ -45,7 +45,7 @@ spec:
       {{- end }}
       {{- end }}
     spec:
-      hostNetwork: {{ .Values.hostNetwork.enabled }}
+      hostNetwork: {{ .Values.controller.hostNetwork.enabled }}
       containers:
       - name: spark-operator-controller
         image: {{ include "spark-operator.image" . }}

--- a/stable/spark-operator/templates/webhook/deployment.yaml
+++ b/stable/spark-operator/templates/webhook/deployment.yaml
@@ -39,6 +39,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      hostNetwork: {{ .Values.webhook.hostNetwork.enabled }}
       containers:
       - name: spark-operator-webhook
         image: {{ include "spark-operator.image" . }}

--- a/stable/spark-operator/values.yaml
+++ b/stable/spark-operator/values.yaml
@@ -204,6 +204,9 @@ controller:
       # -- Specifies the maximum delay duration for the workqueue rate limiter.
       duration: 6h
 
+  hostNetwork:
+    enabled: true
+
 webhook:
 
   # -- Specifies whether to enable webhook.
@@ -325,6 +328,9 @@ webhook:
     # -- The number of pods that must be available.
     # Require `webhook.replicas` to be greater than 1
     minAvailable: 1
+
+  hostNetwork:
+    enabled: true
 
 spark:
   # -- List of namespaces where to run spark jobs.


### PR DESCRIPTION
Fixes [IG-23489](https://iguazio.atlassian.net/browse/IG-23489).

### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)


[IG-23489]: https://iguazio.atlassian.net/browse/IG-23489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ