### PR TITLE
[mlrun] Rename OPA sidecar port to opa-http to avoid name collision

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.11.23
+version: 0.11.24
 appVersion: 1.11.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -164,7 +164,7 @@ spec:
           image: "{{ .Values.api.opa.image.repository }}:{{ .Values.api.opa.image.tag }}"
           imagePullPolicy: {{ .Values.api.opa.image.pullPolicy }}
           ports:
-            - name: http
+            - name: opa-http
               containerPort: {{ .Values.api.opa.port }}
           {{- if .Values.api.opa.livenessProbe }}
           livenessProbe:

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -163,7 +163,7 @@ spec:
           image: "{{ .Values.api.opa.image.repository }}:{{ .Values.api.opa.image.tag }}"
           imagePullPolicy: {{ .Values.api.opa.image.pullPolicy }}
           ports:
-            - name: http
+            - name: opa-http
               containerPort: {{ .Values.api.opa.port }}
           {{- if .Values.api.opa.livenessProbe }}
           livenessProbe:

--- a/stable/mlrun/templates/ms-deployment.yaml
+++ b/stable/mlrun/templates/ms-deployment.yaml
@@ -149,7 +149,7 @@ spec:
           image: "{{ $.Values.api.opa.image.repository }}:{{ $.Values.api.opa.image.tag }}"
           imagePullPolicy: {{ $.Values.api.opa.image.pullPolicy }}
           ports:
-            - name: http
+            - name: opa-http
               containerPort: {{ $.Values.api.opa.port }}
           {{- if $.Values.api.opa.livenessProbe }}
           livenessProbe:

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -334,7 +334,7 @@ api:
     readinessProbe:
       httpGet:
         path: /health?bundle=true
-        port: http
+        port: opa-http
       initialDelaySeconds: 10
       timeoutSeconds: 10
       periodSeconds: 15
@@ -342,7 +342,7 @@ api:
 
     livenessProbe:
       httpGet:
-        port: http
+        port: opa-http
       initialDelaySeconds: 15
       timeoutSeconds: 30
       periodSeconds: 15


### PR DESCRIPTION
### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

The OPA sidecar container in the MLRun api deployments declares its container port as `http`, colliding with the main `api` container's `http` port (8080). Kubernetes raises:

```
Warning: spec.template.spec.containers[1].ports[0]: duplicate port name "http"
with spec.template.spec.containers[0].ports[0], services and probes that select
ports by name will use spec.template.spec.containers[0].ports[0]
```


