### PR TITLE
[mlrun] Bump version to 0.11.9 and update liveness/readiness probes to use grpc

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.11.8
+version: 0.11.9
 appVersion: 1.9.2
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -221,24 +221,14 @@ spec:
           {{- end }}
           {{- if .Values.api.sidecars.logCollector.livenessProbe }}
           livenessProbe:
-          {{- if semverCompare ">=1.24-0" .Capabilities.KubeVersion.GitVersion }}
             grpc:
               port: {{ .Values.api.sidecars.logCollector.listenPort }}
-          {{- else }}
-            exec:
-              command: [ "/grpc_health_probe", "-addr=:{{ .Values.api.sidecars.logCollector.listenPort }}" ]
-          {{- end }}
             {{ toYaml .Values.api.sidecars.logCollector.livenessProbe | nindent 12 }}
           {{- end }}
           {{- if .Values.api.sidecars.logCollector.readinessProbe }}
           readinessProbe:
-          {{- if semverCompare ">=1.24-0" .Capabilities.KubeVersion.GitVersion }}
             grpc:
               port: {{ .Values.api.sidecars.logCollector.listenPort }}
-          {{- else }}
-            exec:
-              command: [ "/grpc_health_probe", "-addr=:{{ .Values.api.sidecars.logCollector.listenPort }}" ]
-          {{- end }}
             {{ toYaml .Values.api.sidecars.logCollector.readinessProbe | nindent 12 }}
           {{- end }}
           resources:

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -215,14 +215,14 @@ spec:
           {{- end }}
           {{- if .Values.api.sidecars.logCollector.livenessProbe }}
           livenessProbe:
-            exec:
-              command: [ "/grpc_health_probe", "-addr=:{{ .Values.api.sidecars.logCollector.listenPort }}" ]
+            grpc:
+              port: {{ .Values.api.sidecars.logCollector.listenPort }}
             {{ toYaml .Values.api.sidecars.logCollector.livenessProbe | nindent 12 }}
           {{- end }}
           {{- if .Values.api.sidecars.logCollector.readinessProbe }}
           readinessProbe:
-            exec:
-              command: [ "/grpc_health_probe", "-addr=:{{ .Values.api.sidecars.logCollector.listenPort }}" ]
+            grpc:
+              port: {{ .Values.api.sidecars.logCollector.listenPort }}
             {{ toYaml .Values.api.sidecars.logCollector.readinessProbe | nindent 12 }}
           {{- end }}
           resources:


### PR DESCRIPTION
no use that binary really, use grpc health endpoint


### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

align chief and worker and set both to use grpc probes and not exec-ing

https://iguazio.atlassian.net/browse/ML-11047