### PR TITLE
[Metrics Server Exporter] Add image pull secrets support

### DIFF
--- a/stable/metrics-server-exporter/Chart.yaml
+++ b/stable/metrics-server-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: ">=2.0.0"
-version: 0.9.1
+version: 0.9.2
 description: K8s metrics exporter in prometheus format
 name: metrics-server-exporter
 home: https://iguazio.com

--- a/stable/metrics-server-exporter/templates/metrics-server-exporter-deployment.yaml
+++ b/stable/metrics-server-exporter/templates/metrics-server-exporter-deployment.yaml
@@ -26,6 +26,10 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: metrics-server-exporter
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{ toYaml .Values.imagePullSecrets | indent 2 }}
+      {{- end }}
       containers:
       - name: metrics-server-exporter
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/metrics-server-exporter/values.yaml
+++ b/stable/metrics-server-exporter/values.yaml
@@ -69,3 +69,6 @@ tolerations: []
 affinity: {}
 
 priorityClassName: ""
+
+# Image pull secrets for private registries
+imagePullSecrets: []


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

Add support for image pull secrets to the metrics server exporter deployment
