### PR TITLE
[mlrun] Fix UI container port assignment

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.11.17
+version: 0.11.18
 appVersion: 1.10.2
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/_helpers.tpl
+++ b/stable/mlrun/templates/_helpers.tpl
@@ -260,22 +260,6 @@ DB run user
 {{- end -}}
 
 {{/*
-UI container port -
-In 1.0.5 we introduced a backwards incompatible change to run images rootless (including the mlrun-ui image).
-This means nginx cannot use port 80 and now uses 8090 instead.
-In order to support system tests, we need a special condition to decide which port to use.
-The non GA images are created in the following format "<latest-version-released>-commit-id", e.g. - "1.0.4-sa1asd1"
-which actually represents newer changes after 1.0.4.
-*/}}
-{{- define "mlrun.ui.HTTPContainerPort" -}}
-{{- if and (semverCompare "!=1.0.4" .Values.ui.image.tag) (semverCompare ">1.0.3-x" .Values.ui.image.tag) -}}
-{{- print "8090" -}}
-{{- else -}}
-{{- print "80" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Common selector labels
 */}}
 {{- define "mlrun.common.selectorLabels" -}}

--- a/stable/mlrun/templates/ui-deployment.yaml
+++ b/stable/mlrun/templates/ui-deployment.yaml
@@ -32,7 +32,7 @@ spec:
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ include "mlrun.ui.HTTPContainerPort" . }}
+              containerPort: 8090
               protocol: TCP
           env:
           - name: MLRUN_API_PROXY_URL


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

container port 80 is no longer supported. mlrun ui listens on port 8090
