### PR TITLE
[v3io-framesd] Remove CSV backend to fix config

### DIFF
--- a/stable/v3io-framesd/Chart.yaml
+++ b/stable/v3io-framesd/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: V3IO frames daemon
 name: v3io-framesd
-version: 0.8.0
+version: 0.8.1
 home: https://iguazio.com
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
 sources:

--- a/stable/v3io-framesd/templates/v3io-framesd-configmap.yaml
+++ b/stable/v3io-framesd/templates/v3io-framesd-configmap.yaml
@@ -18,9 +18,6 @@ data:
     backends:
 {{- range $index, $backend := .Values.config.backends }}
       - type: {{ $backend }}
-{{- if eq $backend "csv" }}
-        rootdir: ""
-{{- end }}
 {{- end }}
 
   v3io-framesd.sh: |

--- a/stable/v3io-framesd/values.yaml
+++ b/stable/v3io-framesd/values.yaml
@@ -14,7 +14,6 @@ config:
     - kv
     - tsdb
     - stream
-    - csv
 
 v3io:
   api:


### PR DESCRIPTION
Following removal of CSV backend from V3IO frames in https://github.com/v3io/frames/releases/tag/v0.13.10.

[IG-24276](https://iguazio.atlassian.net/browse/IG-24276)

### Checklist
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

[IG-24276]: https://iguazio.atlassian.net/browse/IG-24276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ