### PR TITLE
[pipelines-v2] Harden KFP pods with configurable security contexts and bump images

### DIFF
--- a/stable/pipelines-v2/Chart.yaml
+++ b/stable/pipelines-v2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: ">=2.5.0"
-version: 0.12.7
+appVersion: ">=2.16.0"
+version: 0.13.0
 name: pipelines-v2
 description: Kubeflow pipelines framework for machine learning
 home: https://www.kubeflow.org/

--- a/stable/pipelines-v2/templates/argo/workflow-controller-configmap.yaml
+++ b/stable/pipelines-v2/templates/argo/workflow-controller-configmap.yaml
@@ -29,6 +29,11 @@ data:
         name: {{ include "pipelines.minioStorageSecretName" . }}
         key: {{ include "pipelines.minioSecretKeyName" . }}
 
+  executor: |
+    imagePullPolicy: IfNotPresent
+    securityContext:
+{{ toYaml .Values.securityContext.workflowController.executor | indent 6 }}
+
 {{- else if eq .Values.storageMode.kind "v3io" }}
 data:
   config: |
@@ -53,5 +58,9 @@ data:
           archiveLogs: true
       }
     }
+  executor: |
+    imagePullPolicy: IfNotPresent
+    securityContext:
+{{ toYaml .Values.securityContext.workflowController.executor | indent 6 }}
 {{- end }}
 {{- end }}

--- a/stable/pipelines-v2/templates/argo/workflow-controller-deployment.yaml
+++ b/stable/pipelines-v2/templates/argo/workflow-controller-deployment.yaml
@@ -68,10 +68,13 @@ spec:
           initialDelaySeconds: 90
           periodSeconds: 60
           timeoutSeconds: 30
+        securityContext:
+          {{- toYaml .Values.securityContext.workflowController.container | nindent 10 }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
-      securityContext: {}
+      securityContext:
+        {{- toYaml .Values.securityContext.workflowController.pod | nindent 8 }}
       serviceAccount: argo
       serviceAccountName: argo
       terminationGracePeriodSeconds: {{ .Values.configurations.argo.template.spec.terminationGracePeriodSeconds }}

--- a/stable/pipelines-v2/templates/metadata/envoy-deployment.yaml
+++ b/stable/pipelines-v2/templates/metadata/envoy-deployment.yaml
@@ -19,6 +19,8 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
+      securityContext:
+        {{- toYaml .Values.securityContext.defaultPod | nindent 8 }}
       containers:
       - name: container
         image: {{ .Values.images.metadataEnvoy.repository }}:{{ .Values.images.metadataEnvoy.tag }}

--- a/stable/pipelines-v2/templates/metadata/envoy-deployment.yaml
+++ b/stable/pipelines-v2/templates/metadata/envoy-deployment.yaml
@@ -30,15 +30,7 @@ spec:
         - name: envoy-admin
           containerPort: 9901
         securityContext:
-          allowPrivilegeEscalation: false
-          seccompProfile:
-            type: RuntimeDefault
-          runAsNonRoot: true
-          runAsUser: 1000
-          runAsGroup: 0
-          capabilities:
-            drop:
-            - ALL
+          {{- toYaml .Values.securityContext.defaultContainer | nindent 10 }}
         volumeMounts:
         - name: envoy-config
           mountPath: /etc/envoy

--- a/stable/pipelines-v2/templates/metadata/grpc-deployment.yaml
+++ b/stable/pipelines-v2/templates/metadata/grpc-deployment.yaml
@@ -40,6 +40,8 @@ spec:
               echo "user=$(cat /mysql-secret/username)" >> /config/mysql.cnf
               echo "password=$(cat /mysql-secret/password)" >> /config/mysql.cnf
               echo "host=mysql-kf" >> /config/mysql.cnf
+          securityContext:
+            {{- toYaml .Values.securityContext.metadataGrpc.initMysqlCnf | nindent 12 }}
           volumeMounts:
             - name: mysql-cnf
               mountPath: /config
@@ -73,15 +75,7 @@ spec:
             - "mysqladmin --defaults-extra-file=/mysql.cnf status --wait=10"
           image: {{ .Values.images.metadata.init.repository }}:{{ .Values.images.metadata.init.tag }}
           securityContext:
-            allowPrivilegeEscalation: false
-            seccompProfile:
-              type: RuntimeDefault
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 0
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.securityContext.metadataGrpc.metadataInit | nindent 12 }}
           volumeMounts:
             - name: mysql-cnf
               mountPath: /mysql.cnf
@@ -150,6 +144,8 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 5
             timeoutSeconds: 2
+          securityContext:
+            {{- toYaml .Values.securityContext.metadataGrpc.metadataContainer | nindent 12 }}
           resources:
 {{ toYaml .Values.resources.metadata | indent 12 }}
       serviceAccountName: metadata-grpc-server

--- a/stable/pipelines-v2/templates/metadata/grpc-deployment.yaml
+++ b/stable/pipelines-v2/templates/metadata/grpc-deployment.yaml
@@ -21,6 +21,8 @@ spec:
         component: metadata-grpc-server
 {{ include "pipelines.commonLabels" . | indent 8 }}
     spec:
+      securityContext:
+        {{- toYaml .Values.securityContext.defaultPod | nindent 8 }}
       volumes:
         - name: mysql-cnf
           emptyDir: {}

--- a/stable/pipelines-v2/templates/metadata/writer-deployment.yaml
+++ b/stable/pipelines-v2/templates/metadata/writer-deployment.yaml
@@ -34,6 +34,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        securityContext:
+          {{- toYaml .Values.securityContext.metadataWriter.container | nindent 10 }}
         resources:
 {{ toYaml .Values.resources.metadataWriter | indent 10 }}
       serviceAccountName: kubeflow-pipelines-metadata-writer

--- a/stable/pipelines-v2/templates/metadata/writer-deployment.yaml
+++ b/stable/pipelines-v2/templates/metadata/writer-deployment.yaml
@@ -19,6 +19,8 @@ spec:
         component: metadata-writer
 {{ include "pipelines.commonLabels" . | indent 8 }}
     spec:
+      securityContext:
+        {{- toYaml .Values.securityContext.defaultPod | nindent 8 }}
       containers:
       - name: main
         image: {{ .Values.images.metadataWriter.repository }}:{{ .Values.images.metadataWriter.tag }}

--- a/stable/pipelines-v2/templates/ml-pipeline/apiserver/deployment.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/apiserver/deployment.yaml
@@ -152,15 +152,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 2
           securityContext:
-            allowPrivilegeEscalation: false
-            seccompProfile:
-              type: RuntimeDefault
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 0
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.securityContext.defaultContainer | nindent 12 }}
           resources:
 {{ toYaml .Values.resources.apiServer | indent 12 }}
       serviceAccountName: ml-pipeline

--- a/stable/pipelines-v2/templates/ml-pipeline/apiserver/deployment.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/apiserver/deployment.yaml
@@ -21,6 +21,8 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         checksum/{{ include "pipelines.dbSecretName" . }}: {{ (lookup "v1" "Secret" .Release.Namespace (include "pipelines.dbSecretName" .)).data | default dict | toJson | sha256sum }}
     spec:
+      securityContext:
+        {{- toYaml .Values.securityContext.defaultPod | nindent 8 }}
       containers:
         - name: ml-pipeline-api-server
           env:

--- a/stable/pipelines-v2/templates/ml-pipeline/persistenceagent/deployment.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/persistenceagent/deployment.yaml
@@ -20,6 +20,8 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
+      securityContext:
+        {{- toYaml .Values.securityContext.defaultPod | nindent 8 }}
       containers:
       - name: ml-pipeline-persistenceagent
         image: {{ .Values.images.persistenceagent.repository }}:{{ .Values.images.persistenceagent.tag }}

--- a/stable/pipelines-v2/templates/ml-pipeline/persistenceagent/deployment.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/persistenceagent/deployment.yaml
@@ -43,15 +43,7 @@ spec:
           - mountPath: /var/run/secrets/kubeflow/tokens
             name: persistenceagent-sa-token
         securityContext:
-          allowPrivilegeEscalation: false
-          seccompProfile:
-            type: RuntimeDefault
-          runAsNonRoot: true
-          runAsUser: 1000
-          runAsGroup: 0
-          capabilities:
-            drop:
-            - ALL
+          {{- toYaml .Values.securityContext.defaultContainer | nindent 10 }}
       serviceAccountName: ml-pipeline-persistenceagent
       volumes:
         - name: persistenceagent-sa-token

--- a/stable/pipelines-v2/templates/ml-pipeline/scheduledworkflow/deployment.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/scheduledworkflow/deployment.yaml
@@ -18,6 +18,8 @@ spec:
         component: ml-pipeline-scheduledworkflow
 {{ include "pipelines.commonLabels" . | indent 8 }}
     spec:
+      securityContext:
+        {{- toYaml .Values.securityContext.defaultPod | nindent 8 }}
       containers:
       - image: {{ .Values.images.scheduledworkflow.repository }}:{{ .Values.images.scheduledworkflow.tag }}
         imagePullPolicy: {{ .Values.images.imagePullPolicy }}

--- a/stable/pipelines-v2/templates/ml-pipeline/scheduledworkflow/deployment.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/scheduledworkflow/deployment.yaml
@@ -37,15 +37,7 @@ spec:
         resources:
 {{ toYaml .Values.resources.scheduledWorkflow | indent 10 }}
         securityContext:
-          allowPrivilegeEscalation: false
-          seccompProfile:
-            type: RuntimeDefault
-          runAsNonRoot: true
-          runAsUser: 1000
-          runAsGroup: 0
-          capabilities:
-            drop:
-            - ALL
+          {{- toYaml .Values.securityContext.defaultContainer | nindent 10 }}
         volumeMounts:
           - mountPath: /var/run/secrets/kubeflow/tokens
             name: scheduledworkflow-sa-token

--- a/stable/pipelines-v2/templates/ml-pipeline/ui/deployment.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/ui/deployment.yaml
@@ -33,15 +33,7 @@ spec:
               mountPath: /etc/config
               readOnly: true
           securityContext:
-            allowPrivilegeEscalation: false
-            seccompProfile:
-              type: RuntimeDefault
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 0
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.securityContext.defaultContainer | nindent 12 }}
           env:
             - name: VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH
               value: /etc/config/viewer-pod-template.json

--- a/stable/pipelines-v2/templates/ml-pipeline/ui/deployment.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/ui/deployment.yaml
@@ -18,6 +18,8 @@ spec:
         component: ml-pipeline-ui
 {{ include "pipelines.commonLabels" . | indent 8 }}
     spec:
+      securityContext:
+        {{- toYaml .Values.securityContext.defaultPod | nindent 8 }}
       volumes:
         - name: config-volume
           configMap:

--- a/stable/pipelines-v2/templates/ml-pipeline/viewer-crd/deployment.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/viewer-crd/deployment.yaml
@@ -20,6 +20,8 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
+      securityContext:
+        {{- toYaml .Values.securityContext.defaultPod | nindent 8 }}
       containers:
         - image: {{ .Values.images.viewerCrdController.repository }}:{{ .Values.images.viewerCrdController.tag }}
           imagePullPolicy: {{ .Values.images.imagePullPolicy }}

--- a/stable/pipelines-v2/templates/ml-pipeline/viewer-crd/deployment.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/viewer-crd/deployment.yaml
@@ -40,15 +40,7 @@ spec:
           resources:
 {{ toYaml .Values.resources.viewerCRD | indent 12 }}
           securityContext:
-            allowPrivilegeEscalation: false
-            seccompProfile:
-              type: RuntimeDefault
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 0
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.securityContext.defaultContainer | nindent 12 }}
       serviceAccountName: ml-pipeline-viewer-crd-service-account
 {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/stable/pipelines-v2/templates/ml-pipeline/visualizationserver/deployment.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/visualizationserver/deployment.yaml
@@ -21,6 +21,8 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
     spec:
+      securityContext:
+        {{- toYaml .Values.securityContext.defaultPod | nindent 8 }}
       containers:
       - image: {{ .Values.images.visualizationServer.repository }}:{{ .Values.images.visualizationServer.tag }}
         imagePullPolicy: {{ .Values.images.imagePullPolicy }}

--- a/stable/pipelines-v2/templates/ml-pipeline/visualizationserver/deployment.yaml
+++ b/stable/pipelines-v2/templates/ml-pipeline/visualizationserver/deployment.yaml
@@ -52,15 +52,7 @@ spec:
           periodSeconds: 5
           timeoutSeconds: 2
         securityContext:
-          allowPrivilegeEscalation: false
-          seccompProfile:
-            type: RuntimeDefault
-          runAsNonRoot: true
-          runAsUser: 1000
-          runAsGroup: 0
-          capabilities:
-            drop:
-            - ALL
+          {{- toYaml .Values.securityContext.defaultContainer | nindent 10 }}
         resources:
 {{ toYaml .Values.resources.visualizationServer | indent 10 }}
       serviceAccountName: ml-pipeline-visualizationserver

--- a/stable/pipelines-v2/values.yaml
+++ b/stable/pipelines-v2/values.yaml
@@ -233,3 +233,21 @@ db:
 managedstorage:
   enabled: false
   gcsBucketName: ""
+
+# -------------------------------------------------------------------
+# SECURITY CONTEXTS
+# -------------------------------------------------------------------
+securityContext:
+  # -- Standard container-level context shared by most containers
+  defaultContainer:
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 0
+    capabilities:
+      drop:
+        - ALL
+
+  # -- Argo workflow controller

--- a/stable/pipelines-v2/values.yaml
+++ b/stable/pipelines-v2/values.yaml
@@ -105,52 +105,52 @@ images:
     tag: 1.37.0
 
   argoexec:
-    repository: gcr.io/ml-pipeline/argoexec
-    tag: v3.4.17-license-compliance
+    repository: quay.io/argoproj/argoexec
+    tag: v3.7.11
 
   workflowController:
-    repository: gcr.io/ml-pipeline/workflow-controller
-    tag: v3.4.17-license-compliance
+    repository: quay.io/argoproj/workflow-controller
+    tag: v3.7.11
 
   apiServer:
     repository: ghcr.io/kubeflow/kfp-api-server
-    tag: 2.14.3
+    tag: 2.16.0
 
   persistenceagent:
     repository: ghcr.io/kubeflow/kfp-persistence-agent
-    tag: 2.14.3
+    tag: 2.16.0
 
   scheduledworkflow:
     repository: ghcr.io/kubeflow/kfp-scheduled-workflow-controller
-    tag: 2.14.3
+    tag: 2.16.0
 
   ui:
     repository: ghcr.io/kubeflow/kfp-frontend
-    tag: 2.14.3
+    tag: 2.16.0
 
   viewerCrdController:
     repository: ghcr.io/kubeflow/kfp-viewer-crd-controller
-    tag: 2.14.3
+    tag: 2.16.0
 
   visualizationServer:
     repository: ghcr.io/kubeflow/kfp-visualization-server
-    tag: 2.14.3
+    tag: 2.16.0
 
   metadata:
     container:
       repository: gcr.io/tfx-oss-public/ml_metadata_store_server
-      tag: 1.16.0
+      tag: 1.17.1
     init:
       repository: imega/mysql-client
       tag: 10.6.4
 
   metadataEnvoy:
     repository: ghcr.io/kubeflow/kfp-metadata-envoy
-    tag: 2.14.3
+    tag: 2.16.0
 
   metadataWriter:
     repository: ghcr.io/kubeflow/kfp-metadata-writer
-    tag: 2.14.3
+    tag: 2.16.0
 
   mysqlLegacy:
     repository: gcr.io/iguazio/mysql-legacy
@@ -219,13 +219,17 @@ db:
 
   podSecurityContext:
     runAsUser: 1001
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
 
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    seccompProfile:
+      type: RuntimeDefault
 
   dumpRestore:
     enabled: true   # enable to dump data from KFP 1.8 MySQL 5.6 to KFP 2.X MySQL version 8.4
@@ -257,3 +261,66 @@ securityContext:
         - ALL
 
   # -- Argo workflow controller
+  workflowController:
+    pod:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+    container:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
+    # Executor context (embedded in configmap)
+    executor:
+      runAsNonRoot: true
+      runAsUser: 65532
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
+
+  # -- Metadata gRPC server
+  metadataGrpc:
+    initMysqlCnf:
+      runAsUser: 65534
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
+    metadataInit:
+      allowPrivilegeEscalation: false
+      seccompProfile:
+        type: RuntimeDefault
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 0
+      capabilities:
+        drop:
+          - ALL
+    metadataContainer:
+      runAsUser: 65534
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
+
+  # -- Metadata writer
+  metadataWriter:
+    container:
+      runAsUser: 65534
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault

--- a/stable/pipelines-v2/values.yaml
+++ b/stable/pipelines-v2/values.yaml
@@ -238,6 +238,12 @@ managedstorage:
 # SECURITY CONTEXTS
 # -------------------------------------------------------------------
 securityContext:
+  # -- Standard pod-level context shared by most deployments
+  defaultPod:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+
   # -- Standard container-level context shared by most containers
   defaultContainer:
     allowPrivilegeEscalation: false


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

This PR hardens the pipelines-v2 (Kubeflow Pipelines) chart by centralizing and making configurable pod and container security contexts across all KFP and Argo components, and bumps component images and chart version.


- Default security context behavior is stricter (non-root, dropped capabilities, seccomp). Override `securityContext` in values if you need different settings (e.g. different `runAsUser`/`runAsGroup`).

- Manual: deploy with default values and confirm all KFP and Argo pods start and pipelines successfully executed.
