### PR TITLE
[mlrun] Upgrade MySQL image tag to 8.4

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.12.0
+version: 0.11.13
 appVersion: 1.10.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.11.12
+version: 0.12.0
 appVersion: 1.10.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/_helpers.tpl
+++ b/stable/mlrun/templates/_helpers.tpl
@@ -184,15 +184,15 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Determine MySQL image tag based on MLRun appVersion.
+Determine MySQL image tag based on MLRun API image tag.
 - If db.image.tag is explicitly set in values, use that (allows override)
-- Otherwise, use MySQL 8.0 for appVersion < 1.11.0, and MySQL 8.4 for appVersion >= 1.11.0
+- Otherwise, use MySQL 8.0 for api.image.tag < 1.11.0, and MySQL 8.4 for api.image.tag >= 1.11.0
 */}}
 {{- define "mlrun.db.mysqlTag" -}}
 {{- if .Values.db.image.tag -}}
 {{- .Values.db.image.tag -}}
 {{- else -}}
-{{- if semverCompare "<1.11.0" .Chart.AppVersion -}}
+{{- if semverCompare "<1.11.0" .Values.api.image.tag -}}
 {{- print "8.0" -}}
 {{- else -}}
 {{- print "8.4" -}}

--- a/stable/mlrun/templates/_helpers.tpl
+++ b/stable/mlrun/templates/_helpers.tpl
@@ -183,6 +183,23 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-init" (include "mlrun.db.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Determine MySQL image tag based on MLRun appVersion.
+- If db.image.tag is explicitly set in values, use that (allows override)
+- Otherwise, use MySQL 8.0 for appVersion < 1.11.0, and MySQL 8.4 for appVersion >= 1.11.0
+*/}}
+{{- define "mlrun.db.mysqlTag" -}}
+{{- if .Values.db.image.tag -}}
+{{- .Values.db.image.tag -}}
+{{- else -}}
+{{- if semverCompare "<1.11.0" .Chart.AppVersion -}}
+{{- print "8.0" -}}
+{{- else -}}
+{{- print "8.4" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 
 {{/*
 This is to couple nuclio and mlrun charts, and comes to workaround the fact that the same

--- a/stable/mlrun/templates/db-deployment.yaml
+++ b/stable/mlrun/templates/db-deployment.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 120
       initContainers:
         - name: init-mysql
-          image: "{{ .Values.db.image.repository }}:{{ .Values.db.image.tag }}"
+          image: "{{ .Values.db.image.repository }}:{{ include "mlrun.db.mysqlTag" . }}"
           imagePullPolicy: {{ .Values.db.image.pullPolicy }}
           resources:
             {{- toYaml .Values.db.resources | nindent 12 }}
@@ -47,7 +47,7 @@ spec:
         - name: {{ template "mlrun.name" . }}-{{ .Values.db.name }}
           securityContext:
             {{- toYaml .Values.db.securityContext | nindent 12 }}
-          image: "{{ .Values.db.image.repository }}:{{ .Values.db.image.tag }}"
+          image: "{{ .Values.db.image.repository }}:{{ include "mlrun.db.mysqlTag" . }}"
           imagePullPolicy: {{ .Values.db.image.pullPolicy }}
           command: ["/bin/bash", "/etc/config/mysql/v3io-mysql.sh"]
           ports:

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -395,9 +395,9 @@ db:
 
   image:
     repository: mysql
-    # MySQL tag is automatically determined based on MLRun appVersion:
-    # - MySQL 8.0 for appVersion < 1.11.0
-    # - MySQL 8.4 for appVersion >= 1.11.0
+    # MySQL tag is automatically determined based on MLRun API image tag:
+    # - MySQL 8.0 for api.image.tag < 1.11.0
+    # - MySQL 8.4 for api.image.tag >= 1.11.0
     # Set this value explicitly to override the automatic selection
     tag: ""
     pullPolicy: IfNotPresent

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -395,7 +395,7 @@ db:
 
   image:
     repository: mysql
-    tag: "8.0"
+    tag: "8.4"
     pullPolicy: IfNotPresent
     pullSecrets: []
 

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -395,7 +395,11 @@ db:
 
   image:
     repository: mysql
-    tag: "8.4"
+    # MySQL tag is automatically determined based on MLRun appVersion:
+    # - MySQL 8.0 for appVersion < 1.11.0
+    # - MySQL 8.4 for appVersion >= 1.11.0
+    # Set this value explicitly to override the automatic selection
+    tag: ""
     pullPolicy: IfNotPresent
     pullSecrets: []
 


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

https://iguazio.atlassian.net/browse/ML-11664

```
==========================================
MySQL Tag Selection Tests
==========================================

Test 1: MLRun 1.10.0 -> MySQL 8.0
  API tag: 1.10.0
  Expected MySQL tag: 8.0
  Actual MySQL tag: 8.0
  PASSED

Test 2: MLRun 1.11.0-rc5 -> MySQL 8.4
  API tag: 1.11.0-rc5
  Expected MySQL tag: 8.4
  Actual MySQL tag: 8.4
  PASSED

==========================================
Test Summary
==========================================
Total tests: 2
```
