### PR TITLE
[mlrun] Add api.podLabels for pod template metadata

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.11.20
+version: 0.11.21
 appVersion: 1.10.2
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -20,7 +20,13 @@ spec:
   template:
     metadata:
       labels:
+        {{- $podLabels := default dict .Values.api.podLabels }}
+        {{- if $podLabels }}
+        {{- $selector := include "mlrun.api.chief.selectorLabels" . | fromYaml }}
+        {{- toYaml (mergeOverwrite $selector $podLabels) | nindent 8 }}
+        {{- else }}
         {{- include "mlrun.api.chief.selectorLabels" . | nindent 8 }}
+        {{- end }}
       annotations:
         kubectl.kubernetes.io/default-container: {{ template "mlrun.name" . }}-{{ .Values.api.name }}
     spec:

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -19,7 +19,13 @@ spec:
   template:
     metadata:
       labels:
+        {{- $podLabels := default dict .Values.api.podLabels }}
+        {{- if $podLabels }}
+        {{- $selector := include "mlrun.api.worker.selectorLabels" . | fromYaml }}
+        {{- toYaml (mergeOverwrite $selector $podLabels) | nindent 8 }}
+        {{- else }}
         {{- include "mlrun.api.worker.selectorLabels" . | nindent 8 }}
+        {{- end }}
       annotations:
         kubectl.kubernetes.io/default-container: {{ template "mlrun.name" . }}-{{ .Values.api.name }}
     spec:

--- a/stable/mlrun/templates/ms-deployment.yaml
+++ b/stable/mlrun/templates/ms-deployment.yaml
@@ -19,7 +19,13 @@ spec:
   template:
     metadata:
       labels:
+        {{- $podLabels := default dict $.Values.api.podLabels }}
+        {{- if $podLabels }}
+        {{- $base := include "mlrun.api.microservices.current.labels" (dict "root" $ "microservice" .) | fromYaml }}
+        {{- toYaml (mergeOverwrite $base $podLabels) | nindent 8 }}
+        {{- else }}
         {{- include "mlrun.api.microservices.current.labels" (dict "root" $ "microservice" .) | nindent 8 }}
+        {{- end }}
       annotations:
         kubectl.kubernetes.io/default-container: {{ template "mlrun.name" $ }}-{{ $.Values.api.name }}
     spec:

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -5,6 +5,11 @@ fullnameOverride:
 api:
   name: api
   fullnameOverride:
+  # Additional labels added to the API pod template.metadata.labels.
+  # Merged with the chart's selectorLabels; values here take precedence.
+  # Example use: { "azure.workload.identity/use": "true" } to activate
+  # Azure Workload Identity token injection on AKS.
+  podLabels: {}
   microservices:
     enabled: false
     services:


### PR DESCRIPTION
## Summary
- Add `api.podLabels` (default `{}`) merged into pod `template.metadata.labels` for the chief, worker, and microservices Deployments.
- On key collision, `podLabels` **take precedence** over the chart's existing labels (via `mergeOverwrite`).
- `selector.matchLabels` is deliberately left untouched, so values can change across upgrades without breaking selectors on running Deployments.
- When `api.podLabels` is unset/empty the rendered output is byte-identical to the previous chart (no upgrade churn).
- No chart-version bump in this PR — handled by CI.

## Motivation
Enables mlefi ([IG4-2250](https://iguazio.atlassian.net/browse/IG4-2250)) to inject `azure.workload.identity/use: "true"` on MLRun API pods (chief, worker, and the alerts microservice) when the cluster runs on Azure with Workload Identity configured. The mlefi-side change is a no-op until this chart change merges.

Out of scope: `db-deployment.yaml`, `ui-deployment.yaml` — the WI label is only required on the API-side pods.

## Test plan
- [x] `helm template` (defaults) on chief, worker, ms — output byte-identical to current chart.
- [x] `helm template --set api.podLabels.azure\.workload\.identity/use=true` — label appears under `spec.template.metadata.labels` on chief, worker, and ms (alerts); **NOT** under `spec.selector.matchLabels`.
- [x] `helm template --set api.podLabels.app\.kubernetes\.io/name=override` — `podLabels` value wins over the chart label in `spec.template.metadata.labels`, while `spec.selector.matchLabels` retains the original. (User footgun: overriding a selector key on the pod template would orphan the pod from its Deployment — intentional, not guarded against.)
- [ ] Reviewer to confirm rendered diff on a real cluster upgrade is no-op when `podLabels` is unset.