### PR TITLE
[pipelines-v2] Align metadata-envoy with global image pull secrets behavior

### DIFF
--- a/stable/pipelines-v2/Chart.yaml
+++ b/stable/pipelines-v2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: ">=2.16.0"
-version: 0.13.1
+version: 0.13.2
 name: pipelines-v2
 description: Kubeflow pipelines framework for machine learning
 home: https://www.kubeflow.org/

--- a/stable/pipelines-v2/templates/metadata/envoy-deployment.yaml
+++ b/stable/pipelines-v2/templates/metadata/envoy-deployment.yaml
@@ -19,6 +19,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
+{{- include "pipelines.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- toYaml .Values.securityContext.defaultPod | nindent 8 }}
       containers:


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

This change makes metadata-envoy follow the same image pull secret behavior as the rest of the pipelines-v2 components.
Previously, metadata-envoy could miss private registry credentials because its Deployment did not include the shared image pull secret helper.

https://iguazio.atlassian.net/browse/IG4-1846