### PR TITLE
[mlrun] Make OPA container extra args configurable and bump OPA to 1.17

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.11.23
+version: 0.11.24
 appVersion: 1.11.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -184,7 +184,9 @@ spec:
             - "--log-level={{ .Values.api.opa.logLevel }}"
             - "--log-format={{ .Values.api.opa.logFormat }}"
             - "--ignore=.*"
-            - "--disable-telemetry"
+            {{- range .Values.api.opa.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
           volumeMounts:
             - readOnly: true
               mountPath: /config

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -183,7 +183,9 @@ spec:
             - "--log-level={{ .Values.api.opa.logLevel }}"
             - "--log-format={{ .Values.api.opa.logFormat }}"
             - "--ignore=.*"
-            - "--disable-telemetry"
+            {{- range .Values.api.opa.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
           volumeMounts:
             - readOnly: true
               mountPath: /config

--- a/stable/mlrun/templates/ms-deployment.yaml
+++ b/stable/mlrun/templates/ms-deployment.yaml
@@ -169,7 +169,9 @@ spec:
             - "--log-level={{ $.Values.api.opa.logLevel }}"
             - "--log-format={{ $.Values.api.opa.logFormat }}"
             - "--ignore=.*"
-            - "--disable-telemetry"
+            {{- range $.Values.api.opa.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
           volumeMounts:
             - readOnly: true
               mountPath: /config

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -309,9 +309,12 @@ api:
     logLevel: info
     logFormat: json
 
+    extraArgs:
+      - "--skip-version-check"
+
     image:
       repository: openpolicyagent/opa
-      tag: 1.6.0
+      tag: 1.17.0
       pullPolicy: IfNotPresent
       pullSecrets: []
 


### PR DESCRIPTION
### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description
**Changes**
- `stable/mlrun/templates/api-chief-deployment.yaml`, `api-worker-deployment.yaml`, `ms-deployment.yaml`: drop the hardcoded `--disable-telemetry` arg; iterate `api.opa.extraArgs` after the fixed args.
- `stable/mlrun/values.yaml`: add `api.opa.extraArgs` default list (`["--skip-version-check"]`); bump OPA image tag `1.6.0 → 1.17.0`.
- `stable/mlrun/Chart.yaml`: bump chart version `0.11.23 → 0.11.24`.

**Why the flag rename:** OPA deprecated `--disable-telemetry` in favor of `--skip-version-check`. Both flags share the same single behavior — suppress the version-check phone-home to GitHub releases — so runtime telemetry posture is unchanged. `--skip-version-check` is also accepted by OPA 1.16.x, so the flag swap is forward- and backward-compatible.
