### PR TITLE
[MLRun] Align OPA container args to latest version

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.11.1
+version: 0.11.2
 appVersion: 1.8.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -184,6 +184,7 @@ spec:
             - "--log-level={{ .Values.api.opa.logLevel }}"
             - "--log-format={{ .Values.api.opa.logFormat }}"
             - "--ignore=.*"
+            - "--disable-telemetry"
           volumeMounts:
             - readOnly: true
               mountPath: /config

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -179,6 +179,7 @@ spec:
           args:
             - "run"
             - "--server"
+            - "--addr=0.0.0.0:8181"
             - "--config-file=/config/config.yaml"
             - "--log-level={{ .Values.api.opa.logLevel }}"
             - "--log-format={{ .Values.api.opa.logFormat }}"

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -178,6 +178,7 @@ spec:
             - "--log-level={{ .Values.api.opa.logLevel }}"
             - "--log-format={{ .Values.api.opa.logFormat }}"
             - "--ignore=.*"
+            - "--disable-telemetry"
           volumeMounts:
             - readOnly: true
               mountPath: /config

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -173,6 +173,7 @@ spec:
           args:
             - "run"
             - "--server"
+            - "--addr=0.0.0.0:8181"
             - "--config-file=/config/config.yaml"
             - "--log-level={{ .Values.api.opa.logLevel }}"
             - "--log-format={{ .Values.api.opa.logFormat }}"


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description
Latest OPA clients (version 1.5.1) require the listening address to be passed explicitly.

https://iguazio.atlassian.net/browse/IG-23798
https://iguazio.atlassian.net/browse/IG-23799
