### PR TITLE
[provazio] Add serviceAccount annotations support for IRSA

### DIFF
--- a/stable/provazio/Chart.yaml
+++ b/stable/provazio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Iguazio provisioner
 name: provazio
-version: 1.1.3
+version: 1.1.4
 appVersion: 0.24.37
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://iguazio.com

--- a/stable/provazio/templates/dashboard-service-account.yaml
+++ b/stable/provazio/templates/dashboard-service-account.yaml
@@ -10,5 +10,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: dashboard
+  {{- with .Values.dashboard.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 
 {{- end }}

--- a/stable/provazio/templates/vault-service-account.yaml
+++ b/stable/provazio/templates/vault-service-account.yaml
@@ -10,5 +10,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: vault
+  {{- with .Values.vault.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 
 {{- end }}

--- a/stable/provazio/values.yaml
+++ b/stable/provazio/values.yaml
@@ -102,6 +102,14 @@ dashboard:
 
   podAnnotations: {}
 
+  ## Service account configuration
+  ## Used for IRSA (IAM Roles for Service Accounts) on EKS
+  serviceAccount:
+    annotations: {}
+    # Example for IRSA:
+    # annotations:
+    #   eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/my-irsa-role
+
   ## List of node taints to tolerate (requires Kubernetes >= 1.6)
   tolerations: []
   #  - key: "key"
@@ -211,6 +219,14 @@ vault:
   nodeSelector: {}
 
   podAnnotations: {}
+
+  ## Service account configuration
+  ## Used for IRSA (IAM Roles for Service Accounts) on EKS
+  serviceAccount:
+    annotations: {}
+    # Example for IRSA:
+    # annotations:
+    #   eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/my-irsa-role
 
   ## List of node taints to tolerate (requires Kubernetes >= 1.6)
   tolerations: []


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

- Add annotations support to dashboard-service-account.yaml template
- Add annotations support to vault-service-account.yaml template
- Add serviceAccount.annotations to values.yaml for dashboard and vault

This allows IRSA (IAM Roles for Service Accounts) annotations to be configured via Helm values, ensuring they persist across helm install/upgrade cycles.

Example usage:
  dashboard:
    serviceAccount:
      annotations:
        eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/my-role
