### PR TITLE
[mlrun] Support ReadWriteMany access mode when worker replicas > 0

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.11.15
+version: 0.11.16
 appVersion: 1.10.1
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/_helpers.tpl
+++ b/stable/mlrun/templates/_helpers.tpl
@@ -438,3 +438,20 @@ Resolve the MLRun DB DSN
     {{- printf .Values.httpDB.dsn -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Resolve the API persistence access mode
+- If accessMode is explicitly set, use it
+- Otherwise, infer from worker replicas:
+  - ReadWriteMany when worker replicas > 0 (multiple pods need shared volume)
+  - ReadWriteOnce when worker replicas == 0 (single pod)
+*/}}
+{{- define "mlrun.api.persistence.accessMode" -}}
+  {{- if .Values.api.persistence.accessMode -}}
+    {{- printf .Values.api.persistence.accessMode -}}
+  {{- else if gt (int .Values.api.worker.minReplicas) 0 -}}
+    {{- print "ReadWriteMany" -}}
+  {{- else -}}
+    {{- print "ReadWriteOnce" -}}
+  {{- end -}}
+{{- end -}}

--- a/stable/mlrun/templates/mlrun-api-pvc.yaml
+++ b/stable/mlrun/templates/mlrun-api-pvc.yaml
@@ -11,7 +11,7 @@ metadata:
 {{- end }}
 spec:
   accessModes:
-    - {{ .Values.api.persistence.accessMode | quote }}
+    - {{ include "mlrun.api.persistence.accessMode" . | quote }}
   resources:
     requests:
       storage: {{ .Values.api.persistence.size | quote }}

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -60,7 +60,11 @@ api:
     enabled: false
     existingClaim:
     storageClass:
-    accessMode: "ReadWriteOnce"
+    # Access mode for the PVC. If empty, automatically inferred:
+    # - ReadWriteMany when worker.minReplicas > 0 (multiple pods need shared volume)
+    # - ReadWriteOnce when worker.minReplicas == 0 (single pod)
+    # If explicitly set, the provided value is used regardless of worker count.
+    accessMode: ""
     size: "8Gi"
     annotations: ~
 


### PR DESCRIPTION
## Summary
This PR adds automatic ReadWriteMany (RWX) access mode configuration for MLRun API PVC based on worker replica count, with support for explicit override.

## Changes
- Added `mlrun.api.persistence.accessMode` helper function in `_helpers.tpl` that dynamically determines the PVC access mode
- Updated `mlrun-api-pvc.yaml` to use the new helper function
- Updated `values.yaml` to set `accessMode` to empty string by default (enabling automatic inference)
- Added comprehensive documentation explaining the behavior
- Bumped chart version to 0.11.16

## Behavior
The access mode is determined by the following logic:

1. **If `accessMode` is explicitly set**: Use the provided value (regardless of worker count)
2. **Else if `worker.minReplicas > 0`**: Automatically use `ReadWriteMany` to allow both chief and worker pods to share the volume
3. **Else**: Automatically use `ReadWriteOnce` for single pod deployments

This provides flexibility - users can either:
- Leave `accessMode` empty for automatic inference based on worker count (recommended)
- Explicitly set `accessMode` to override the automatic behavior when needed

## Testing
Verified all scenarios with helm template:
- ✅ Empty accessMode + 0 workers → `ReadWriteOnce` (inferred)
- ✅ Empty accessMode + 2 workers → `ReadWriteMany` (inferred)
- ✅ Explicit `ReadWriteMany` + 0 workers → `ReadWriteMany` (explicit overrides)
- ✅ Explicit `ReadWriteOnce` + 2 workers → `ReadWriteOnce` (explicit overrides)

related to https://iguazio.atlassian.net/browse/IG4-1236 