### PR TITLE
[Pipelines-v2] Add indexes to KFP DB, to prevent timeouts when fetching large amounts of KFP runs

### DIFF
--- a/stable/pipelines-v2/Chart.yaml
+++ b/stable/pipelines-v2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: ">=2.5.0"
-version: 0.11.12
+version: 0.11.13
 name: pipelines-v2
 description: Kubeflow pipelines framework for machine learning
 home: https://www.kubeflow.org/

--- a/stable/pipelines-v2/templates/mysql/configmap-kf.yaml
+++ b/stable/pipelines-v2/templates/mysql/configmap-kf.yaml
@@ -129,6 +129,69 @@ data:
     wait "${NEW_PID}"
     touch ${LOCK_FILE}
     echo "Import complete."
+  fix-kfp-indices.sql: |
+    -- This script adds missing indexes and makes some existing indexes invisible to
+    -- improve performance of common queries in Kubeflow Pipelines 2.5 on MySQL 8.4.
+    -- Run details index
+    SET @idx_exists = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'run_details'
+    AND INDEX_NAME = 'run_details_experiment_created_uuid_desc'
+    );
+    SET @sql = IF(@idx_exists = 0,
+    'CREATE INDEX run_details_experiment_created_uuid_desc ON run_details (ExperimentUUID, CreatedAtInSec DESC, UUID DESC);',
+    'SELECT "Index run_details_experiment_created_uuid_desc already exists";'
+    );
+    PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+    -- resource_references index
+    SET @idx_exists = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'resource_references'
+    AND INDEX_NAME = 'rr_type_uuid_payload'
+    );
+    SET @sql = IF(@idx_exists = 0,
+    'CREATE INDEX rr_type_uuid_payload ON resource_references (ResourceType, ResourceUUID, Payload(255));',
+    'SELECT "Index rr_type_uuid_payload already exists";'
+    );
+    PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+    -- tasks index
+    SET @idx_exists = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'tasks'
+    AND INDEX_NAME = 'tasks_runuuid_payload'
+    );
+    SET @sql = IF(@idx_exists = 0,
+    'CREATE INDEX tasks_runuuid_payload ON tasks (RunUUID, Payload(255));',
+    'SELECT "Index tasks_runuuid_payload already exists";'
+    );
+    PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+    -- run_metrics index
+    SET @idx_exists = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'run_metrics'
+    AND INDEX_NAME = 'run_metrics_runuuid_payload'
+    );
+    SET @sql = IF(@idx_exists = 0,
+    'CREATE INDEX run_metrics_runuuid_payload ON run_metrics (RunUUID, Payload(255));',
+    'SELECT "Index run_metrics_runuuid_payload already exists";'
+    );
+    PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+    -- Make specific indexes invisible (no error if they don't exist)
+    ALTER TABLE run_details ALTER INDEX experimentuuid_createatinsec INVISIBLE;
+    ALTER TABLE run_details ALTER INDEX idx_created_desc INVISIBLE;
+    ALTER TABLE run_details ALTER INDEX idx_run_details_created_uuid_asc INVISIBLE;
+
+    -- Refresh statistics
+    ANALYZE TABLE run_details;
+
 
   start-mysql.sh: |
     #!/usr/bin/env bash
@@ -138,6 +201,7 @@ data:
     : "${MYSQL_PWD:?Environment variable MYSQL_PWD must be set.}"
 
     readonly RAW_INIT_SCRIPT="/etc/config/mysql/init-scripts/create_user.sql"
+    readonly FIX_INDICES_SCRIPT="/etc/config/mysql/init-scripts/fix-kfp-indices.sql"
     readonly INIT_SCRIPT="/tmp/create_user.sql"
     readonly BASE_DIR="/var/lib/mysql"
     readonly DATA_DIR="${BASE_DIR}/data"
@@ -146,6 +210,8 @@ data:
     sed -e "s|\${DB_USER}|${DB_USER}|g" \
         -e "s|\${MYSQL_PWD}|${MYSQL_PWD}|g" \
         "${RAW_INIT_SCRIPT}" > "${INIT_SCRIPT}"
+
+    cat "${FIX_INDICES_SCRIPT}" >> "${INIT_SCRIPT}"
 
     MYSQLD_OPTS=(
       --mysql-native-password=ON


### PR DESCRIPTION

### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

Add indexes to KFP DB, to prevent timeouts when fetching large amounts of KFP runs.(https://iguazio.atlassian.net/browse/ML-10987)