### PR TITLE
[MLRun] Fix extraEnv value propogation

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.11.21
+version: 0.11.22
 appVersion: 1.10.2
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -124,8 +124,7 @@ spec:
           {{- if .Values.api.extraEnv }}
           {{- range .Values.api.extraEnv }}
           {{- if not (hasKey $.Values.api.extraEnvKeyValue .name) }}
-          - name: {{ .name }}
-            value: {{ .value }}
+          - {{ toYaml . | nindent 12 | trim }}
           {{- end }}
           {{- end }}
           {{- end }}

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -123,8 +123,7 @@ spec:
           {{- if .Values.api.extraEnv }}
           {{- range .Values.api.extraEnv }}
           {{- if not (hasKey $.Values.api.extraEnvKeyValue .name) }}
-          - name: {{ .name }}
-            value: {{ .value }}
+          - {{ toYaml . | nindent 12 | trim }}
           {{- end }}
           {{- end }}
           {{- end }}

--- a/stable/mlrun/templates/ms-deployment.yaml
+++ b/stable/mlrun/templates/ms-deployment.yaml
@@ -111,8 +111,7 @@ spec:
           {{- if $.Values.api.extraEnv }}
           {{- range $.Values.api.extraEnv }}
           {{- if not (hasKey $.Values.api.extraEnvKeyValue .name) }}
-          - name: {{ .name }}
-            value: {{ .value }}
+          - {{ toYaml . | nindent 12 | trim }}
           {{- end }}
           {{- end }}
           {{- end }}


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

MLRun's `extraEnv` only supported the single `value` env vars, although the template supports other options like `valueFrom`. If the values had `valueFrom` style env vars, they were simply dropped.

The [comment in the values file](https://github.com/v3io/helm-charts/blob/development/stable/mlrun/values.yaml#L176-L180) suggests how to use it - now it will also work :) 
