### PR TITLE
[mlrun] fix mlrun-db readiness probe 1s timeout causing intermittent restarts

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.11.24
+version: 0.11.25
 appVersion: 1.11.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -488,7 +488,7 @@ db:
     exec:
       command: ["/bin/bash", "/etc/config/mysql/health_check.sh"]
     initialDelaySeconds: 10
-    timeoutSeconds: 1
+    timeoutSeconds: 10
     periodSeconds: 10
     failureThreshold: 3
 


### PR DESCRIPTION
### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

The mlrun-db readiness probe runs `/bin/bash /etc/config/mysql/health_check.sh`, which execs `mysqladmin ...`. The default `timeoutSeconds: 1` is too tight for that command on a BestEffort QoS pod.

Change: `db.readinessProbe.timeoutSeconds: 1 → 10`.

Chart bumped to `0.11.25`. No template changes — only the default value.

Related: ML-12708 (https://ecliptos.atlassian.net/browse/ML-12708)