### PR TITLE
[spark-operator] Fix image name corruption

### DIFF
--- a/stable/spark-operator/Chart.yaml
+++ b/stable/spark-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator.
-version: 2.0.18
+version: 2.0.19
 appVersion: 2.2.1
 keywords:
 - apache spark

--- a/stable/spark-operator/templates/_helpers.tpl
+++ b/stable/spark-operator/templates/_helpers.tpl
@@ -74,5 +74,5 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Spark Operator image
 */}}
 {{- define "spark-operator.image" -}}
-{{ printf "%s/%s:%s" .Values.image.registry .Values.image.repository (.Values.image.tag | default .Chart.AppVersion | toString) }}
+{{ printf "%s%s:%s" .Values.image.registry .Values.image.repository (.Values.image.tag | default .Chart.AppVersion | toString) }}
 {{- end -}}

--- a/stable/spark-operator/values.yaml
+++ b/stable/spark-operator/values.yaml
@@ -39,7 +39,7 @@ image:
   # -- Image registry.
   registry: ""
   # -- Image repository.
-  repository: kubeflow/spark-operator/controller
+  repository: kubeflow/spark-operator
   # -- Image tag.
   # @default -- If not set, the chart appVersion will be used.
   tag: ""


### PR DESCRIPTION
Reverting the small subset of #1115 that caused the breakage.

[IG-24952](https://iguazio.atlassian.net/browse/IG-24952)

### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

[IG-24952]: https://iguazio.atlassian.net/browse/IG-24952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ