### PR TITLE
[mpi-operator, pipelines-v2] Bump versions to 0.7.1 and 0.12.7; add support for imagePullSecrets in ServiceAccounts

### DIFF
--- a/stable/mpi-operator/Chart.yaml
+++ b/stable/mpi-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "==0.2.0"
 description: Kubeflow MPI job operator
 name: mpi-operator
-version: 0.7.0
+version: 0.7.1
 home: https://www.kubeflow.org/
 icon: https://github.com/kubeflow/marketing-materials/blob/master/logos/Raster/Kubeflow-Logo-RGB.png
 sources:

--- a/stable/mpi-operator/templates/_helpers.tpl
+++ b/stable/mpi-operator/templates/_helpers.tpl
@@ -52,3 +52,23 @@ Return the appropriate apiVersion for CRD APIs.
 {{- print "apiextensions.k8s.io/v1beta1" }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Render imagePullSecrets for ServiceAccounts from global values.
+*/}}
+{{- define "mpi-operator.imagePullSecrets" -}}
+{{- $pullSecrets := list -}}
+{{- range .Values.global.imagePullSecrets -}}
+  {{- if kindIs "map" . -}}
+    {{- $pullSecrets = append $pullSecrets .name -}}
+  {{- else -}}
+    {{- $pullSecrets = append $pullSecrets . -}}
+  {{- end -}}
+{{- end -}}
+{{- if (not (empty $pullSecrets)) -}}
+imagePullSecrets:
+{{- range $pullSecrets | uniq }}
+  - name: {{ . }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/stable/mpi-operator/templates/mpi-operator-serviceaccount.yaml
+++ b/stable/mpi-operator/templates/mpi-operator-serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
     chart: {{ template "mpi-operator.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- include "mpi-operator.imagePullSecrets" . | nindent 0 }}
 {{- end }}

--- a/stable/mpi-operator/values.yaml
+++ b/stable/mpi-operator/values.yaml
@@ -16,6 +16,9 @@ rbac:
 deployment:
   create: true
 
+global:
+  imagePullSecrets: []
+
 image:
   deployment:
     replicas: 1

--- a/stable/pipelines-v2/Chart.yaml
+++ b/stable/pipelines-v2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: ">=2.5.0"
-version: 0.12.6
+version: 0.12.7
 name: pipelines-v2
 description: Kubeflow pipelines framework for machine learning
 home: https://www.kubeflow.org/

--- a/stable/pipelines-v2/templates/_helpers.tpl
+++ b/stable/pipelines-v2/templates/_helpers.tpl
@@ -64,3 +64,23 @@ Define secret key name for the minio secret
 {{- "mysql-kf-secret" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Render imagePullSecrets for ServiceAccounts from global values.
+*/}}
+{{- define "pipelines.imagePullSecrets" -}}
+{{- $pullSecrets := list -}}
+{{- range .Values.global.imagePullSecrets -}}
+  {{- if kindIs "map" . -}}
+    {{- $pullSecrets = append $pullSecrets .name -}}
+  {{- else -}}
+    {{- $pullSecrets = append $pullSecrets . -}}
+  {{- end -}}
+{{- end -}}
+{{- if (not (empty $pullSecrets)) -}}
+imagePullSecrets:
+{{- range $pullSecrets | uniq }}
+  - name: {{ . }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/stable/pipelines-v2/templates/argo/workflow-controller-serviceaccount.yaml
+++ b/stable/pipelines-v2/templates/argo/workflow-controller-serviceaccount.yaml
@@ -7,4 +7,5 @@ metadata:
   labels:
     component: argo
 {{ include "pipelines.commonLabels" . | indent 4 }}
+{{- include "pipelines.imagePullSecrets" . | nindent 0 }}
 {{- end }}

--- a/stable/pipelines-v2/templates/metadata/grpc-serviceaccount.yaml
+++ b/stable/pipelines-v2/templates/metadata/grpc-serviceaccount.yaml
@@ -3,4 +3,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: metadata-grpc-server
+{{- include "pipelines.imagePullSecrets" . | nindent 0 }}
 {{- end }}

--- a/stable/pipelines-v2/templates/metadata/writer-serviceaccount.yaml
+++ b/stable/pipelines-v2/templates/metadata/writer-serviceaccount.yaml
@@ -7,4 +7,5 @@ metadata:
   labels:
     component: metadata-writer
 {{ include "pipelines.commonLabels" . | indent 4 }}
+{{- include "pipelines.imagePullSecrets" . | nindent 0 }}
 {{- end }}

--- a/stable/pipelines-v2/templates/ml-pipeline/apiserver/serviceaccount.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/apiserver/serviceaccount.yaml
@@ -7,4 +7,5 @@ metadata:
   labels:
     component: ml-pipeline
 {{ include "pipelines.commonLabels" . | indent 4 }}
+{{- include "pipelines.imagePullSecrets" . | nindent 0 }}
 {{- end }}

--- a/stable/pipelines-v2/templates/ml-pipeline/container-builder/serviceaccount.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/container-builder/serviceaccount.yaml
@@ -5,4 +5,5 @@ metadata:
   name: kubeflow-pipelines-container-builder
   labels:
 {{ include "pipelines.commonLabels" . | indent 4 }}
+{{- include "pipelines.imagePullSecrets" . | nindent 0 }}
 {{- end }}

--- a/stable/pipelines-v2/templates/ml-pipeline/persistenceagent/serviceaccount.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/persistenceagent/serviceaccount.yaml
@@ -7,4 +7,5 @@ metadata:
   labels:
     component: ml-pipeline-persistenceagent
 {{ include "pipelines.commonLabels" . | indent 4 }}
+{{- include "pipelines.imagePullSecrets" . | nindent 0 }}
 {{- end }}

--- a/stable/pipelines-v2/templates/ml-pipeline/scheduledworkflow/serviceaccount.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/scheduledworkflow/serviceaccount.yaml
@@ -7,4 +7,5 @@ metadata:
   labels:
     component: ml-pipeline-scheduledworkflow
 {{ include "pipelines.commonLabels" . | indent 4 }}
+{{- include "pipelines.imagePullSecrets" . | nindent 0 }}
 {{- end }}

--- a/stable/pipelines-v2/templates/ml-pipeline/ui/serviceaccount.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/ui/serviceaccount.yaml
@@ -7,4 +7,5 @@ metadata:
   labels:
     component: ml-pipeline-ui
 {{ include "pipelines.commonLabels" . | indent 4 }}
+{{- include "pipelines.imagePullSecrets" . | nindent 0 }}
 {{- end }}

--- a/stable/pipelines-v2/templates/ml-pipeline/viewer-crd/serviceaccount.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/viewer-crd/serviceaccount.yaml
@@ -7,4 +7,5 @@ metadata:
   labels:
     component: ml-pipeline-viewer-crd
 {{ include "pipelines.commonLabels" . | indent 4 }}
+{{- include "pipelines.imagePullSecrets" . | nindent 0 }}
 {{- end }}

--- a/stable/pipelines-v2/templates/ml-pipeline/viewer/serviceaccount.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/viewer/serviceaccount.yaml
@@ -5,4 +5,5 @@ metadata:
   name: kubeflow-pipelines-viewer
   labels:
 {{ include "pipelines.commonLabels" . | indent 4 }}
+{{- include "pipelines.imagePullSecrets" . | nindent 0 }}
 {{- end }}

--- a/stable/pipelines-v2/templates/ml-pipeline/visualizationserver/serviceaccount.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/visualizationserver/serviceaccount.yaml
@@ -7,4 +7,5 @@ metadata:
   labels:
     component: ml-pipeline-visualizationserver
 {{ include "pipelines.commonLabels" . | indent 4 }}
+{{- include "pipelines.imagePullSecrets" . | nindent 0 }}
 {{- end }}

--- a/stable/pipelines-v2/templates/mysql/sa.yml
+++ b/stable/pipelines-v2/templates/mysql/sa.yml
@@ -3,4 +3,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: mysql-kf
+{{- include "pipelines.imagePullSecrets" . | nindent 0 }}
 {{- end }}

--- a/stable/pipelines-v2/values.yaml
+++ b/stable/pipelines-v2/values.yaml
@@ -7,6 +7,9 @@ deployment:
 rbac:
   create: true
 
+global:
+  imagePullSecrets: []
+
 # -------------------------------------------------------------------
 # STORAGE (Pipeline Artifacts + Metadata DB Backend)
 # -------------------------------------------------------------------


### PR DESCRIPTION
### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

#### Summary
This PR adds configurable `imagePullSecrets` support to ServiceAccounts in `mpi-operator` and `pipelines-v2`, and bumps chart versions accordingly.

#### Related Issues
Related Jira: https://iguazio.atlassian.net/browse/IG4-1156

#### Additional Notes
- This change is backward-compatible: when `global.imagePullSecrets` is empty (default), manifests remain unchanged.
- Reviewer focus: ensure ServiceAccount coverage is complete and helper output formatting is valid across both charts.