### PR TITLE
[Pipelines-v2] Disable redo log in mysql while restoring KFP dumps from KFP 1.8 to KFP 2.5

### DIFF
--- a/stable/pipelines-v2/Chart.yaml
+++ b/stable/pipelines-v2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: ">=2.5.0"
-version: 0.11.13
+version: 0.11.14
 name: pipelines-v2
 description: Kubeflow pipelines framework for machine learning
 home: https://www.kubeflow.org/

--- a/stable/pipelines-v2/templates/metadata/grpc-deployment.yaml
+++ b/stable/pipelines-v2/templates/metadata/grpc-deployment.yaml
@@ -130,6 +130,12 @@ spec:
           ports:
             - name: grpc-api
               containerPort: 8080
+          startupProbe:
+            tcpSocket:
+              port: grpc-api
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 360
           livenessProbe:
             tcpSocket:
               port: grpc-api

--- a/stable/pipelines-v2/templates/mysql/configmap-kf.yaml
+++ b/stable/pipelines-v2/templates/mysql/configmap-kf.yaml
@@ -129,7 +129,8 @@ data:
     echo "Importing mlpipeline database from ${PIPELINE_DUMP_FILE}..."
     mysql --defaults-extra-file="${SECRET_FILE}" --socket "${SOCKET}" mlpipeline < ${PIPELINE_DUMP_FILE}
     mysql_exec "ALTER INSTANCE ENABLE INNODB REDO_LOG;"
-
+    mysql_exec "SET PERSIST innodb_stats_auto_recalc = DEFAULT;"
+    mysql_exec "SET PERSIST innodb_lock_wait_timeout = DEFAULT;"
     mysqladmin --defaults-extra-file="${SECRET_FILE}" --socket "${SOCKET}" shutdown
     wait "${NEW_PID}"
     touch ${LOCK_FILE}

--- a/stable/pipelines-v2/templates/mysql/configmap-kf.yaml
+++ b/stable/pipelines-v2/templates/mysql/configmap-kf.yaml
@@ -111,20 +111,25 @@ data:
     mysqld "${MYSQLD_OPTS[@]}" &
     NEW_PID=$!
 
+    mysql_exec() {
+      mysql --defaults-extra-file="${SECRET_FILE}" --socket "${SOCKET}" --execute="$1"
+    }
+
     until mysqladmin --defaults-extra-file="${SECRET_FILE}" --socket "${SOCKET}" ping; do
       sleep 1
     done
-    mysql \
-      --defaults-extra-file="${SECRET_FILE}" \
-      --socket "${SOCKET}" \
-      --execute="CREATE DATABASE IF NOT EXISTS metadb;"
-    mysql \
-      --defaults-extra-file="${SECRET_FILE}" \
-      --socket "${SOCKET}" \
-      --execute="CREATE DATABASE IF NOT EXISTS mlpipeline;"
+    mysql_exec "CREATE DATABASE IF NOT EXISTS metadb;"
+    mysql_exec "CREATE DATABASE IF NOT EXISTS mlpipeline;"
 
+    mysql_exec "SET PERSIST innodb_stats_auto_recalc = 0;"
+    mysql_exec "SET PERSIST innodb_lock_wait_timeout = 120;"
+    mysql_exec "ALTER INSTANCE DISABLE INNODB REDO_LOG;"
+    echo "Importing metadb database from ${META_DUMP_FILE}..."
     mysql --defaults-extra-file="${SECRET_FILE}" --socket "${SOCKET}" metadb < ${META_DUMP_FILE}
-    mysql --defaults-extra-file="${SECRET_FILE}" --socket "${SOCKET}" mlpipeline < ${PIPELINE_DUMP_FILE}
+    echo "Importing mlpipeline database from ${PIPELINE_DUMP_FILE}..."
+    zmysql --defaults-extra-file="${SECRET_FILE}" --socket "${SOCKET}" mlpipeline < ${PIPELINE_DUMP_FILE}
+    mysql_exec "ALTER INSTANCE ENABLE INNODB REDO_LOG;"
+
     mysqladmin --defaults-extra-file="${SECRET_FILE}" --socket "${SOCKET}" shutdown
     wait "${NEW_PID}"
     touch ${LOCK_FILE}

--- a/stable/pipelines-v2/templates/mysql/configmap-kf.yaml
+++ b/stable/pipelines-v2/templates/mysql/configmap-kf.yaml
@@ -127,7 +127,7 @@ data:
     echo "Importing metadb database from ${META_DUMP_FILE}..."
     mysql --defaults-extra-file="${SECRET_FILE}" --socket "${SOCKET}" metadb < ${META_DUMP_FILE}
     echo "Importing mlpipeline database from ${PIPELINE_DUMP_FILE}..."
-    zmysql --defaults-extra-file="${SECRET_FILE}" --socket "${SOCKET}" mlpipeline < ${PIPELINE_DUMP_FILE}
+    mysql --defaults-extra-file="${SECRET_FILE}" --socket "${SOCKET}" mlpipeline < ${PIPELINE_DUMP_FILE}
     mysql_exec "ALTER INSTANCE ENABLE INNODB REDO_LOG;"
 
     mysqladmin --defaults-extra-file="${SECRET_FILE}" --socket "${SOCKET}" shutdown


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description
Add startup probe for metadata gRPC and optimize MySQL import in pipelines-v2 while restoring KFP dumps from KFP 1.8 to KFP 2.5.

### Changes Made
- **Chart version bump:** `0.11.13` → `0.11.14`.  
- **Metadata gRPC deployment:**  
  - Added `startupProbe` with `tcpSocket` on `grpc-api` port (period 10s, timeout 2s, failureThreshold 360).  
- **MySQL ConfigMap init script:**  
  - Refactored repetitive `mysql` calls into `mysql_exec` helper.  
  - Added temporary settings during import:  
    - `innodb_stats_auto_recalc = 0`  
    - `innodb_lock_wait_timeout = 120`  
  - Temporarily disabled InnoDB redo log during import.  
  - Added clear logging for metadb/mlpipeline imports.  

### Testing
- Ensured MySQL init script executes sequentially without errors.  
- Confirmed metadata gRPC pod transitions through startup probe before liveness.  
- Tested in environment with large amount of data in both databases.


https://iguazio.atlassian.net/browse/IG-24264
