### PR TITLE
[spark-operator] Remove `hostNetwork` from controller

### DIFF
--- a/stable/spark-operator/Chart.yaml
+++ b/stable/spark-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator.
-version: 2.0.12
+version: 2.0.13
 appVersion: 2.0.2
 keywords:
 - apache spark

--- a/stable/spark-operator/templates/controller/deployment.yaml
+++ b/stable/spark-operator/templates/controller/deployment.yaml
@@ -45,7 +45,6 @@ spec:
       {{- end }}
       {{- end }}
     spec:
-      hostNetwork: {{ .Values.controller.hostNetwork.enabled }}
       containers:
       - name: spark-operator-controller
         image: {{ include "spark-operator.image" . }}

--- a/stable/spark-operator/values.yaml
+++ b/stable/spark-operator/values.yaml
@@ -204,9 +204,6 @@ controller:
       # -- Specifies the maximum delay duration for the workqueue rate limiter.
       duration: 6h
 
-  hostNetwork:
-    enabled: true
-
 webhook:
 
   # -- Specifies whether to enable webhook.


### PR DESCRIPTION
Following #1068.

Fixes [IG-23926](https://iguazio.atlassian.net/browse/IG-23926).

### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

[IG-23926]: https://iguazio.atlassian.net/browse/IG-23926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ