### PR TITLE
[pipelines-v2] Support PVC-backed MySQL and refactor storage configuration

### DIFF
--- a/stable/pipelines-v2/Chart.yaml
+++ b/stable/pipelines-v2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: ">=2.5.0"
-version: 0.11.18
+version: 0.11.19
 name: pipelines-v2
 description: Kubeflow pipelines framework for machine learning
 home: https://www.kubeflow.org/

--- a/stable/pipelines-v2/Chart.yaml
+++ b/stable/pipelines-v2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: ">=2.5.0"
-version: 0.11.19
+version: 0.11.20
 name: pipelines-v2
 description: Kubeflow pipelines framework for machine learning
 home: https://www.kubeflow.org/

--- a/stable/pipelines-v2/Chart.yaml
+++ b/stable/pipelines-v2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: ">=2.5.0"
-version: 0.11.20
+version: 0.12.0
 name: pipelines-v2
 description: Kubeflow pipelines framework for machine learning
 home: https://www.kubeflow.org/

--- a/stable/pipelines-v2/templates/argo/workflow-controller-configmap.yaml
+++ b/stable/pipelines-v2/templates/argo/workflow-controller-configmap.yaml
@@ -6,14 +6,14 @@ metadata:
   labels:
     component: workflow-controller
 {{ include "pipelines.commonLabels" . | indent 4 }}
-{{- if eq .Values.storageMode.kind "minio" }}
+{{- if .Values.storageMode.kind.minio.enabled }}
 data:                      # "config: |" key is optional in 2.7+!
   instanceID: my-ci-controller
   artifactRepository: |    # However, all nested maps must be strings
     archiveLogs: true
     s3:
-      endpoint: {{ .Values.storageMode.minio.serviceHost }}:{{ .Values.storageMode.minio.servicePort }}
-      bucket: {{ .Values.storageMode.minio.defaultBucket }}
+      endpoint: {{ .Values.storageMode.kind.minio.ServiceHost }}:{{ .Values.storageMode.kind.minio.ServicePort }}
+      bucket: {{ .Values.storageMode.kind.minio.DefaultBucket }}
       insecure: true
       accessKeySecret:
         name: mlpipeline-minio-artifact
@@ -21,9 +21,9 @@ data:                      # "config: |" key is optional in 2.7+!
       secretKeySecret:
         name: mlpipeline-minio-artifact
         key: secretkey
-{{- else if eq .Values.storageMode.kind "v3io" }}
+{{- else if .Values.storageMode.kind.v3io.enabled }}
 data:
-  # emissary executor is a more portable default, see https://github.com/kubeflow/pipelines/issues/1654.
+  # emissary executor is a more portable default, see https://github.com/kubeflow/kfp/issues/1654.
   #  containerRuntimeExecutor: emissary
 
   config: |

--- a/stable/pipelines-v2/templates/argo/workflow-controller-configmap.yaml
+++ b/stable/pipelines-v2/templates/argo/workflow-controller-configmap.yaml
@@ -6,26 +6,25 @@ metadata:
   labels:
     component: workflow-controller
 {{ include "pipelines.commonLabels" . | indent 4 }}
-{{- if .Values.storageMode.kind.minio.enabled }}
+{{- if eq .Values.storageMode.kind "minio" }}
 data:                      # "config: |" key is optional in 2.7+!
   instanceID: my-ci-controller
   artifactRepository: |    # However, all nested maps must be strings
-   archiveLogs: true
-   s3:
-     endpoint: {{ .Values.storageMode.kind.minio.ServiceHost }}:{{ .Values.storageMode.kind.minio.ServicePort }}
-     bucket: {{ .Values.storageMode.kind.minio.DefaultBucket }}
-     insecure: true
-     accessKeySecret:
-       name: mlpipeline-minio-artifact
-       key: accesskey
-     secretKeySecret:
-       name: mlpipeline-minio-artifact
-       key: secretkey
-{{- end -}}
-{{- if .Values.storageMode.kind.v3io.enabled }}
+    archiveLogs: true
+    s3:
+      endpoint: {{ .Values.storageMode.minio.serviceHost }}:{{ .Values.storageMode.minio.servicePort }}
+      bucket: {{ .Values.storageMode.minio.defaultBucket }}
+      insecure: true
+      accessKeySecret:
+        name: mlpipeline-minio-artifact
+        key: accesskey
+      secretKeySecret:
+        name: mlpipeline-minio-artifact
+        key: secretkey
+{{- else if eq .Values.storageMode.kind "v3io" }}
 data:
   # emissary executor is a more portable default, see https://github.com/kubeflow/pipelines/issues/1654.
-#  containerRuntimeExecutor: emissary
+  #  containerRuntimeExecutor: emissary
 
   config: |
     {

--- a/stable/pipelines-v2/templates/argo/workflow-controller-configmap.yaml
+++ b/stable/pipelines-v2/templates/argo/workflow-controller-configmap.yaml
@@ -6,14 +6,14 @@ metadata:
   labels:
     component: workflow-controller
 {{ include "pipelines.commonLabels" . | indent 4 }}
-{{- if .Values.storageMode.kind.minio.enabled }}
+{{- if eq .Values.storageMode.kind "minio" }}
 data:                      # "config: |" key is optional in 2.7+!
   instanceID: my-ci-controller
   artifactRepository: |    # However, all nested maps must be strings
     archiveLogs: true
     s3:
-      endpoint: {{ .Values.storageMode.kind.minio.ServiceHost }}:{{ .Values.storageMode.kind.minio.ServicePort }}
-      bucket: {{ .Values.storageMode.kind.minio.DefaultBucket }}
+      endpoint: {{ .Values.storageMode.minio.serviceHost }}:{{ .Values.storageMode.minio.servicePort }}
+      bucket: {{ .Values.storageMode.minio.defaultBucket }}
       insecure: true
       accessKeySecret:
         name: mlpipeline-minio-artifact
@@ -21,7 +21,8 @@ data:                      # "config: |" key is optional in 2.7+!
       secretKeySecret:
         name: mlpipeline-minio-artifact
         key: secretkey
-{{- else if .Values.storageMode.kind.v3io.enabled }}
+
+{{- else if eq .Values.storageMode.kind "v3io" }}
 data:
   # emissary executor is a more portable default, see https://github.com/kubeflow/kfp/issues/1654.
   #  containerRuntimeExecutor: emissary
@@ -48,5 +49,5 @@ data:
           archiveLogs: true
       }
     }
-{{- end -}}
+{{- end }}
 {{- end }}

--- a/stable/pipelines-v2/templates/argo/workflow-controller-configmap.yaml
+++ b/stable/pipelines-v2/templates/argo/workflow-controller-configmap.yaml
@@ -9,6 +9,11 @@ metadata:
 {{- if eq .Values.storageMode.kind "minio" }}
 data:                      # "config: |" key is optional in 2.7+!
   instanceID: my-ci-controller
+  metricsConfig: |
+    enabled: false
+    path: /metrics
+    port: 9090
+    ignoreErrors: false
   artifactRepository: |    # However, all nested maps must be strings
     archiveLogs: true
     s3:

--- a/stable/pipelines-v2/templates/ml-pipeline/apiserver/deployment.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/apiserver/deployment.yaml
@@ -60,7 +60,7 @@ spec:
               value: mysql-kf
             # ------ end of MySQL Config ------
 
-        {{- if eq .Values.storageMode.kind "minio" }}
+        {{- if .Values.storageMode.kind.minio.enabled }}
             # -------- MinIO object store config --------
             - name: OBJECTSTORECONFIG_ACCESSKEY
               valueFrom:
@@ -88,7 +88,7 @@ spec:
                   name: pipeline-install-config
                   key: minioServiceHost
 
-        {{- else if eq .Values.storageMode.kind "v3io" }}
+        {{- else if .Values.storageMode.kind.v3io.enabled }}
             # -------- v3io object store config --------
             - name: OBJECTSTORECONFIG_ACCESSKEY
               value: "{{ .Values.configurations.credentials.accessKey }}"

--- a/stable/pipelines-v2/templates/ml-pipeline/apiserver/deployment.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/apiserver/deployment.yaml
@@ -60,7 +60,7 @@ spec:
               value: mysql-kf
             # ------ end of MySQL Config ------
 
-        {{- if .Values.storageMode.kind.minio.enabled }}
+        {{- if eq .Values.storageMode.kind "minio" }}
             # -------- MinIO object store config --------
             - name: OBJECTSTORECONFIG_ACCESSKEY
               valueFrom:
@@ -88,7 +88,7 @@ spec:
                   name: pipeline-install-config
                   key: minioServiceHost
 
-        {{- else if .Values.storageMode.kind.v3io.enabled }}
+        {{- else if eq .Values.storageMode.kind "v3io" }}
             # -------- v3io object store config --------
             - name: OBJECTSTORECONFIG_ACCESSKEY
               value: "{{ .Values.configurations.credentials.accessKey }}"

--- a/stable/pipelines-v2/templates/ml-pipeline/apiserver/deployment.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/apiserver/deployment.yaml
@@ -22,145 +22,146 @@ spec:
         checksum/mysql-kf-secret: {{ (lookup "v1" "Secret" .Release.Namespace "mysql-kf-secret").data | default dict | toJson | sha256sum }}
     spec:
       containers:
-      - name: ml-pipeline-api-server
-        env:
-        - name: LOG_LEVEL
-          value: "info"
-        # Driver / launcher log level during pipeline execution
-        - name: PIPELINE_LOG_LEVEL
-          value: "1"
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: OBJECTSTORECONFIG_SECURE
-          value: "false"
-        {{- if .Values.storageMode.kind.v3io.enabled }}
-        - name: OBJECTSTORECONFIG_ACCESSKEY
-          value: "{{ .Values.configurations.credentials.accessKey }}"
-        - name: OBJECTSTORECONFIG_SECRETACCESSKEY
-          value: minio123
-        - name: OBJECTSTORECONFIG_BUCKETNAME
-          value: "{{ .Values.storage.artifacts.containerName }}"
-        - name: DBCONFIG_USER
-          valueFrom:
-            secretKeyRef:
-              name: mysql-kf-secret
-              key: username
-        - name: DBCONFIG_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: mysql-kf-secret
-              key: password
-        - name: DBCONFIG_MYSQLCONFIG_USER
-          valueFrom:
-            secretKeyRef:
-              name: mysql-kf-secret
-              key: username
-        - name: DBCONFIG_MYSQLCONFIG_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: mysql-kf-secret
-              key: password
-        - name: DBCONFIG_MYSQLCONFIG_HOST
-          value: mysql-kf
+        - name: ml-pipeline-api-server
+          env:
+            - name: LOG_LEVEL
+              value: "info"
+            - name: PIPELINE_LOG_LEVEL
+              value: "1"
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OBJECTSTORECONFIG_SECURE
+              value: "false"
 
-        # end of MySQL Config
-        - name: OBJECTSTORECONFIG_PORT
-          value: "{{ .Values.configurations.ports.nginxPort }}"
-        - name: OBJECTSTORECONFIG_HOST
-          value: v3io-webapi
+            # -------- DB config (shared for v3io / minio) --------
+            - name: DBCONFIG_USER
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-kf-secret
+                  key: username
+            - name: DBCONFIG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-kf-secret
+                  key: password
+            - name: DBCONFIG_MYSQLCONFIG_USER
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-kf-secret
+                  key: username
+            - name: DBCONFIG_MYSQLCONFIG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-kf-secret
+                  key: password
+            - name: DBCONFIG_MYSQLCONFIG_HOST
+              value: mysql-kf
+            # ------ end of MySQL Config ------
+
+        {{- if eq .Values.storageMode.kind "minio" }}
+            # -------- MinIO object store config --------
+            - name: OBJECTSTORECONFIG_ACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  name: mlpipeline-minio-artifact
+                  key: accesskey
+            - name: OBJECTSTORECONFIG_SECRETACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  name: mlpipeline-minio-artifact
+                  key: secretkey
+            - name: OBJECTSTORECONFIG_BUCKETNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: minioDefaultBucket
+            - name: OBJECTSTORECONFIG_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: minioServicePort
+            - name: OBJECTSTORECONFIG_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: minioServiceHost
+
+        {{- else if eq .Values.storageMode.kind "v3io" }}
+            # -------- v3io object store config --------
+            - name: OBJECTSTORECONFIG_ACCESSKEY
+              value: "{{ .Values.configurations.credentials.accessKey }}"
+            - name: OBJECTSTORECONFIG_SECRETACCESSKEY
+              value: minio123
+            - name: OBJECTSTORECONFIG_BUCKETNAME
+              value: "{{ .Values.storage.artifacts.containerName }}"
+            - name: OBJECTSTORECONFIG_PORT
+              value: "{{ .Values.configurations.ports.nginxPort }}"
+            - name: OBJECTSTORECONFIG_HOST
+              value: v3io-webapi
         {{- end }}
-        {{- if .Values.storageMode.kind.minio.enabled }}
-        - name: OBJECTSTORECONFIG_ACCESSKEY
-          valueFrom:
-            secretKeyRef:
-              name: mlpipeline-minio-artifact
-              key: accesskey
-        - name: OBJECTSTORECONFIG_SECRETACCESSKEY
-          valueFrom:
-            secretKeyRef:
-              name: mlpipeline-minio-artifact
-              key: secretkey
-        - name: OBJECTSTORECONFIG_BUCKETNAME
-          valueFrom:
-            configMapKeyRef:
-              name: pipeline-install-config
-              key: minioDefaultBucket
-        - name: OBJECTSTORECONFIG_PORT
-          valueFrom:
-            configMapKeyRef:
-              name: pipeline-install-config
-              key: minioServicePort
-        - name: OBJECTSTORECONFIG_HOST
-          valueFrom:
-            configMapKeyRef:
-              name: pipeline-install-config
-              key: minioServiceHost
-        {{- end }}
-        - name: OBJECTSTORECONFIG_MULTIPART_DISABLE
-          value: "true"
-        - name: OBJECTSTORECONFIG_FORCEV2SIGNATURE
-          value: "true"
-        - name: AUTO_UPDATE_PIPELINE_DEFAULT_VERSION
-          value: "false"
-        image: {{ .Values.images.apiServer.repository }}:{{ .Values.images.apiServer.tag }}
-        imagePullPolicy: {{ .Values.images.imagePullPolicy }}
-        ports:
-        - name: http
-          containerPort: 8888
-        - name: grpc
-          containerPort: 8887
-        readinessProbe:
-          exec:
-            command:
-              - wget
-              - -q # quiet
-              - -S # show server response
-              - -O
-              - "-" # Redirect output to stdout
-              - http://localhost:8888/apis/v1beta1/healthz
-          initialDelaySeconds: 3
-          periodSeconds: 5
-          timeoutSeconds: 2
-        livenessProbe:
-          exec:
-            command:
-              - wget
-              - -q # quiet
-              - -S # show server response
-              - -O
-              - "-" # Redirect output to stdout
-              - http://localhost:8888/apis/v1beta1/healthz
-          initialDelaySeconds: 3
-          periodSeconds: 5
-          timeoutSeconds: 2
-        # This startup probe provides up to a 60 second grace window before the
-        # liveness probe takes over to accomodate the occasional database
-        # migration.
-        startupProbe:
-          exec:
-            command:
-              - wget
-              - -q # quiet
-              - -S # show server response
-              - -O
-              - "-" # Redirect output to stdout
-              - http://localhost:8888/apis/v1beta1/healthz
-          failureThreshold: 12
-          periodSeconds: 5
-          timeoutSeconds: 2
-        securityContext:
-          allowPrivilegeEscalation: false
-          seccompProfile:
-            type: RuntimeDefault
-          runAsNonRoot: true
-          runAsUser: 1000
-          runAsGroup: 0
-          capabilities:
-            drop:
-            - ALL
-        resources:
+
+            - name: OBJECTSTORECONFIG_MULTIPART_DISABLE
+              value: "true"
+            - name: OBJECTSTORECONFIG_FORCEV2SIGNATURE
+              value: "true"
+            - name: AUTO_UPDATE_PIPELINE_DEFAULT_VERSION
+              value: "false"
+          image: {{ .Values.images.apiServer.repository }}:{{ .Values.images.apiServer.tag }}
+          imagePullPolicy: {{ .Values.images.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8888
+            - name: grpc
+              containerPort: 8887
+          readinessProbe:
+            exec:
+              command:
+                - wget
+                - -q
+                - -S
+                - -O
+                - "-"
+                - http://localhost:8888/apis/v1beta1/healthz
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          livenessProbe:
+            exec:
+              command:
+                - wget
+                - -q
+                - -S
+                - -O
+                - "-"
+                - http://localhost:8888/apis/v1beta1/healthz
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          startupProbe:
+            exec:
+              command:
+                - wget
+                - -q
+                - -S
+                - -O
+                - "-"
+                - http://localhost:8888/apis/v1beta1/healthz
+            failureThreshold: 12
+            periodSeconds: 5
+            timeoutSeconds: 2
+          securityContext:
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 0
+            capabilities:
+              drop:
+                - ALL
+          resources:
 {{ toYaml .Values.resources.apiServer | indent 12 }}
       serviceAccountName: ml-pipeline
       {{- if .Values.nodeSelector }}

--- a/stable/pipelines-v2/templates/ml-pipeline/minio/mlpipeline-minio-artifact.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/minio/mlpipeline-minio-artifact.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.storageMode.kind.minio.enabled }}
+{{- if eq .Values.storageMode.kind "minio" }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -8,6 +8,6 @@ metadata:
   name: mlpipeline-minio-artifact
   namespace: {{ .Release.Namespace }}
 data:
-  accesskey: {{ .Values.storageMode.kind.minio.accessKey | b64enc }}
-  secretkey: {{ .Values.storageMode.kind.minio.secretKey | b64enc }}
+  accesskey: {{ .Values.storageMode.minio.accessKey | b64enc }}
+  secretkey: {{ .Values.storageMode.minio.secretKey | b64enc }}
 {{- end -}}

--- a/stable/pipelines-v2/templates/ml-pipeline/minio/mlpipeline-minio-artifact.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/minio/mlpipeline-minio-artifact.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.storageMode.kind "minio" }}
+{{- if .Values.storageMode.kind.minio.enabled }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -8,6 +8,6 @@ metadata:
   name: mlpipeline-minio-artifact
   namespace: {{ .Release.Namespace }}
 data:
-  accesskey: {{ .Values.storageMode.minio.accessKey | b64enc }}
-  secretkey: {{ .Values.storageMode.minio.secretKey | b64enc }}
+  accesskey: {{ .Values.storageMode.kind.minio.accessKey | b64enc }}
+  secretkey: {{ .Values.storageMode.kind.minio.secretKey | b64enc }}
 {{- end -}}

--- a/stable/pipelines-v2/templates/ml-pipeline/minio/mlpipeline-minio-artifact.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/minio/mlpipeline-minio-artifact.yaml
@@ -1,16 +1,13 @@
-{{- if .Values.storageMode.kind.minio.enabled }}
+{{- if eq .Values.storageMode.kind "minio" }}
 apiVersion: v1
-data:
-  accesskey: {{ .Values.storageMode.kind.minio.accessKey | b64enc }}
-  secretkey: {{ .Values.storageMode.kind.minio.secretKey | b64enc }}
 kind: Secret
+type: Opaque
 metadata:
-  annotations:
-    meta.helm.sh/release-name: my-mlrun
-    meta.helm.sh/release-namespace: mlrun
   labels:
     app: pipelines
   name: mlpipeline-minio-artifact
-  namespace: mlrun
-type: Opaque
+  namespace: {{ .Release.Namespace }}
+data:
+  accesskey: {{ .Values.storageMode.minio.accessKey | b64enc }}
+  secretkey: {{ .Values.storageMode.minio.secretKey | b64enc }}
 {{- end -}}

--- a/stable/pipelines-v2/templates/ml-pipeline/minio/pipeline-install-config.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/minio/pipeline-install-config.yaml
@@ -1,11 +1,11 @@
-{{- if .Values.storageMode.kind.minio.enabled }}
+{{- if eq .Values.storageMode.kind "minio" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: pipeline-install-config
   labels: {}
 data:
-  minioServiceHost: "{{ .Values.storageMode.kind.minio.ServiceHost }}"
-  minioServicePort: "{{ .Values.storageMode.kind.minio.ServicePort }}"
-  minioDefaultBucket: "{{ .Values.storageMode.kind.minio.DefaultBucket }}"
+  minioServiceHost: "{{ .Values.storageMode.minio.serviceHost }}"
+  minioServicePort: "{{ .Values.storageMode.minio.servicePort }}"
+  minioDefaultBucket: "{{ .Values.storageMode.minio.defaultBucket }}"
 {{- end -}}

--- a/stable/pipelines-v2/templates/ml-pipeline/minio/pipeline-install-config.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/minio/pipeline-install-config.yaml
@@ -1,11 +1,11 @@
-{{- if .Values.storageMode.kind.minio.enabled }}
+{{- if eq .Values.storageMode.kind "minio" }}
 apiVersion: v1
-data:
-  minioServiceHost:  "{{ .Values.storageMode.kind.minio.ServiceHost }}"
-  minioServicePort: "{{ .Values.storageMode.kind.minio.ServicePort }}"
-  minioDefaultBucket: "{{ .Values.storageMode.kind.minio.DefaultBucket }}"
 kind: ConfigMap
 metadata:
-  labels:
   name: pipeline-install-config
+  labels: {}
+data:
+  minioServiceHost: "{{ .Values.storageMode.minio.serviceHost }}"
+  minioServicePort: "{{ .Values.storageMode.minio.servicePort }}"
+  minioDefaultBucket: "{{ .Values.storageMode.minio.defaultBucket }}"
 {{- end -}}

--- a/stable/pipelines-v2/templates/ml-pipeline/minio/pipeline-install-config.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/minio/pipeline-install-config.yaml
@@ -5,7 +5,7 @@ metadata:
   name: pipeline-install-config
   labels: {}
 data:
-  minioServiceHost: "{{ .Values.storageMode.minio.serviceHost }}"
+  minioServiceHost: "{{ tpl .Values.storageMode.minio.serviceHost . }}"
   minioServicePort: "{{ .Values.storageMode.minio.servicePort }}"
   minioDefaultBucket: "{{ .Values.storageMode.minio.defaultBucket }}"
 {{- end -}}

--- a/stable/pipelines-v2/templates/ml-pipeline/minio/pipeline-install-config.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/minio/pipeline-install-config.yaml
@@ -1,11 +1,11 @@
-{{- if eq .Values.storageMode.kind "minio" }}
+{{- if .Values.storageMode.kind.minio.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: pipeline-install-config
   labels: {}
 data:
-  minioServiceHost: "{{ .Values.storageMode.minio.serviceHost }}"
-  minioServicePort: "{{ .Values.storageMode.minio.servicePort }}"
-  minioDefaultBucket: "{{ .Values.storageMode.minio.defaultBucket }}"
+  minioServiceHost: "{{ .Values.storageMode.kind.minio.ServiceHost }}"
+  minioServicePort: "{{ .Values.storageMode.kind.minio.ServicePort }}"
+  minioDefaultBucket: "{{ .Values.storageMode.kind.minio.DefaultBucket }}"
 {{- end -}}

--- a/stable/pipelines-v2/templates/ml-pipeline/ui/deployment.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/ui/deployment.yaml
@@ -2,96 +2,118 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ml-pipeline-ui
-  namespace: {{ .Release.Namespace }}
   labels:
-    component: ml-pipeline-ui
+    component: ml-pipeline
 {{ include "pipelines.commonLabels" . | indent 4 }}
+  name: ml-pipeline
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
-      component: ml-pipeline-ui
+      component: ml-pipeline
 {{ include "pipelines.commonLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        component: ml-pipeline-ui
+        component: ml-pipeline
 {{ include "pipelines.commonLabels" . | indent 8 }}
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        checksum/mysql-kf-secret: {{ (lookup "v1" "Secret" .Release.Namespace "mysql-kf-secret").data | default dict | toJson | sha256sum }}
     spec:
-      volumes:
-        - name: config-volume
-          configMap:
-            name: ml-pipeline-ui-configmap
       containers:
-        - image: {{ .Values.images.ui.repository }}:{{ .Values.images.ui.tag }}
-          imagePullPolicy: {{ .Values.images.imagePullPolicy }}
-          name: ml-pipeline-ui
-          ports:
-            - containerPort: 3000
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/config
-              readOnly: true
-          securityContext:
-            allowPrivilegeEscalation: false
-            seccompProfile:
-              type: RuntimeDefault
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 0
-            capabilities:
-              drop:
-                - ALL
+        - name: ml-pipeline-api-server
           env:
-            - name: VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH
-              value: /etc/config/viewer-pod-template.json
-        {{- if eq .Values.storageMode.kind "v3io" }}
-            - name: MINIO_V3IO
+            - name: LOG_LEVEL
+              value: "info"
+            - name: PIPELINE_LOG_LEVEL
               value: "1"
-            - name: MINIO_PORT
-              value: "{{ .Values.configurations.ports.nginxPort }}"
-            - name: MINIO_HOST
-              value: v3io-webapi
-            - name: MINIO_ACCESS_KEY
-              value: minio
-            - name: HTTP_AUTHORIZATION_KEY
-              value: X-v3io-session-key
-            - name: HTTP_AUTHORIZATION_DEFAULT_VALUE
-              value: "{{ .Values.configurations.credentials.accessKey }}"
-            - name: MINIO_NAMESPACE
-              value: ""
-        {{- else if eq .Values.storageMode.kind "minio" }}
-            - name: MINIO_PORT
+            - name: POD_NAMESPACE
               valueFrom:
-                configMapKeyRef:
-                  name: pipeline-install-config
-                  key: minioServicePort
-            - name: MINIO_HOST
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OBJECTSTORECONFIG_SECURE
+              value: "false"
+
+            # -------- DB config (shared for v3io / minio) --------
+            - name: DBCONFIG_USER
               valueFrom:
-                configMapKeyRef:
-                  name: pipeline-install-config
-                  key: minioServiceHost
-            - name: AWS_ACCESS_KEY_ID
+                secretKeyRef:
+                  name: mysql-kf-secret
+                  key: username
+            - name: DBCONFIG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-kf-secret
+                  key: password
+            - name: DBCONFIG_MYSQLCONFIG_USER
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-kf-secret
+                  key: username
+            - name: DBCONFIG_MYSQLCONFIG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-kf-secret
+                  key: password
+            - name: DBCONFIG_MYSQLCONFIG_HOST
+              value: mysql-kf
+            # ------ end of MySQL Config ------
+
+        {{- if .Values.storageMode.kind.minio.enabled }}
+            # -------- MinIO object store config --------
+            - name: OBJECTSTORECONFIG_ACCESSKEY
               valueFrom:
                 secretKeyRef:
                   name: mlpipeline-minio-artifact
                   key: accesskey
-            - name: AWS_SECRET_ACCESS_KEY
+            - name: OBJECTSTORECONFIG_SECRETACCESSKEY
               valueFrom:
                 secretKeyRef:
                   name: mlpipeline-minio-artifact
                   key: secretkey
-        {{- end }}
-            - name: DISABLE_GKE_METADATA
-              value: "true"
-            - name: ALLOW_CUSTOM_VISUALIZATIONS
-              value: "true"
-            - name: FRONTEND_SERVER_NAMESPACE
+            - name: OBJECTSTORECONFIG_BUCKETNAME
               valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: ARGO_ARCHIVE_LOGS
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: minioDefaultBucket
+            - name: OBJECTSTORECONFIG_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: minioServicePort
+            - name: OBJECTSTORECONFIG_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: minioServiceHost
+        {{- else if .Values.storageMode.kind.v3io.enabled }}
+            # -------- v3io object store config --------
+            - name: OBJECTSTORECONFIG_ACCESSKEY
+              value: "{{ .Values.configurations.credentials.accessKey }}"
+            - name: OBJECTSTORECONFIG_SECRETACCESSKEY
+              value: minio123
+            - name: OBJECTSTORECONFIG_BUCKETNAME
+              value: "{{ .Values.storage.artifacts.containerName }}"
+            - name: OBJECTSTORECONFIG_PORT
+              value: "{{ .Values.configurations.ports.nginxPort }}"
+            - name: OBJECTSTORECONFIG_HOST
+              value: v3io-webapi
+        {{- end }}
+
+            - name: OBJECTSTORECONFIG_MULTIPART_DISABLE
               value: "true"
+            - name: OBJECTSTORECONFIG_FORCEV2SIGNATURE
+              value: "true"
+            - name: AUTO_UPDATE_PIPELINE_DEFAULT_VERSION
+              value: "false"
+          image: {{ .Values.images.apiServer.repository }}:{{ .Values.images.apiServer.tag }}
+          imagePullPolicy: {{ .Values.images.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8888
+            - name: grpc
+              containerPort: 8887
           readinessProbe:
             exec:
               command:
@@ -100,7 +122,7 @@ spec:
                 - -S
                 - -O
                 - "-"
-                - http://localhost:3000/apis/v1beta1/healthz
+                - http://localhost:8888/apis/v1beta1/healthz
             initialDelaySeconds: 3
             periodSeconds: 5
             timeoutSeconds: 2
@@ -112,26 +134,54 @@ spec:
                 - -S
                 - -O
                 - "-"
-                - http://localhost:3000/apis/v1beta1/healthz
+                - http://localhost:8888/apis/v1beta1/healthz
             initialDelaySeconds: 3
             periodSeconds: 5
             timeoutSeconds: 2
+          startupProbe:
+            exec:
+              command:
+                - wget
+                - -q
+                - -S
+                - -O
+                - "-"
+                - http://localhost:8888/apis/v1beta1/healthz
+            failureThreshold: 12
+            periodSeconds: 5
+            timeoutSeconds: 2
+          securityContext:
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 0
+            capabilities:
+              drop:
+                - ALL
           resources:
-{{ toYaml .Values.resources.ui | indent 10 }}
-      serviceAccountName: ml-pipeline-ui
-{{- with .Values.nodeSelector }}
+{{ toYaml .Values.resources.apiServer | indent 12 }}
+      serviceAccountName: ml-pipeline
+      {{- if .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-{{- end }}
-{{- with .Values.tolerations }}
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- else }}
+      nodeSelector: {}
+      {{- end }}
+      {{- if .Values.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
-{{- end }}
-{{- with .Values.affinity }}
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- else }}
+      tolerations: []
+      {{- end }}
+      {{- if .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
-{{- end }}
-{{- if .Values.priorityClassName }}
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- else }}
+      affinity: {}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
-{{- end }}
+      {{- end }}
 {{- end }}

--- a/stable/pipelines-v2/templates/ml-pipeline/ui/deployment.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/ui/deployment.yaml
@@ -2,119 +2,99 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    component: ml-pipeline
-{{ include "pipelines.commonLabels" . | indent 4 }}
-  name: ml-pipeline
+  name: ml-pipeline-ui
   namespace: {{ .Release.Namespace }}
+  labels:
+    component: ml-pipeline-ui
+{{ include "pipelines.commonLabels" . | indent 4 }}
 spec:
   selector:
     matchLabels:
-      component: ml-pipeline
+      component: ml-pipeline-ui
 {{ include "pipelines.commonLabels" . | indent 6 }}
   template:
     metadata:
       labels:
-        component: ml-pipeline
+        component: ml-pipeline-ui
 {{ include "pipelines.commonLabels" . | indent 8 }}
-      annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
-        checksum/mysql-kf-secret: {{ (lookup "v1" "Secret" .Release.Namespace "mysql-kf-secret").data | default dict | toJson | sha256sum }}
     spec:
+      volumes:
+        - name: config-volume
+          configMap:
+            name: ml-pipeline-ui-configmap
       containers:
-        - name: ml-pipeline-api-server
+        - image: {{ .Values.images.ui.repository }}:{{ .Values.images.ui.tag }}
+          imagePullPolicy: {{ .Values.images.imagePullPolicy }}
+          name: ml-pipeline-ui
+          ports:
+            - containerPort: 3000
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 0
+            capabilities:
+              drop:
+                - ALL
           env:
-            - name: LOG_LEVEL
-              value: "info"
-            - name: PIPELINE_LOG_LEVEL
+            - name: VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH
+              value: /etc/config/viewer-pod-template.json
+
+            {{- if eq .Values.storageMode.kind "v3io" }}
+            - name: MINIO_V3IO
               value: "1"
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: OBJECTSTORECONFIG_SECURE
-              value: "false"
-
-            # -------- DB config (shared for v3io / minio) --------
-            - name: DBCONFIG_USER
-              valueFrom:
-                secretKeyRef:
-                  name: mysql-kf-secret
-                  key: username
-            - name: DBCONFIG_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: mysql-kf-secret
-                  key: password
-            - name: DBCONFIG_MYSQLCONFIG_USER
-              valueFrom:
-                secretKeyRef:
-                  name: mysql-kf-secret
-                  key: username
-            - name: DBCONFIG_MYSQLCONFIG_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: mysql-kf-secret
-                  key: password
-            - name: DBCONFIG_MYSQLCONFIG_HOST
-              value: mysql-kf
-            # ------ end of MySQL Config ------
-
-            {{- if eq .Values.storageMode.kind "minio" }}
-            # -------- MinIO object store config --------
-            - name: OBJECTSTORECONFIG_ACCESSKEY
-              valueFrom:
-                secretKeyRef:
-                  name: mlpipeline-minio-artifact
-                  key: accesskey
-            - name: OBJECTSTORECONFIG_SECRETACCESSKEY
-              valueFrom:
-                secretKeyRef:
-                  name: mlpipeline-minio-artifact
-                  key: secretkey
-            - name: OBJECTSTORECONFIG_BUCKETNAME
-              valueFrom:
-                configMapKeyRef:
-                  name: pipeline-install-config
-                  key: minioDefaultBucket
-            - name: OBJECTSTORECONFIG_PORT
+            - name: MINIO_PORT
+              value: "{{ .Values.configurations.ports.nginxPort }}"
+            - name: MINIO_HOST
+              value: v3io-webapi
+            - name: MINIO_ACCESS_KEY
+              value: minio
+            - name: HTTP_AUTHORIZATION_KEY
+              value: X-v3io-session-key
+            - name: HTTP_AUTHORIZATION_DEFAULT_VALUE
+              value: "{{ .Values.configurations.credentials.accessKey }}"
+            - name: MINIO_NAMESPACE
+              value: ""
+            {{- else if eq .Values.storageMode.kind "minio" }}
+            - name: MINIO_PORT
               valueFrom:
                 configMapKeyRef:
                   name: pipeline-install-config
                   key: minioServicePort
-            - name: OBJECTSTORECONFIG_HOST
+            - name: MINIO_HOST
               valueFrom:
                 configMapKeyRef:
                   name: pipeline-install-config
                   key: minioServiceHost
-
-            {{- else if eq .Values.storageMode.kind "v3io" }}
-            # -------- v3io object store config --------
-            - name: OBJECTSTORECONFIG_ACCESSKEY
-              value: "{{ .Values.configurations.credentials.accessKey }}"
-            - name: OBJECTSTORECONFIG_SECRETACCESSKEY
-              value: minio123
-            - name: OBJECTSTORECONFIG_BUCKETNAME
-              value: "{{ .Values.storage.artifacts.containerName }}"
-            - name: OBJECTSTORECONFIG_PORT
-              value: "{{ .Values.configurations.ports.nginxPort }}"
-            - name: OBJECTSTORECONFIG_HOST
-              value: v3io-webapi
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: mlpipeline-minio-artifact
+                  key: accesskey
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mlpipeline-minio-artifact
+                  key: secretkey
             {{- end }}
 
-            - name: OBJECTSTORECONFIG_MULTIPART_DISABLE
+            - name: DISABLE_GKE_METADATA
               value: "true"
-            - name: OBJECTSTORECONFIG_FORCEV2SIGNATURE
+            - name: ALLOW_CUSTOM_VISUALIZATIONS
               value: "true"
-            - name: AUTO_UPDATE_PIPELINE_DEFAULT_VERSION
-              value: "false"
-          image: {{ .Values.images.apiServer.repository }}:{{ .Values.images.apiServer.tag }}
-          imagePullPolicy: {{ .Values.images.imagePullPolicy }}
-          ports:
-            - name: http
-              containerPort: 8888
-            - name: grpc
-              containerPort: 8887
+            - name: FRONTEND_SERVER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ARGO_ARCHIVE_LOGS
+              value: "true"
+
           readinessProbe:
             exec:
               command:
@@ -123,7 +103,7 @@ spec:
                 - -S
                 - -O
                 - "-"
-                - http://localhost:8888/apis/v1beta1/healthz
+                - http://localhost:3000/apis/v1beta1/healthz
             initialDelaySeconds: 3
             periodSeconds: 5
             timeoutSeconds: 2
@@ -135,54 +115,26 @@ spec:
                 - -S
                 - -O
                 - "-"
-                - http://localhost:8888/apis/v1beta1/healthz
+                - http://localhost:3000/apis/v1beta1/healthz
             initialDelaySeconds: 3
             periodSeconds: 5
             timeoutSeconds: 2
-          startupProbe:
-            exec:
-              command:
-                - wget
-                - -q
-                - -S
-                - -O
-                - "-"
-                - http://localhost:8888/apis/v1beta1/healthz
-            failureThreshold: 12
-            periodSeconds: 5
-            timeoutSeconds: 2
-          securityContext:
-            allowPrivilegeEscalation: false
-            seccompProfile:
-              type: RuntimeDefault
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 0
-            capabilities:
-              drop:
-                - ALL
           resources:
-{{ toYaml .Values.resources.apiServer | indent 12 }}
-      serviceAccountName: ml-pipeline
-      {{- if .Values.nodeSelector }}
+{{ toYaml .Values.resources.ui | indent 12 }}
+      serviceAccountName: ml-pipeline-ui
+{{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-      {{- else }}
-      nodeSelector: {}
-      {{- end }}
-      {{- if .Values.tolerations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
-      {{- else }}
-      tolerations: []
-      {{- end }}
-      {{- if .Values.affinity }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
-      {{- else }}
-      affinity: {}
-      {{- end }}
-      {{- if .Values.priorityClassName }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
-      {{- end }}
+{{- end }}
 {{- end }}

--- a/stable/pipelines-v2/templates/ml-pipeline/ui/deployment.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/ui/deployment.yaml
@@ -60,7 +60,7 @@ spec:
               value: mysql-kf
             # ------ end of MySQL Config ------
 
-        {{- if .Values.storageMode.kind.minio.enabled }}
+            {{- if eq .Values.storageMode.kind "minio" }}
             # -------- MinIO object store config --------
             - name: OBJECTSTORECONFIG_ACCESSKEY
               valueFrom:
@@ -87,7 +87,8 @@ spec:
                 configMapKeyRef:
                   name: pipeline-install-config
                   key: minioServiceHost
-        {{- else if .Values.storageMode.kind.v3io.enabled }}
+
+            {{- else if eq .Values.storageMode.kind "v3io" }}
             # -------- v3io object store config --------
             - name: OBJECTSTORECONFIG_ACCESSKEY
               value: "{{ .Values.configurations.credentials.accessKey }}"
@@ -99,7 +100,7 @@ spec:
               value: "{{ .Values.configurations.ports.nginxPort }}"
             - name: OBJECTSTORECONFIG_HOST
               value: v3io-webapi
-        {{- end }}
+            {{- end }}
 
             - name: OBJECTSTORECONFIG_MULTIPART_DISABLE
               value: "true"

--- a/stable/pipelines-v2/templates/ml-pipeline/ui/deployment.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/ui/deployment.yaml
@@ -19,105 +19,104 @@ spec:
 {{ include "pipelines.commonLabels" . | indent 8 }}
     spec:
       volumes:
-      - name: config-volume
-        configMap:
-          name: ml-pipeline-ui-configmap
-      containers:
-      - image: {{ .Values.images.ui.repository }}:{{ .Values.images.ui.tag }}
-        imagePullPolicy: {{ .Values.images.imagePullPolicy }}
-        name: ml-pipeline-ui
-        ports:
-        - containerPort: 3000
-        volumeMounts:
         - name: config-volume
-          mountPath: /etc/config
-          readOnly: true
-        securityContext:
-          allowPrivilegeEscalation: false
-          seccompProfile:
-            type: RuntimeDefault
-          runAsNonRoot: true
-          runAsUser: 1000
-          runAsGroup: 0
-          capabilities:
-            drop:
-            - ALL
-        env:
-          - name: VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH
-            value: /etc/config/viewer-pod-template.json
-        {{- if .Values.storageMode.kind.v3io.enabled }}
-          - name: MINIO_V3IO
-            value: "1"
-          - name: MINIO_PORT
-            value: "{{ .Values.configurations.ports.nginxPort }}"
-          - name: MINIO_HOST
-            value: v3io-webapi
-          - name: MINIO_ACCESS_KEY
-            value: minio
-          - name: HTTP_AUTHORIZATION_KEY
-            value: X-v3io-session-key
-          - name: HTTP_AUTHORIZATION_DEFAULT_VALUE
-            value: "{{ .Values.configurations.credentials.accessKey }}"
-          - name: MINIO_NAMESPACE
-            value: ""
-        {{- end  }}
-        {{- if .Values.storageMode.kind.minio.enabled }}
-          - name: MINIO_PORT
-            valueFrom:
-              configMapKeyRef:
-                name: pipeline-install-config
-                key: minioDefaultBucket
-          - name: MINIO_HOST
-            valueFrom:
-              configMapKeyRef:
-                name: pipeline-install-config
-                key: minioServiceHost
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: mlpipeline-minio-artifact
-                key: accesskey
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: mlpipeline-minio-artifact
-                key: secretkey
+          configMap:
+            name: ml-pipeline-ui-configmap
+      containers:
+        - image: {{ .Values.images.ui.repository }}:{{ .Values.images.ui.tag }}
+          imagePullPolicy: {{ .Values.images.imagePullPolicy }}
+          name: ml-pipeline-ui
+          ports:
+            - containerPort: 3000
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 0
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH
+              value: /etc/config/viewer-pod-template.json
+        {{- if eq .Values.storageMode.kind "v3io" }}
+            - name: MINIO_V3IO
+              value: "1"
+            - name: MINIO_PORT
+              value: "{{ .Values.configurations.ports.nginxPort }}"
+            - name: MINIO_HOST
+              value: v3io-webapi
+            - name: MINIO_ACCESS_KEY
+              value: minio
+            - name: HTTP_AUTHORIZATION_KEY
+              value: X-v3io-session-key
+            - name: HTTP_AUTHORIZATION_DEFAULT_VALUE
+              value: "{{ .Values.configurations.credentials.accessKey }}"
+            - name: MINIO_NAMESPACE
+              value: ""
+        {{- else if eq .Values.storageMode.kind "minio" }}
+            - name: MINIO_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: minioServicePort
+            - name: MINIO_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: minioServiceHost
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: mlpipeline-minio-artifact
+                  key: accesskey
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mlpipeline-minio-artifact
+                  key: secretkey
         {{- end }}
-          - name: DISABLE_GKE_METADATA
-            value: "true"
-          - name: ALLOW_CUSTOM_VISUALIZATIONS
-            value: "true"
-          - name: FRONTEND_SERVER_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: ARGO_ARCHIVE_LOGS
-            value: "true"
-        readinessProbe:
-          exec:
-            command:
-              - wget
-              - -q # quiet
-              - -S # show server response
-              - -O
-              - "-" # Redirect output to stdout
-              - http://localhost:3000/apis/v1beta1/healthz
-          initialDelaySeconds: 3
-          periodSeconds: 5
-          timeoutSeconds: 2
-        livenessProbe:
-          exec:
-            command:
-              - wget
-              - -q # quiet
-              - -S # show server response
-              - -O
-              - "-" # Redirect output to stdout
-              - http://localhost:3000/apis/v1beta1/healthz
-          initialDelaySeconds: 3
-          periodSeconds: 5
-          timeoutSeconds: 2
-        resources:
+            - name: DISABLE_GKE_METADATA
+              value: "true"
+            - name: ALLOW_CUSTOM_VISUALIZATIONS
+              value: "true"
+            - name: FRONTEND_SERVER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ARGO_ARCHIVE_LOGS
+              value: "true"
+          readinessProbe:
+            exec:
+              command:
+                - wget
+                - -q
+                - -S
+                - -O
+                - "-"
+                - http://localhost:3000/apis/v1beta1/healthz
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          livenessProbe:
+            exec:
+              command:
+                - wget
+                - -q
+                - -S
+                - -O
+                - "-"
+                - http://localhost:3000/apis/v1beta1/healthz
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          resources:
 {{ toYaml .Values.resources.ui | indent 10 }}
       serviceAccountName: ml-pipeline-ui
 {{- with .Values.nodeSelector }}

--- a/stable/pipelines-v2/templates/ml-pipeline/viewer-crd/deployment.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/viewer-crd/deployment.yaml
@@ -21,34 +21,34 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
       containers:
-      - image: {{ .Values.images.viewerCrdController.repository }}:{{ .Values.images.viewerCrdController.tag }}
-        imagePullPolicy: {{ .Values.images.imagePullPolicy }}
-        name: ml-pipeline-viewer-crd
-        env:
-        - name: MAX_NUM_VIEWERS
-          value: "50"
-{{- if .Values.storageMode.kind.v3io.enabled }}
-        - name: MINIO_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-{{- end }}
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        resources:
-{{ toYaml .Values.resources.viewerCRD | indent 10 }}
-        securityContext:
-          allowPrivilegeEscalation: false
-          seccompProfile:
-            type: RuntimeDefault
-          runAsNonRoot: true
-          runAsUser: 1000
-          runAsGroup: 0
-          capabilities:
-            drop:
-              - ALL
+        - image: {{ .Values.images.viewerCrdController.repository }}:{{ .Values.images.viewerCrdController.tag }}
+          imagePullPolicy: {{ .Values.images.imagePullPolicy }}
+          name: ml-pipeline-viewer-crd
+          env:
+            - name: MAX_NUM_VIEWERS
+              value: "50"
+            {{- if eq .Values.storageMode.kind "v3io" }}
+            - name: MINIO_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- end }}
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+{{ toYaml .Values.resources.viewerCRD | indent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 0
+            capabilities:
+              drop:
+                - ALL
       serviceAccountName: ml-pipeline-viewer-crd-service-account
 {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/pipelines-v2/templates/mysql/configmap-kf.yaml
+++ b/stable/pipelines-v2/templates/mysql/configmap-kf.yaml
@@ -12,7 +12,10 @@ data:
     DROP USER IF EXISTS '${DB_USER}'@'%';
     CREATE USER IF NOT EXISTS '${DB_USER}'@'%' IDENTIFIED WITH mysql_native_password BY '${MYSQL_PWD}';
     GRANT ALL PRIVILEGES ON *.* TO '${DB_USER}'@'%';
+    CREATE DATABASE IF NOT EXISTS metadb;
+    CREATE DATABASE IF NOT EXISTS mlpipeline;
     FLUSH PRIVILEGES;
+{{- if .Values.db.dumpRestore.enabled }}
 
   dump-or-skip.sh: |
     #!/usr/bin/env bash
@@ -135,6 +138,8 @@ data:
     wait "${NEW_PID}"
     touch ${LOCK_FILE}
     echo "Import complete."
+{{- end }}
+
   fix-kfp-indices.sql: |
     -- This script adds missing indexes and makes some existing indexes invisible to
     -- improve performance of common queries in Kubeflow Pipelines 2.5 on MySQL 8.4.
@@ -253,5 +258,4 @@ data:
     fi
 
     exec mysqld "${MYSQLD_OPTS[@]}"
-
 {{- end }}

--- a/stable/pipelines-v2/templates/mysql/deployment.yaml
+++ b/stable/pipelines-v2/templates/mysql/deployment.yaml
@@ -34,16 +34,33 @@ spec:
             - key: mysql.cnf
               path: mysql.cnf
       - name: mysql-fuse
-{{- if .Values.storage.metadata.volumes.storageOverride }}
-{{ toYaml .Values.storage.metadata.volumes.storageOverride | nindent 10 }}
-{{- else }}
+        {{- /* PVC mode */}}
+        {{- if eq .Values.storage.metadata.mode "pvc" }}
+        persistentVolumeClaim:
+          {{- if .Values.storage.metadata.persistence.existingClaim }}
+          claimName: {{ .Values.storage.metadata.persistence.existingClaim }}
+          {{- else }}
+          claimName: {{ .Values.storage.metadata.persistence.claimName }}
+          {{- end }}
+
+        {{- /* no persistence mode */}}
+        {{- else if eq .Values.storage.metadata.mode "none" }}
+        emptyDir: {}
+
+        {{- /* v3io override */}}
+        {{- else if .Values.storage.metadata.volumes.storageOverride }}
+{{ toYaml .Values.storage.metadata.volumes.storageOverride | nindent 8 }}
+
+        {{- /* default: v3io flex volume */}}
+        {{- else }}
         flexVolume:
           driver: "v3io/fuse"
           options:
             container: {{ .Values.storage.metadata.containerName }}
             subPath: {{ .Values.storage.metadata.subPath }}
             accessKey: {{ .Values.configurations.credentials.accessKey }}
-{{- end }}
+        {{- end }}
+
       - name: dump-volume
         emptyDir: {}
 

--- a/stable/pipelines-v2/templates/mysql/deployment.yaml
+++ b/stable/pipelines-v2/templates/mysql/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     component: mysql-kf
 {{ include "pipelines.commonLabels" . | indent 4 }}
 spec:
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       component: mysql-kf
@@ -24,28 +26,28 @@ spec:
         {{- toYaml .Values.db.podSecurityContext | nindent 8 }}
       serviceAccountName: mysql-kf
       volumes:
-      - name: mysql-init-scripts
-        configMap:
-          name: mysql-kf
-      - name: mysql-kf-secret
-        secret:
-          secretName: mysql-kf-secret
-          items:
-            - key: mysql.cnf
-              path: mysql.cnf
-      - name: mysql-fuse
+        - name: mysql-init-scripts
+          configMap:
+            name: mysql-kf
+        - name: mysql-kf-secret
+          secret:
+            secretName: mysql-kf-secret
+            items:
+              - key: mysql.cnf
+                path: mysql.cnf
+        - name: mysql-fuse
         {{- /* PVC mode */}}
         {{- if eq .Values.storage.metadata.mode "pvc" }}
-        persistentVolumeClaim:
+          persistentVolumeClaim:
           {{- if .Values.storage.metadata.persistence.existingClaim }}
-          claimName: {{ .Values.storage.metadata.persistence.existingClaim }}
+            claimName: {{ .Values.storage.metadata.persistence.existingClaim }}
           {{- else }}
-          claimName: {{ .Values.storage.metadata.persistence.claimName }}
+            claimName: {{ .Values.storage.metadata.persistence.claimName }}
           {{- end }}
 
         {{- /* no persistence mode */}}
         {{- else if eq .Values.storage.metadata.mode "none" }}
-        emptyDir: {}
+          emptyDir: {}
 
         {{- /* v3io override */}}
         {{- else if .Values.storage.metadata.volumes.storageOverride }}
@@ -53,112 +55,116 @@ spec:
 
         {{- /* default: v3io flex volume */}}
         {{- else }}
-        flexVolume:
-          driver: "v3io/fuse"
-          options:
-            container: {{ .Values.storage.metadata.containerName }}
-            subPath: {{ .Values.storage.metadata.subPath }}
-            accessKey: {{ .Values.configurations.credentials.accessKey }}
+          flexVolume:
+            driver: "v3io/fuse"
+            options:
+              container: {{ .Values.storage.metadata.containerName }}
+              subPath: {{ .Values.storage.metadata.subPath }}
+              accessKey: {{ .Values.configurations.credentials.accessKey }}
         {{- end }}
 
-      - name: dump-volume
-        emptyDir: {}
+      {{- if .Values.db.dumpRestore.enabled }}
+        - name: dump-volume
+          emptyDir: {}
+      {{- end }}
 
+      {{- if .Values.db.dumpRestore.enabled }}
       initContainers:
-      - name: dump-old-mysql
-        image: {{ .Values.images.mysqlLegacy.repository }}:{{ .Values.images.mysqlLegacy.tag }}
-        imagePullPolicy: IfNotPresent
-        resources:
+        - name: dump-old-mysql
+          image: {{ .Values.images.mysqlLegacy.repository }}:{{ .Values.images.mysqlLegacy.tag }}
+          imagePullPolicy: IfNotPresent
+          resources:
 {{ toYaml .Values.resources.mysql | indent 12 }}
-        command:
-          - /bin/bash
-          - /etc/config/mysql/init-scripts/dump-or-skip.sh
-        securityContext:
+          command:
+            - /bin/bash
+            - /etc/config/mysql/init-scripts/dump-or-skip.sh
+          securityContext:
 {{ toYaml .Values.db.securityContext | indent 14 }}
-        volumeMounts:
-          - name: mysql-fuse
-            mountPath: "/var/lib/mysql"
-          - name: mysql-init-scripts
-            mountPath: /etc/config/mysql/init-scripts
-          - name: dump-volume
-            mountPath: /dump
-          - name: mysql-kf-secret
-            mountPath: /run/secrets/mysql
-            readOnly: true
+          volumeMounts:
+            - name: mysql-fuse
+              mountPath: "/var/lib/mysql"
+            - name: mysql-init-scripts
+              mountPath: /etc/config/mysql/init-scripts
+            - name: dump-volume
+              mountPath: /dump
+            - name: mysql-kf-secret
+              mountPath: /run/secrets/mysql
+              readOnly: true
 
-      - name: import-into-new-mysql
-        image: {{ .Values.images.mysql.repository }}:{{ .Values.images.mysql.tag }}
-        imagePullPolicy: {{ .Values.images.imagePullPolicy }}
-        command:
-          - /bin/bash
-          - /etc/config/mysql/init-scripts/import-if-dump-done.sh
-        env:
-          - name: DB_USER
-            valueFrom:
-              secretKeyRef:
-                name: mysql-kf-secret
-                key: username
-          - name: MYSQL_PWD
-            valueFrom:
-              secretKeyRef:
-                name: mysql-kf-secret
-                key: password
-        volumeMounts:
-          - name: mysql-fuse
-            mountPath: "/var/lib/mysql"
-          - name: mysql-init-scripts
-            mountPath: /etc/config/mysql/init-scripts
-          - name: dump-volume
-            mountPath: /dump
-          - name: mysql-kf-secret
-            mountPath: /run/secrets/mysql
-            readOnly: true
+        - name: import-into-new-mysql
+          image: {{ .Values.images.mysql.repository }}:{{ .Values.images.mysql.tag }}
+          imagePullPolicy: {{ .Values.images.imagePullPolicy }}
+          command:
+            - /bin/bash
+            - /etc/config/mysql/init-scripts/import-if-dump-done.sh
+          env:
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-kf-secret
+                  key: username
+            - name: MYSQL_PWD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-kf-secret
+                  key: password
+          volumeMounts:
+            - name: mysql-fuse
+              mountPath: "/var/lib/mysql"
+            - name: mysql-init-scripts
+              mountPath: /etc/config/mysql/init-scripts
+            - name: dump-volume
+              mountPath: /dump
+            - name: mysql-kf-secret
+              mountPath: /run/secrets/mysql
+              readOnly: true
+      {{- end }}
 
       containers:
-      - name: {{ .Values.configurations.mysql.spec.template.spec.containers.name }}
-        securityContext:
+        - name: {{ .Values.configurations.mysql.spec.template.spec.containers.name }}
+          securityContext:
 {{ toYaml .Values.db.securityContext | indent 14 }}
-        image: {{ .Values.images.mysql.repository }}:{{ .Values.images.mysql.tag }}
-        imagePullPolicy: {{ .Values.images.imagePullPolicy }}
-        command:
-          - /bin/bash
-          - /etc/config/mysql/init-scripts/start-mysql.sh
-        ports:
-          - name: mysql-kf
-            containerPort: 3306
-            protocol: TCP
-        livenessProbe:
-          exec:
-            command: ["mysqladmin","--defaults-extra-file=/run/secrets/mysql/mysql.cnf","ping","-h","127.0.0.1"]
-          initialDelaySeconds: {{ .Values.configurations.mysql.spec.template.spec.containers.livenessProbe.initialDelaySeconds }}
-          failureThreshold: {{ .Values.configurations.mysql.spec.template.spec.containers.livenessProbe.failureThreshold }}
-          periodSeconds: {{ .Values.configurations.mysql.spec.template.spec.containers.livenessProbe.periodSeconds }}
-        readinessProbe:
-          exec:
-            command: ["mysqladmin","--defaults-extra-file=/run/secrets/mysql/mysql.cnf","ping","-h","127.0.0.1"]
-          initialDelaySeconds: {{ .Values.configurations.mysql.spec.template.spec.containers.readinessProbe.initialDelaySeconds }}
-          failureThreshold: {{ .Values.configurations.mysql.spec.template.spec.containers.readinessProbe.failureThreshold }}
-          periodSeconds: {{ .Values.configurations.mysql.spec.template.spec.containers.readinessProbe.periodSeconds }}
-        env:
-          - name: DB_USER
-            valueFrom:
-              secretKeyRef:
-                name: mysql-kf-secret
-                key: username
-          - name: MYSQL_PWD
-            valueFrom:
-              secretKeyRef:
-                name: mysql-kf-secret
-                key: password
-        volumeMounts:
-          - name: mysql-fuse
-            mountPath: "/var/lib/mysql"
-          - name: mysql-init-scripts
-            mountPath: /etc/config/mysql/init-scripts
-          - name: mysql-kf-secret
-            mountPath: /run/secrets/mysql
-            readOnly: true
-        resources:
+          image: {{ .Values.images.mysql.repository }}:{{ .Values.images.mysql.tag }}
+          imagePullPolicy: {{ .Values.images.imagePullPolicy }}
+          command:
+            - /bin/bash
+            - /etc/config/mysql/init-scripts/start-mysql.sh
+          ports:
+            - name: mysql-kf
+              containerPort: 3306
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command: ["mysqladmin","--defaults-extra-file=/run/secrets/mysql/mysql.cnf","ping","-h","127.0.0.1"]
+            initialDelaySeconds: {{ .Values.configurations.mysql.spec.template.spec.containers.livenessProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.configurations.mysql.spec.template.spec.containers.livenessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.configurations.mysql.spec.template.spec.containers.livenessProbe.periodSeconds }}
+          readinessProbe:
+            exec:
+              command: ["mysqladmin","--defaults-extra-file=/run/secrets/mysql/mysql.cnf","ping","-h","127.0.0.1"]
+            initialDelaySeconds: {{ .Values.configurations.mysql.spec.template.spec.containers.readinessProbe.initialDelaySeconds }}
+            failureThreshold: {{ .Values.configurations.mysql.spec.template.spec.containers.readinessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.configurations.mysql.spec.template.spec.containers.readinessProbe.periodSeconds }}
+          env:
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-kf-secret
+                  key: username
+            - name: MYSQL_PWD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-kf-secret
+                  key: password
+          volumeMounts:
+            - name: mysql-fuse
+              mountPath: "/var/lib/mysql"
+            - name: mysql-init-scripts
+              mountPath: /etc/config/mysql/init-scripts
+            - name: mysql-kf-secret
+              mountPath: /run/secrets/mysql
+              readOnly: true
+          resources:
 {{ toYaml .Values.resources.mysql | indent 14 }}
 {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/pipelines-v2/templates/mysql/pvc-mysql.yaml
+++ b/stable/pipelines-v2/templates/mysql/pvc-mysql.yaml
@@ -1,8 +1,13 @@
-{{- if .Values.storage.metadata.persistence.enabled -}}
-kind: PersistentVolumeClaim
+{{- /*
+This PVC is created only when:
+  - storage.metadata.mode == "pvc"
+  - no existingClaim is provided
+*/ -}}
+{{- if and (eq .Values.storage.metadata.mode "pvc") (not .Values.storage.metadata.persistence.existingClaim) -}}
 apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.storage.metadata.volumes.storageOverride.persistentVolumeClaim.claimName }}
+  name: {{ .Values.storage.metadata.persistence.claimName | quote }}
   labels:
 {{ include "pipelines.commonLabels" . | indent 4 }}
 {{- with .Values.storage.metadata.persistence.annotations }}
@@ -15,6 +20,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.storage.metadata.persistence.size | quote }}
+
 {{- if .Values.storage.metadata.persistence.storageClass }}
 {{- if (eq "-" .Values.storage.metadata.persistence.storageClass) }}
   storageClassName: ""

--- a/stable/pipelines-v2/values.yaml
+++ b/stable/pipelines-v2/values.yaml
@@ -171,7 +171,7 @@ storageMode:
   kind: v3io        # default; set to "minio" to switch
 
   minio:
-    serviceHost: minio
+    serviceHost: mlrun-minio.{{ .Release.Namespace }}.svc
     servicePort: 9000
     defaultBucket: mlrun
     accessKey: minio

--- a/stable/pipelines-v2/values.yaml
+++ b/stable/pipelines-v2/values.yaml
@@ -82,6 +82,7 @@ configurations:
 # -------------------------------------------------------------------
 # IMAGES
 # -------------------------------------------------------------------
+# updated versions can be taken from here: https://github.com/kubeflow/pipelines/blob/master/manifests/kustomize/base/kustomization.yaml
 images:
   imagePullPolicy: IfNotPresent
 
@@ -185,6 +186,11 @@ db:
     runAsUser: 1001
 
   securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
 
   dumpRestore:
     enabled: true   # enable to dump data from KFP 1.8 MySQL 5.6 to KFP 2.X MySQL version 8.4

--- a/stable/pipelines-v2/values.yaml
+++ b/stable/pipelines-v2/values.yaml
@@ -187,7 +187,7 @@ db:
   securityContext: {}
 
   dumpRestore:
-    enabled: true   # you control dump/restore logic with this flag
+    enabled: true   # enable to dump data from KFP 1.8 MySQL 5.6 to KFP 2.X MySQL version 8.4
 
 managedstorage:
   enabled: false

--- a/stable/pipelines-v2/values.yaml
+++ b/stable/pipelines-v2/values.yaml
@@ -174,8 +174,8 @@ storageMode:
     serviceHost: mlrun-minio.{{ .Release.Namespace }}.svc
     servicePort: 9000
     defaultBucket: mlrun
-    accessKey: minio
-    secretKey: minio123
+    accessKey: console
+    secretKey: console123
 
 # -------------------------------------------------------------------
 # MySQL pod security

--- a/stable/pipelines-v2/values.yaml
+++ b/stable/pipelines-v2/values.yaml
@@ -1,13 +1,15 @@
 crd:
   create: false
+
 deployment:
   create: true
+
 rbac:
   create: true
 
-# kubeflow pipelines uses two kinds of storage:
-# Metadata -  mostly used for purposes of sorting and filtering uses mysql
-# Artifacts - heavier data (packages, views, etc. Also large-scale metrics) we use iguazio storage for this
+# -------------------------------------------------------------------
+# STORAGE (Pipeline Artifacts + Metadata DB Backend)
+# -------------------------------------------------------------------
 storage:
   artifacts:
     containerName: users
@@ -20,7 +22,6 @@ storage:
     persistence:
       enabled: false
       existingClaim:
-      # Name of PVC to use/create when mode=pvc and existingClaim is empty
       claimName: mysql-kf-pvc
       storageClass:
       accessMode: "ReadWriteOnce"
@@ -30,17 +31,14 @@ storage:
     subPath: /mlpipeline/mysql-kf
     volumes:
       storageOverride: {}
-    # define volume for nfs uc.
-    #volumes:
-    #  storageOverride:
-    #    persistentVolumeClaim:
-    #      claimName: pipeline-mysql-pvc
 
 configurations:
   credentials:
     accessKey: overrideMe
+
   ports:
     nginxPort: 8081
+
   argo:
     kfpContainerRuntimeExecutor: emissary
     progressDeadlineSeconds: 600
@@ -53,6 +51,7 @@ configurations:
     template:
       spec:
         terminationGracePeriodSeconds: 30
+
   mysql:
     spec:
       template:
@@ -67,6 +66,7 @@ configurations:
               initialDelaySeconds: 20
               failureThreshold: 3
               periodSeconds: 10
+
   kfpDefaultPipelineRoot:
     objref:
       kind: ConfigMap
@@ -74,40 +74,53 @@ configurations:
       apiVersion: v1
       fieldref:
         fieldpath: data.defaultPipelineRoot
+
   persistenceagent:
     ttlSecondsAfterWorkflowFinish: 86400
     numWorkers: 2
 
-# updated versions can be taken from here: https://github.com/kubeflow/pipelines/blob/master/manifests/kustomize/base/kustomization.yaml
+# -------------------------------------------------------------------
+# IMAGES
+# -------------------------------------------------------------------
 images:
   imagePullPolicy: IfNotPresent
+
   busybox:
     repository: busybox
     tag: 1.37.0
+
   argoexec:
     repository: gcr.io/ml-pipeline/argoexec
     tag: v3.4.17-license-compliance
+
   workflowController:
     repository: gcr.io/ml-pipeline/workflow-controller
     tag: v3.4.17-license-compliance
+
   apiServer:
     repository: ghcr.io/kubeflow/kfp-api-server
     tag: 2.14.3
+
   persistenceagent:
     repository: ghcr.io/kubeflow/kfp-persistence-agent
     tag: 2.14.3
+
   scheduledworkflow:
     repository: ghcr.io/kubeflow/kfp-scheduled-workflow-controller
     tag: 2.14.3
+
   ui:
     repository: ghcr.io/kubeflow/kfp-frontend
     tag: 2.14.3
+
   viewerCrdController:
     repository: ghcr.io/kubeflow/kfp-viewer-crd-controller
     tag: 2.14.3
+
   visualizationServer:
     repository: ghcr.io/kubeflow/kfp-visualization-server
     tag: 2.14.3
+
   metadata:
     container:
       repository: gcr.io/tfx-oss-public/ml_metadata_store_server
@@ -115,32 +128,24 @@ images:
     init:
       repository: imega/mysql-client
       tag: 10.6.4
+
   metadataEnvoy:
     repository: ghcr.io/kubeflow/kfp-metadata-envoy
     tag: 2.14.3
+
   metadataWriter:
     repository: ghcr.io/kubeflow/kfp-metadata-writer
     tag: 2.14.3
+
   mysqlLegacy:
-    repository: mysql
+    repository: gcr.io/iguazio/mysql
     tag: 5.6
+
   mysql:
-    repository: gcr.io/ml-pipeline/mysql
+    repository: gcr.io/iguazio/mysql
     tag: 8.4
 
 resources:
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, use the following
-  # format in any of the below subelements, adjust them as necessary, and remove the curly
-  # braces after the block name, e.g. 'workflowController:'
-  # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
-  # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
-
   workflowController: {}
   metadata: {}
   metadataWriter: {}
@@ -153,43 +158,36 @@ resources:
   visualizationServer: {}
   mysql: {}
 
-## Node labels for pod assignment
-## Ref: https://kubernetes.io/docs/user-guide/node-selection/
-##
 nodeSelector: {}
-
-## List of node taints to tolerate (requires Kubernetes >= 1.6)
 tolerations: []
-#  - key: "key"
-#    operator: "Equal|Exists"
-#    value: "value"
-#    effect: "NoSchedule|PreferNoSchedule|NoExecute"
-
-## Affinity
-## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
-
 priorityClassName: ""
 
+# -------------------------------------------------------------------
+# Artifact store backend selector:
+#   kind: v3io | minio
+# -------------------------------------------------------------------
 storageMode:
-  kind:
-    v3io:
-      enabled: true
-      # in case of nfs storage
-      #enabled: false
-    minio:
-      enabled: false
+  kind: v3io        # default; set to "minio" to switch
 
+  minio:
+    serviceHost: minio
+    servicePort: 9000
+    defaultBucket: mlrun
+    accessKey: minio
+    secretKey: minio123
+
+# -------------------------------------------------------------------
+# MySQL pod security
+# -------------------------------------------------------------------
 db:
   podSecurityContext:
     runAsUser: 1001
 
   securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
+
+  dumpRestore:
+    enabled: false   # you control dump/restore logic with this flag
 
 managedstorage:
   enabled: false

--- a/stable/pipelines-v2/values.yaml
+++ b/stable/pipelines-v2/values.yaml
@@ -84,35 +84,35 @@ images:
     tag: v3.4.17-license-compliance
   apiServer:
     repository: ghcr.io/kubeflow/kfp-api-server
-    tag: 2.5.0
+    tag: 2.14.3
   persistenceagent:
     repository: ghcr.io/kubeflow/kfp-persistence-agent
-    tag: 2.5.0
+    tag: 2.14.3
   scheduledworkflow:
     repository: ghcr.io/kubeflow/kfp-scheduled-workflow-controller
-    tag: 2.5.0
+    tag: 2.14.3
   ui:
     repository: ghcr.io/kubeflow/kfp-frontend
-    tag: 2.5.0
+    tag: 2.14.3
   viewerCrdController:
     repository: ghcr.io/kubeflow/kfp-viewer-crd-controller
-    tag: 2.5.0
+    tag: 2.14.3
   visualizationServer:
     repository: ghcr.io/kubeflow/kfp-visualization-server
-    tag: 2.5.0
+    tag: 2.14.3
   metadata:
     container:
       repository: gcr.io/tfx-oss-public/ml_metadata_store_server
-      tag: 1.14.0
+      tag: 1.16.0
     init:
       repository: imega/mysql-client
       tag: 10.6.4
   metadataEnvoy:
     repository: ghcr.io/kubeflow/kfp-metadata-envoy
-    tag: 2.5.0
+    tag: 2.14.3
   metadataWriter:
       repository: ghcr.io/kubeflow/kfp-metadata-writer
-      tag: 2.5.0
+      tag: 2.14.3
   mysqlLegacy:
     repository: mysql
     tag: 5.6

--- a/stable/pipelines-v2/values.yaml
+++ b/stable/pipelines-v2/values.yaml
@@ -172,7 +172,7 @@ storageMode:
   kind: v3io        # default; set to "minio" to switch
 
   minio:
-    serviceHost: mlrun-minio.{{ .Release.Namespace }}.svc
+    serviceHost: minio.{{ .Release.Namespace }}.svc
     servicePort: 9000
     defaultBucket: mlrun
     accessKey: console

--- a/stable/pipelines-v2/values.yaml
+++ b/stable/pipelines-v2/values.yaml
@@ -12,9 +12,16 @@ storage:
   artifacts:
     containerName: users
   metadata:
+    # mode controls how the MySQL data directory is stored:
+    #   v3io - use v3io flexVolume (or volumes.storageOverride if provided)
+    #   pvc  - use a Kubernetes PVC (created or existing)
+    #   none - use an ephemeral emptyDir (no persistence at all)
+    mode: "v3io"
     persistence:
       enabled: false
       existingClaim:
+      # Name of PVC to use/create when mode=pvc and existingClaim is empty
+      claimName: mysql-kf-pvc
       storageClass:
       accessMode: "ReadWriteOnce"
       size: "8Gi"
@@ -28,6 +35,7 @@ storage:
     #  storageOverride:
     #    persistentVolumeClaim:
     #      claimName: pipeline-mysql-pvc
+
 configurations:
   credentials:
     accessKey: overrideMe
@@ -111,8 +119,8 @@ images:
     repository: ghcr.io/kubeflow/kfp-metadata-envoy
     tag: 2.14.3
   metadataWriter:
-      repository: ghcr.io/kubeflow/kfp-metadata-writer
-      tag: 2.14.3
+    repository: ghcr.io/kubeflow/kfp-metadata-writer
+    tag: 2.14.3
   mysqlLegacy:
     repository: mysql
     tag: 5.6

--- a/stable/pipelines-v2/values.yaml
+++ b/stable/pipelines-v2/values.yaml
@@ -138,7 +138,7 @@ images:
     tag: 2.14.3
 
   mysqlLegacy:
-    repository: gcr.io/iguazio/mysql
+    repository: gcr.io/iguazio/mysql-legacy
     tag: 5.6
 
   mysql:
@@ -187,7 +187,7 @@ db:
   securityContext: {}
 
   dumpRestore:
-    enabled: false   # you control dump/restore logic with this flag
+    enabled: true   # you control dump/restore logic with this flag
 
 managedstorage:
   enabled: false


### PR DESCRIPTION
[pipelines-v2] Support PVC-backed MySQL and storage refactor

### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

Add support for using KFP DB using a PVC with a single switch  
https://iguazio.atlassian.net/browse/IG4-776

Main changes:

- Introduce `storage.metadata.mode` (`v3io` / `pvc` / `none`) and create a PVC only when `mode == "pvc"` and no `existingClaim` is provided.
- Wire MySQL volumes to PVC / emptyDir / v3io flexVolume depending on the selected mode. Set MySQL Deployment strategy to `Recreate` to prevent concurrent writers.
- Wrap dump/restore logic (init scripts, dump-volume, init containers) behind `db.dumpRestore.enabled`. Always create `metadb` and `mlpipeline` databases.
- Replace nested `storageMode.kind.*` with a scalar `storageMode.kind` (`v3io` or `minio`) and add a new `storageMode.minio` block (`serviceHost`, `servicePort`, `defaultBucket`, `accessKey`, `secretKey`).
- Update all MinIO references across templates to align with the new structure (workflow-controller configmap, api-server env vars, UI env vars, viewer-crd, MinIO secret, pipeline-install-config).
- Fix MinIO secret/configmap: use `.Release.Namespace`, correct key names, and support templated host values via `tpl`.
- Switch MySQL images to `gcr.io/iguazio/mysql` and `gcr.io/iguazio/mysql-legacy` (5.6 legacy, 8.4 main).
- General cleanup across templates: indentation, probe commands, env sections, and expanded comments in values.yaml.
