### PR TITLE
[Workflows] Update `manusa/actions-setup-minikube` to resolve `Unsupported OS` failure in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,7 +102,7 @@ jobs:
       with:
         version: "v3.9.1"
 
-    - uses: manusa/actions-setup-minikube@v2.10.0
+    - uses: manusa/actions-setup-minikube@v2.14.0
       if: steps.chart_changed.outputs.any_changed == 'true'
       with:
         minikube version: "v1.32.0"


### PR DESCRIPTION
```
Error: Unsupported OS, action only works in Ubuntu 18, 20, or 22
```