### PR TITLE
[spark-operator] Fix port conflict in GKE

### DIFF
--- a/stable/spark-operator/Chart.yaml
+++ b/stable/spark-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator.
-version: 2.0.20
+version: 2.0.21
 appVersion: 2.2.1
 keywords:
 - apache spark

--- a/stable/spark-operator/values.yaml
+++ b/stable/spark-operator/values.yaml
@@ -411,8 +411,9 @@ prometheus:
   metrics:
     # -- Specifies whether to enable prometheus metrics scraping.
     enable: true
-    # -- Metrics port.
-    port: 8080
+    # -- Metrics port. Use a high port to avoid collisions
+    # -- e.g. GKE reserves 8080 for node-local-dns when hostNetwork is used (IG-25049)
+    port: 28282
     # -- Metrics port name.
     portName: metrics
     # -- Metrics serving endpoint.


### PR DESCRIPTION
Fixes [IG-25049](https://iguazio.atlassian.net/browse/IG-25049).

`spark-operator-webhook` was failing on GKE because with `hostNetwork: true` it tried to bind metrics to port `8080`, which GKE reserves for `node-local-dns`. This PR changes the port to `28282` to resolve this conflict.

I verified this fix by editing the deployment on a GCP system and confirming that the new pod was running.

### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)


[IG-25049]: https://iguazio.atlassian.net/browse/IG-25049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ