### PR TITLE
[MLRun] Fix DB's pod affinity indentation

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.10.8
+version: 0.10.9
 appVersion: 1.7.2
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/db-deployment.yaml
+++ b/stable/mlrun/templates/db-deployment.yaml
@@ -150,13 +150,13 @@ spec:
               podAffinityTerm:
                 labelSelector:
                   matchLabels:
-                    {{- include "mlrun.api.selectorLabels" . | nindent 18 }}
+                    {{- include "mlrun.api.chief.selectorLabels" . | nindent 20 }}
                 topologyKey: "kubernetes.io/hostname"
           {{- else }}
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchLabels:
-                  {{- include "mlrun.api.selectorLabels" . | nindent 16 }}
+                  {{- include "mlrun.api.chief.selectorLabels" . | nindent 18 }}
               topologyKey: "kubernetes.io/hostname"
           {{- end }}
     {{- end }}


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

Bad indentation resulted with and empty label selector in the DB's podAffinity, causing all pods to be scheduled on the same node as the DB.

After the fix, the affinity is as follows:
```
      affinity:
        podAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - podAffinityTerm:
              labelSelector:
                matchLabels:
                  app.kubernetes.io/component: api
                  app.kubernetes.io/instance: mlrun
                  app.kubernetes.io/name: mlrun
                  app.kubernetes.io/sub-component: chief
                  release: mlrun
              topologyKey: kubernetes.io/hostname
            weight: 100
```

https://iguazio.atlassian.net/browse/ML-9676