### PR TITLE
[pipelines-v2] Apply KFP index fixes via dedicated Job; add tasks_pod…

### DIFF
--- a/stable/pipelines-v2/Chart.yaml
+++ b/stable/pipelines-v2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: ">=2.16.0"
-version: 0.13.2
+version: 0.13.3
 name: pipelines-v2
 description: Kubeflow pipelines framework for machine learning
 home: https://www.kubeflow.org/

--- a/stable/pipelines-v2/templates/_helpers.tpl
+++ b/stable/pipelines-v2/templates/_helpers.tpl
@@ -16,7 +16,6 @@ Common labels
 */}}
 {{- define "pipelines.commonLabels" -}}
 app: {{ include "pipelines.name" . }}
-chart: {{ include "pipelines.chart" . }}
 release: {{ .Release.Name }}
 heritage: {{ .Release.Service }}
 {{- end -}}

--- a/stable/pipelines-v2/templates/mysql/configmap-kf.yaml
+++ b/stable/pipelines-v2/templates/mysql/configmap-kf.yaml
@@ -204,6 +204,21 @@ data:
     EXECUTE stmt;
     DEALLOCATE PREPARE stmt;
 
+    -- tasks PodName index
+    SET @idx_exists = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'tasks'
+    AND INDEX_NAME = 'tasks_podname'
+    );
+    SET @sql = IF(@idx_exists = 0,
+    'CREATE INDEX tasks_podname ON tasks (PodName);',
+    'SELECT "Index tasks_podname already exists";'
+    );
+    PREPARE stmt FROM @sql;
+    EXECUTE stmt;
+    DEALLOCATE PREPARE stmt;
+
     -- run_metrics index
     SET @idx_exists = (
     SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
@@ -232,7 +247,6 @@ data:
     : "${MYSQL_PWD:?Environment variable MYSQL_PWD must be set.}"
 
     readonly RAW_INIT_SCRIPT="/etc/config/mysql/init-scripts/create_user.sql"
-    readonly FIX_INDICES_SCRIPT="/etc/config/mysql/init-scripts/fix-kfp-indices.sql"
     readonly INIT_SCRIPT="/tmp/create_user.sql"
     readonly BASE_DIR="/var/lib/mysql"
     readonly DATA_DIR="${BASE_DIR}/data"
@@ -241,8 +255,6 @@ data:
     sed -e "s|\${DB_USER}|${DB_USER}|g" \
         -e "s|\${MYSQL_PWD}|${MYSQL_PWD}|g" \
         "${RAW_INIT_SCRIPT}" > "${INIT_SCRIPT}"
-
-    cat "${FIX_INDICES_SCRIPT}" >> "${INIT_SCRIPT}"
 
     MYSQLD_OPTS=(
       --mysql-native-password=ON

--- a/stable/pipelines-v2/templates/mysql/job-fix-indices.yaml
+++ b/stable/pipelines-v2/templates/mysql/job-fix-indices.yaml
@@ -1,0 +1,85 @@
+{{- if .Values.deployment.create }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: mysql-kf-fix-indices-r{{ .Release.Revision }}
+  labels:
+    component: mysql-kf-fix-indices
+{{ include "pipelines.commonLabels" . | indent 4 }}
+spec:
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        component: mysql-kf-fix-indices
+{{ include "pipelines.commonLabels" . | indent 8 }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.db.podSecurityContext | nindent 8 }}
+      serviceAccountName: mysql-kf
+      restartPolicy: OnFailure
+      containers:
+        - name: fix-indices
+          image: {{ .Values.images.mysql.repository }}:{{ .Values.images.mysql.tag }}
+          imagePullPolicy: {{ .Values.images.imagePullPolicy }}
+          securityContext:
+{{ toYaml .Values.db.securityContext | indent 12 }}
+          env:
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pipelines.dbSecretName" . }}
+                  key: username
+            - name: MYSQL_PWD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pipelines.dbSecretName" . }}
+                  key: password
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+
+              MYSQL=( mysql -h mysql-kf -P 3306 -u"${DB_USER}" )
+
+              echo "Waiting for mysql-kf to accept connections..."
+              until "${MYSQL[@]}" -e "SELECT 1" >/dev/null 2>&1; do sleep 3; done
+
+              echo "Waiting for KFP tables in mlpipeline..."
+              until [[ "$("${MYSQL[@]}" -N -B -e "
+                SELECT COUNT(DISTINCT TABLE_NAME)
+                  FROM INFORMATION_SCHEMA.TABLES
+                 WHERE TABLE_SCHEMA = 'mlpipeline'
+                   AND TABLE_NAME IN ('run_details','tasks','resource_references','run_metrics');")" -eq 4 ]]; do
+                sleep 5
+              done
+
+              echo "Applying fix-kfp-indices.sql..."
+              "${MYSQL[@]}" mlpipeline < /etc/config/mysql/init-scripts/fix-kfp-indices.sql
+
+              echo "Done."
+          volumeMounts:
+            - name: mysql-init-scripts
+              mountPath: /etc/config/mysql/init-scripts
+      volumes:
+        - name: mysql-init-scripts
+          configMap:
+            name: mysql-kf
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

- Move `fix-kfp-indices.sql` application out of the `mysql-kf` startup script and into a dedicated `mysql-kf-fix-indices` Job. The Job waits for the KFP application tables (`run_details`, `tasks`, `resource_references`, `run_metrics`) to exist before applying indexes. Running the script inline at MySQL init raced the KFP API server's schema migration and silently failed.
- Add `tasks_podname` index on `tasks(PodName)` for the KFP persistence-agent `ReportWorkflow` query path.
- Drop `chart` from `pipelines.commonLabels`. `commonLabels` is embedded in `selector.matchLabels` of the chart's Deployments; the `chart` label includes the chart version, so a version bump mutated immutable selectors and broke `helm upgrade`.
- The Job is intentionally **not** a helm hook so `helm install/upgrade` does not block on it. The Job name is suffixed with `-r{{ .Release.Revision }}`, so every release revision spawns a fresh Job (Jobs are mostly immutable; a stable name would block updates). Helm deletes the prior revision's Job as part of the upgrade; `ttlSecondsAfterFinished: 86400` is the safety net for abandoned releases.
- Bump chart version to `0.13.3`.


https://iguazio.atlassian.net/browse/IG4-2116