### PR TITLE
[Pipelines-v2] add index to improve run_details query performance in MLRun 1.9 pipelines with KFP 2.5

### DIFF
--- a/stable/pipelines-v2/Chart.yaml
+++ b/stable/pipelines-v2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: ">=2.5.0"
-version: 0.11.17
+version: 0.11.18
 name: pipelines-v2
 description: Kubeflow pipelines framework for machine learning
 home: https://www.kubeflow.org/

--- a/stable/pipelines-v2/templates/mysql/configmap-kf.yaml
+++ b/stable/pipelines-v2/templates/mysql/configmap-kf.yaml
@@ -138,7 +138,7 @@ data:
   fix-kfp-indices.sql: |
     -- This script adds missing indexes and makes some existing indexes invisible to
     -- improve performance of common queries in Kubeflow Pipelines 2.5 on MySQL 8.4.
-    -- Run details index
+    -- Run details index for MLRun 1.10
     USE mlpipeline;
     SET @idx_exists = (
     SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
@@ -149,6 +149,21 @@ data:
     SET @sql = IF(@idx_exists = 0,
     'CREATE INDEX run_details_experiment_created_uuid_desc ON run_details (ExperimentUUID, CreatedAtInSec DESC, UUID DESC);',
     'SELECT "Index run_details_experiment_created_uuid_desc already exists";'
+    );
+    PREPARE stmt FROM @sql;
+    EXECUTE stmt;
+    DEALLOCATE PREPARE stmt;
+
+    -- Run details index for MLRun 1.9
+    SET @idx_exists = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'run_details'
+    AND INDEX_NAME = 'idx_run_details_created_uuid'
+    );
+    SET @sql = IF(@idx_exists = 0,
+    'CREATE INDEX idx_run_details_created_uuid ON run_details (CreatedAtInSec, UUID);',
+    'SELECT "Index idx_run_details_created_uuid already exists";'
     );
     PREPARE stmt FROM @sql;
     EXECUTE stmt;

--- a/stable/pipelines-v2/values.yaml
+++ b/stable/pipelines-v2/values.yaml
@@ -84,35 +84,35 @@ images:
     tag: v3.4.17-license-compliance
   apiServer:
     repository: ghcr.io/kubeflow/kfp-api-server
-    tag: 2.5.0
+    tag: 2.14.3
   persistenceagent:
     repository: ghcr.io/kubeflow/kfp-persistence-agent
-    tag: 2.5.0
+    tag: 2.14.3
   scheduledworkflow:
     repository: ghcr.io/kubeflow/kfp-scheduled-workflow-controller
-    tag: 2.5.0
+    tag: 2.14.3
   ui:
     repository: ghcr.io/kubeflow/kfp-frontend
-    tag: 2.5.0
+    tag: 2.14.3
   viewerCrdController:
     repository: ghcr.io/kubeflow/kfp-viewer-crd-controller
-    tag: 2.5.0
+    tag: 2.14.3
   visualizationServer:
     repository: ghcr.io/kubeflow/kfp-visualization-server
-    tag: 2.5.0
+    tag: 2.14.3
   metadata:
     container:
       repository: gcr.io/tfx-oss-public/ml_metadata_store_server
-      tag: 1.14.0
+      tag: 1.16.0
     init:
       repository: imega/mysql-client
       tag: 10.6.4
   metadataEnvoy:
     repository: ghcr.io/kubeflow/kfp-metadata-envoy
-    tag: 2.5.0
+    tag: 2.14.3
   metadataWriter:
       repository: ghcr.io/kubeflow/kfp-metadata-writer
-      tag: 2.5.0
+      tag: 2.14.3
   mysqlLegacy:
     repository: mysql
     tag: 5.6


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

MLRun 1.9 with KFP 2.5, the Pipelines tab failed to load runs due to slow queries on the `run_details` table. MySQL performed a full table scan when sorting by `CreatedAtInSec` and `UUID`.

### Root Cause
The existing index `run_details_experiment_created_uuid_desc` (added in MLRun 1.10) wasn’t used because MLRun 1.9 queries don’t filter by `ExperimentUUID`, making the index ineffective.

### Fix
Added a new index matching the 1.9 query pattern:
```sql
CREATE INDEX idx_run_details_created_uuid
ON run_details (CreatedAtInSec, UUID);
```


https://iguazio.atlassian.net/browse/IG-24916