### PR TITLE
[mlrun] Support password-protected MySQL root and external DB secrets

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.11.18
+version: 0.11.19
 appVersion: 1.10.2
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/_helpers.tpl
+++ b/stable/mlrun/templates/_helpers.tpl
@@ -142,6 +142,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Resolve the DB secret name.
+If db.existingSecretName is set (by mlefi), use it.
+Otherwise, fall back to the default fullname (Helm-generated secret).
+*/}}
+{{- define "mlrun.db.secretName" -}}
+{{- if .Values.db.existingSecretName -}}
+{{- .Values.db.existingSecretName -}}
+{{- else -}}
+{{- include "mlrun.db.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create a fully qualified db exporter name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -87,13 +87,8 @@ spec:
           - name: MLRUN_HTTPDB__DSN
             valueFrom:
               secretKeyRef:
-                name: {{ include "mlrun.db.fullname" . }}
+                name: {{ include "mlrun.db.secretName" . }}
                 key: dsn
-          - name: MLRUN_HTTPDB__OLD_DSN
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "mlrun.db.fullname" . }}
-                key: oldDsn
           {{- if .Values.v3io.enabled }}
           - name: V3IO_ACCESS_KEY
             valueFrom:

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -86,13 +86,8 @@ spec:
           - name: MLRUN_HTTPDB__DSN
             valueFrom:
               secretKeyRef:
-                name: {{ include "mlrun.db.fullname" . }}
+                name: {{ include "mlrun.db.secretName" . }}
                 key: dsn
-          - name: MLRUN_HTTPDB__OLD_DSN
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "mlrun.db.fullname" . }}
-                key: oldDsn
           {{- if .Values.v3io.enabled }}
           - name: V3IO_ACCESS_KEY
             valueFrom:

--- a/stable/mlrun/templates/db-configmap-init.yaml
+++ b/stable/mlrun/templates/db-configmap-init.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "mlrun.db.labels" . | nindent 4 }}
 data:
   enable-root-remote-access.sql: |
-    -- Allow passwordless (insecure) access to root user from anywhere
+    -- Create root user for remote access and set privileges
     CREATE USER IF NOT EXISTS 'root'@'%';
     GRANT ALL PRIVILEGES ON *.* TO 'root'@'%';
     GRANT SERVICE_CONNECTION_ADMIN ON *.* TO 'root'@'localhost';
@@ -16,4 +16,30 @@ data:
     {{- if not .Values.modelMonitoring.dsn }}
     CREATE DATABASE IF NOT EXISTS mlrun_model_monitoring;
     {{- end }}
+
+  set-root-password.sh: |
+    #!/usr/bin/env bash
+    # Idempotent script to set root password on upgrade from passwordless to password-protected.
+    # Runs as a post-start lifecycle hook.
+    # Only acts if MYSQL_ROOT_PASSWORD is set and the current root has no password.
+    set -e
+    if [ -z "$MYSQL_ROOT_PASSWORD" ]; then
+      echo "MYSQL_ROOT_PASSWORD not set, skipping password enforcement"
+      exit 0
+    fi
+    # Wait for MySQL to be ready
+    for i in $(seq 1 90); do
+      if mysqladmin -u root -S /var/run/mysqld/mysql.sock ping 2>/dev/null; then
+        break
+      fi
+      sleep 1
+    done
+    # Try passwordless connection first (upgrade case)
+    if mysql -u root -S /var/run/mysqld/mysql.sock -e "SELECT 1" 2>/dev/null; then
+      echo "Setting root password..."
+      mysql -u root -S /var/run/mysqld/mysql.sock -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}'; ALTER USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}'; FLUSH PRIVILEGES;"
+      echo "Root password set successfully"
+    else
+      echo "Root already has a password or is not accessible without one -- skipping"
+    fi
 {{- end }}

--- a/stable/mlrun/templates/db-configmap.yaml
+++ b/stable/mlrun/templates/db-configmap.yaml
@@ -8,11 +8,15 @@ metadata:
 data:
 
   health_check.sh: |
-    mysqladmin --protocol=TCP -h {{ .Values.db.dbConfiguration.adminAddress }} -P {{ .Values.db.dbConfiguration.adminPort }} -uroot ping
+    PASS_FLAG=""
+    if [ -n "$MYSQL_ROOT_PASSWORD" ]; then PASS_FLAG="-p${MYSQL_ROOT_PASSWORD}"; fi
+    mysqladmin --protocol=TCP -h {{ .Values.db.dbConfiguration.adminAddress }} -P {{ .Values.db.dbConfiguration.adminPort }} -uroot $PASS_FLAG ping
 
   graceful_shutdown.sh: |
-    mysql -u root -S /var/run/mysqld/mysql.sock -e 'SET GLOBAL innodb_fast_shutdown = 0; FLUSH TABLES WITH READ LOCK;'
-    mysqladmin -u root -S /var/run/mysqld/mysql.sock shutdown
+    PASS_FLAG=""
+    if [ -n "$MYSQL_ROOT_PASSWORD" ]; then PASS_FLAG="-p${MYSQL_ROOT_PASSWORD}"; fi
+    mysql -u root $PASS_FLAG -S /var/run/mysqld/mysql.sock -e 'SET GLOBAL innodb_fast_shutdown = 0; FLUSH TABLES WITH READ LOCK;'
+    mysqladmin -u root $PASS_FLAG -S /var/run/mysqld/mysql.sock shutdown
 
   init-v3io-mysql.sh: |
     #!/usr/bin/env bash

--- a/stable/mlrun/templates/db-deployment.yaml
+++ b/stable/mlrun/templates/db-deployment.yaml
@@ -33,8 +33,16 @@ spec:
           resources:
             {{- toYaml .Values.db.resources | nindent 12 }}
           env:
+            {{- if .Values.db.existingSecretName }}
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mlrun.db.secretName" . }}
+                  key: password
+            {{- else }}
             - name: MYSQL_ALLOW_EMPTY_PASSWORD
               value: "true"
+            {{- end }}
           command: ["/bin/bash", "/etc/config/mysql/init-v3io-mysql.sh"]
           securityContext:
             {{- toYaml .Values.db.securityContext | nindent 12 }}
@@ -55,6 +63,9 @@ spec:
             containerPort: 3306
             protocol: TCP
           lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/bash", "/etc/config/mysql/init-scripts/set-root-password.sh"]
             preStop:
               exec:
                 command: ["/bin/bash", "/etc/config/mysql/graceful_shutdown.sh"]
@@ -67,8 +78,16 @@ spec:
             {{ toYaml .Values.db.readinessProbe | nindent 12 }}
           {{- end }}
           env:
+          {{- if .Values.db.existingSecretName }}
+          - name: MYSQL_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "mlrun.db.secretName" . }}
+                key: password
+          {{- else }}
           - name: MYSQL_ALLOW_EMPTY_PASSWORD
             value: "true"
+          {{- end }}
           {{- if .Values.db.extraEnv }}
           {{ toYaml .Values.db.extraEnv | nindent 10 }}
           {{- end }}
@@ -104,7 +123,7 @@ spec:
           {{- end }}
           env:
             - name: DATA_SOURCE_NAME
-              value: {{ .Values.db.exporter.dataSource }}
+              value: {{ .Values.db.exporter.dataSource | quote }}
           ports:
             - containerPort: {{ .Values.db.exporter.service.internalPort }}
           livenessProbe:

--- a/stable/mlrun/templates/db-secret.yaml
+++ b/stable/mlrun/templates/db-secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.db.existingSecretName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,4 +7,4 @@ metadata:
     {{- include "mlrun.db.labels" . | nindent 4 }}
 data:
   dsn: {{ include "mlrun.dsn" . | b64enc }}
-  oldDsn: {{ toYaml .Values.httpDB.oldDsn | b64enc }}
+{{- end }}

--- a/stable/mlrun/templates/ms-deployment.yaml
+++ b/stable/mlrun/templates/ms-deployment.yaml
@@ -82,13 +82,8 @@ spec:
           - name: MLRUN_HTTPDB__DSN
             valueFrom:
               secretKeyRef:
-                name: {{ include "mlrun.db.fullname" $ }}
+                name: {{ include "mlrun.db.secretName" $ }}
                 key: dsn
-          - name: MLRUN_HTTPDB__OLD_DSN
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "mlrun.db.fullname" $ }}
-                key: oldDsn
           {{- if $.Values.v3io.enabled }}
           - name: V3IO_ACCESS_KEY
             valueFrom:

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -492,6 +492,9 @@ db:
     #   readOnly: true
     #   existingClaim: volume-claim
 
+  # Name of an existing K8s secret containing the DB credentials (password, dsn, oldDsn).
+  existingSecretName: ""
+
   exporter:
 
     enabled: false
@@ -689,15 +692,11 @@ httpDB:
 
   dsn: "sqlite:////mlrun/db/mlrun.db?check_same_thread=false"
 
-  # sqlite database dsn from which to migrate if using mysql database
-  oldDsn: ""
-
   # for external db
   overrideDsn:
 
   # Values to insert if mysql database is needed
   # dsn: "mysql+pymysql://root@mlrun-db:3306/mlrun"
-  # oldDsn: "sqlite:////mlrun/db/mlrun.db?check_same_thread=false"
 
 modelMonitoring:
   # If no dsn has been provided, will initiate monitoring database under mlrun-db service:


### PR DESCRIPTION
Add support for password-protected MySQL root user with backward-compatible upgrade path from passwordless deployments. When db.existingSecretName is set, the chart uses the external secret for DB credentials instead of generating its own. A postStart lifecycle hook idempotently sets the root password on upgrade. 
also Remove obsoleted MLRUN_HTTPDB__OLD_DSN and oldDsn fields.

### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

https://iguazio.atlassian.net/browse/IG4-1684