### PR TITLE
[V3io-configs] Fix int-like usernames encoding

### DIFF
--- a/stable/v3io-configs/Chart.yaml
+++ b/stable/v3io-configs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: V3IO configuration templates
 name: v3io-configs
-version: 0.13.1
+version: 0.13.2
 icon: https://www.iguazio.com/wp-content/uploads/2019/10/Iguazio-Logo.png
 sources:
   - https://github.com/iguazio/kubeops/

--- a/stable/v3io-configs/templates/_env.tpl
+++ b/stable/v3io-configs/templates/_env.tpl
@@ -1,15 +1,15 @@
 {{- define "v3io-configs.auth-only.secret" -}}
 {{- if .Values.v3io.username }}
-username: {{ .Values.v3io.username | b64enc | quote }}
+username: {{ .Values.v3io.username | toString | b64enc | quote }}
 {{- end  }}
 {{- if .Values.v3io.tenant }}
-tenant: {{ .Values.v3io.tenant | b64enc | quote }}
+tenant: {{ .Values.v3io.tenant | toString | b64enc | quote }}
 {{- end  }}
 {{- if .Values.v3io.password }}
-password: {{ .Values.v3io.password | b64enc | quote }}
+password: {{ .Values.v3io.password | toString | b64enc | quote }}
 {{- end  }}
 {{- if .Values.v3io.accessKey }}
-accessKey: {{ .Values.v3io.accessKey | b64enc | quote }}
+accessKey: {{ .Values.v3io.accessKey | toString | b64enc | quote }}
 {{- end  }}
 {{- end -}}
 


### PR DESCRIPTION
Ensure input is string before base64 encoding

### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

https://iguazio.atlassian.net/browse/IG-24289