### PR TITLE
[spark-operator] Fix ingress class name

### DIFF
--- a/stable/spark-operator/Chart.yaml
+++ b/stable/spark-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator.
-version: 2.0.19
+version: 2.0.20
 appVersion: 2.2.1
 keywords:
 - apache spark

--- a/stable/spark-operator/values.yaml
+++ b/stable/spark-operator/values.yaml
@@ -86,7 +86,7 @@ controller:
     # Use ingressUrlFormat instead for provazio backward compatibility
     urlFormat: ""
     # -- Optionally set the ingressClassName.
-    ingressClassName: ""
+    ingressClassName: nginx
     # -- Optionally set default TLS configuration for the Spark UI's ingress. `ingressTLS` in the SparkApplication spec overrides this.
     tls: [ ]
     # - hosts:


### PR DESCRIPTION
This configuration was added between spark-operator 2.0.2 and 2.2.1, and needs to be set to nginx for Spark UI to start.

Fixes [IG-24955](https://iguazio.atlassian.net/browse/IG-24955), which was introduced by #1115.

### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

[IG-24955]: https://iguazio.atlassian.net/browse/IG-24955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ