### PR TITLE
[MLRun] Switch probes to MySQL admin listener

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.11.6
+version: 0.11.7
 appVersion: 1.9.2
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/db-configmap-init.yaml
+++ b/stable/mlrun/templates/db-configmap-init.yaml
@@ -10,6 +10,7 @@ data:
     -- Allow passwordless (insecure) access to root user from anywhere
     CREATE USER IF NOT EXISTS 'root'@'%';
     GRANT ALL PRIVILEGES ON *.* TO 'root'@'%';
+    GRANT SERVICE_CONNECTION_ADMIN ON *.* TO 'root'@'localhost';
     FLUSH PRIVILEGES;
     CREATE DATABASE IF NOT EXISTS mlrun;
     {{- if not .Values.modelMonitoring.dsn }}

--- a/stable/mlrun/templates/db-configmap.yaml
+++ b/stable/mlrun/templates/db-configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
 
   health_check.sh: |
-    mysql -u root -S /var/run/mysqld/mysql.sock -e 'SELECT 1'
+    mysqladmin --protocol=TCP -h {{ .Values.db.dbConfiguration.adminAddress }} -P {{ .Values.db.dbConfiguration.adminPort }} -uroot ping
 
   graceful_shutdown.sh: |
     mysql -u root -S /var/run/mysqld/mysql.sock -e 'SET GLOBAL innodb_fast_shutdown = 0; FLUSH TABLES WITH READ LOCK;'
@@ -60,5 +60,7 @@ data:
       --innodb-page-cleaners={{- .Values.db.dbConfiguration.innodb.pageCleaners }} \
       --innodb-io-capacity={{- .Values.db.dbConfiguration.innodb.IOCapacity }} \
       --innodb-flush-neighbors={{- .Values.db.dbConfiguration.innodb.flushNeighbors }} \
-      --socket=$MYSQL_SOCKET_FILE
+      --socket=$MYSQL_SOCKET_FILE \
+      --admin-address={{- .Values.db.dbConfiguration.adminAddress }} \
+      --admin-port={{- .Values.db.dbConfiguration.adminPort }}
 {{- end }}

--- a/stable/mlrun/templates/db-deployment.yaml
+++ b/stable/mlrun/templates/db-deployment.yaml
@@ -52,9 +52,6 @@ spec:
           - name: mysql
             containerPort: 3306
             protocol: TCP
-          - name: mysql-admin
-            containerPort: {{ .Values.db.dbConfiguration.adminPort }}
-            protocol: TCP
           lifecycle:
             preStop:
               exec:

--- a/stable/mlrun/templates/db-deployment.yaml
+++ b/stable/mlrun/templates/db-deployment.yaml
@@ -52,6 +52,9 @@ spec:
           - name: mysql
             containerPort: 3306
             protocol: TCP
+          - name: mysql-admin
+            containerPort: {{ .Values.db.dbConfiguration.adminPort }}
+            protocol: TCP
           lifecycle:
             preStop:
               exec:

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -546,7 +546,8 @@ db:
     # ideally should be calculated by : <number-of-mlrun-instances> * <max-workers> + 1 ( for SUPER account )
     # SUPER is a MySQL privilege that grants admin rights to the user.
     maxConnections: 512
-
+    adminAddress: 127.0.0.1
+    adminPort: 33062
     # set to 1 day
     # https://dev.mysql.com/doc/refman/8.4/en/replication-options-binary-log.html#sysvar_binlog_expire_logs_seconds
     # binlogs are useful for replication, backup, and point-in-time recovery


### PR DESCRIPTION
* Start `mysqld` with `--admin-address` (127.0.0.1) and `--admin-port` (33062) and expose the port on the pod, but not in the Service.
* Change `health_check.sh` to `mysqladmin ping` over the admin port – avoids ERROR 1040 restarts when 3306 is saturated.
* Grant `SERVICE_CONNECTION_ADMIN` to `root@localhost` so the probe can always connect, even at max_connections.
* Add `db.dbConfiguration.adminAddress` and `adminPort` to`values.yaml`.

https://iguazio.atlassian.net/browse/ML-9876

### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)

[### Description
](https://iguazio.atlassian.net/browse/ML-9876)