### PR TITLE
[mlrun] Added opt-in Gateway and HTTPRoute

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.11.19
+version: 0.11.20
 appVersion: 1.10.2
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/_helpers.tpl
+++ b/stable/mlrun/templates/_helpers.tpl
@@ -2,6 +2,19 @@
 {{/*
 Expand the name of the chart.
 */}}
+{{- define "mlrun.gatewayName" -}}
+{{- printf "%s-gateway" (include "mlrun.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fail-fast when Gateway API CRDs are not installed on the cluster.
+*/}}
+{{- define "mlrun.requireGatewayAPICRDs" -}}
+{{- if not (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1") -}}
+{{- fail "Gateway API CRDs are not installed. See https://gateway-api.sigs.k8s.io/guides/getting-started" -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "mlrun.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/stable/mlrun/templates/gateway-api/api-chief-httproute.yaml
+++ b/stable/mlrun/templates/gateway-api/api-chief-httproute.yaml
@@ -1,0 +1,33 @@
+{{- if "mlrun.api.worker.minReplicas" -}}
+{{- if semverCompare ">=1.1.0-X" .Values.api.image.tag -}}
+{{- if .Values.api.chief.httpRoute.enabled -}}
+{{- include "mlrun.requireGatewayAPICRDs" . }}
+{{- $fullName := include "mlrun.api.chief.fullname" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-httproute
+  labels:
+    {{- include "mlrun.api.chief.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    {{- if .Values.api.chief.httpRoute.parentRefs }}
+    {{- toYaml .Values.api.chief.httpRoute.parentRefs | nindent 4 }}
+    {{- else }}
+    - name: {{ include "mlrun.gatewayName" . }}
+    {{- end }}
+  {{- if .Values.api.chief.httpRoute.host }}
+  hostnames:
+    - {{ .Values.api.chief.httpRoute.host | quote }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ .Values.api.chief.service.port }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/stable/mlrun/templates/gateway-api/api-chief-httproute.yaml
+++ b/stable/mlrun/templates/gateway-api/api-chief-httproute.yaml
@@ -6,7 +6,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ $fullName }}-httproute
+  name: {{ $fullName }}
   labels:
     {{- include "mlrun.api.chief.labels" . | nindent 4 }}
 spec:

--- a/stable/mlrun/templates/gateway-api/api-httproute.yaml
+++ b/stable/mlrun/templates/gateway-api/api-httproute.yaml
@@ -4,7 +4,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ $fullName }}-httproute
+  name: {{ $fullName }}
   labels:
     {{- include "mlrun.api.labels" . | nindent 4 }}
 spec:

--- a/stable/mlrun/templates/gateway-api/api-httproute.yaml
+++ b/stable/mlrun/templates/gateway-api/api-httproute.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.api.httpRoute.enabled -}}
+{{- include "mlrun.requireGatewayAPICRDs" . }}
+{{- $fullName := include "mlrun.api.fullname" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-httproute
+  labels:
+    {{- include "mlrun.api.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    {{- if .Values.api.httpRoute.parentRefs }}
+    {{- toYaml .Values.api.httpRoute.parentRefs | nindent 4 }}
+    {{- else }}
+    - name: {{ include "mlrun.gatewayName" . }}
+    {{- end }}
+  {{- if .Values.api.httpRoute.host }}
+  hostnames:
+    - {{ .Values.api.httpRoute.host | quote }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ .Values.api.service.port }}
+{{- end }}

--- a/stable/mlrun/templates/gateway-api/gateway.yaml
+++ b/stable/mlrun/templates/gateway-api/gateway.yaml
@@ -24,8 +24,8 @@ spec:
         certificateRefs:
           - kind: Secret
             name: {{ .secretName }}
-      {{- with .hosts }}
-      hostname: {{ first . | quote }}
+      {{- with .host }}
+      hostname: {{ . | quote }}
       {{- end }}
       allowedRoutes:
         namespaces:

--- a/stable/mlrun/templates/gateway-api/gateway.yaml
+++ b/stable/mlrun/templates/gateway-api/gateway.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.gateway.enabled }}
+{{- include "mlrun.requireGatewayAPICRDs" . }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ include "mlrun.gatewayName" . }}
+  labels:
+    {{- include "mlrun.common.labels" . | nindent 4 }}
+spec:
+  gatewayClassName: {{ .Values.gateway.gatewayClassName | quote }}
+  listeners:
+    - name: http
+      port: {{ .Values.gateway.listenerPort }}
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+    {{- range .Values.gateway.tls }}
+    - name: https-{{ .secretName }}
+      port: {{ .port }}
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: {{ .secretName }}
+      {{- with .hosts }}
+      hostname: {{ first . | quote }}
+      {{- end }}
+      allowedRoutes:
+        namespaces:
+          from: Same
+    {{- end }}
+{{- end }}

--- a/stable/mlrun/templates/gateway-api/ui-httproute.yaml
+++ b/stable/mlrun/templates/gateway-api/ui-httproute.yaml
@@ -4,7 +4,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ $fullName }}-httproute
+  name: {{ $fullName }}
   labels:
     {{- include "mlrun.ui.labels" . | nindent 4 }}
 spec:

--- a/stable/mlrun/templates/gateway-api/ui-httproute.yaml
+++ b/stable/mlrun/templates/gateway-api/ui-httproute.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.ui.httpRoute.enabled -}}
+{{- include "mlrun.requireGatewayAPICRDs" . }}
+{{- $fullName := include "mlrun.ui.fullname" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-httproute
+  labels:
+    {{- include "mlrun.ui.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    {{- if .Values.ui.httpRoute.parentRefs }}
+    {{- toYaml .Values.ui.httpRoute.parentRefs | nindent 4 }}
+    {{- else }}
+    - name: {{ include "mlrun.gatewayName" . }}
+    {{- end }}
+  {{- if .Values.ui.httpRoute.host }}
+  hostnames:
+    - {{ .Values.ui.httpRoute.host | quote }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ .Values.ui.service.port }}
+{{- end }}

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -751,8 +751,7 @@ gateway:
   tls: []
   #  - secretName: mlrun-tls
   #    port: 443
-  #    hosts:
-  #      - mlrun.local
+  #    host: mlrun.local
 
 # global is a stanza that is used if this is used as a subchart. Ignore otherwise
 global:

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -96,6 +96,14 @@ api:
       #    hosts:
       #      - chart-example.local
 
+    # if enabled, create an HTTPRoute to route traffic from a Gateway to the API chief service
+    httpRoute:
+      enabled: false
+      host: ""
+      # when gateway.enabled is false, reference an existing Gateway here
+      parentRefs: []
+      #   - name: my-gateway
+
     ## Affinity for pod assignment
     ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
     ##
@@ -147,6 +155,14 @@ api:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
+
+  # if enabled, create an HTTPRoute to route traffic from a Gateway to the API service
+  httpRoute:
+    enabled: false
+    host: ""
+    # when gateway.enabled is false, reference an existing Gateway here
+    parentRefs: []
+    #   - name: my-gateway
 
   # Extra env variables - passed as is to the api pod env section therefore can be used to any kind of env var
   extraEnv: []
@@ -624,6 +640,14 @@ ui:
     #    hosts:
     #      - chart-example.local
 
+  # if enabled, create an HTTPRoute to route traffic from a Gateway to the UI service
+  httpRoute:
+    enabled: false
+    host: ""
+    # when gateway.enabled is false, reference an existing Gateway here
+    parentRefs: []
+    #   - name: my-gateway
+
   # Extra env variables
   extraEnv: []
 
@@ -718,6 +742,17 @@ nuclio:
   # This is resolved automatically for mlrun-kit or can be overridden explicitly
   # Must be fully qualified domain name (FQDN) e.g. http://nuclio-dashboard.namespace.svc.cluster.local:8070
   apiURL:
+
+# if enabled, create a Gateway resource for use by HTTPRoutes
+gateway:
+  enabled: false
+  gatewayClassName: traefik
+  listenerPort: 80
+  tls: []
+  #  - secretName: mlrun-tls
+  #    port: 443
+  #    hosts:
+  #      - mlrun.local
 
 # global is a stanza that is used if this is used as a subchart. Ignore otherwise
 global:


### PR DESCRIPTION
### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

This PR introduces opt-in Gateway API support for the mlrun chart, allowing deployments to use Kubernetes Gateway API resources (Gateway + HTTPRoute) as an alternative to traditional Ingress.