### PR TITLE
[spark-operator] Keep webhook service name backward compatible with 3.6.1

### DIFF
--- a/stable/spark-operator/Chart.yaml
+++ b/stable/spark-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator.
-version: 2.0.13
+version: 2.0.14
 appVersion: 2.0.2
 keywords:
 - apache spark

--- a/stable/spark-operator/templates/webhook/_helpers.tpl
+++ b/stable/spark-operator/templates/webhook/_helpers.tpl
@@ -88,7 +88,7 @@ Create the name of the secret to be used by webhook
 Create the name of the service to be used by webhook
 */}}
 {{- define "spark-operator.webhook.serviceName" -}}
-{{ include "spark-operator.webhook.name" . }}-svc
+{{ include "spark-operator.webhook.name" . }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
[IG-23977](https://iguazio.atlassian.net/browse/IG-23977)

### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

[IG-23977]: https://iguazio.atlassian.net/browse/IG-23977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ