### PR TITLE
[MLRun] Increase deployment max surge

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.11.13
+version: 0.11.14
 appVersion: 1.10.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -8,6 +8,11 @@ metadata:
     {{- include "mlrun.api.worker.labels" . | nindent 4 }}
 spec:
   replicas: {{ include "mlrun.api.worker.minReplicas" . }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 50%
+      maxUnavailable: 50%
   selector:
     matchLabels:
       {{- include "mlrun.api.worker.selectorLabels" . | nindent 6 }}

--- a/stable/mlrun/templates/ms-deployment.yaml
+++ b/stable/mlrun/templates/ms-deployment.yaml
@@ -9,8 +9,10 @@ metadata:
     {{- include "mlrun.api.microservices.current.labels" (dict "root" $ "microservice" .) | nindent 4 }}
 spec:
   replicas: {{ .minReplicas | default 1 }}
+  {{- if .strategy }}
   strategy:
-    type: Recreate
+    {{- toYaml .strategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "mlrun.api.microservices.current.selectorLabels" (dict "root" $ "microservice" .) | nindent 6 }}

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -13,6 +13,10 @@ api:
         # auto-scaling is currently not supported and the min value is treated as the fixed value
         minReplicas: 1
 
+        # We cannot have more than a single alerts instance running at a time
+        strategy:
+          type: Recreate
+
         service:
           type: ClusterIP
           port: 8080


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

https://iguazio.atlassian.net/browse/ML-11778

Allowing more than a single pod replacement when having multiple worker replicas - decreasing the time for redeployment
