### PR TITLE
[pipelines-v2] Allow extra mysqld/InnoDB flags via Helm values

### DIFF
--- a/stable/pipelines-v2/Chart.yaml
+++ b/stable/pipelines-v2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: ">=2.16.0"
-version: 0.13.3
+version: 0.13.4
 name: pipelines-v2
 description: Kubeflow pipelines framework for machine learning
 home: https://www.kubeflow.org/

--- a/stable/pipelines-v2/templates/mysql/configmap-kf.yaml
+++ b/stable/pipelines-v2/templates/mysql/configmap-kf.yaml
@@ -262,6 +262,16 @@ data:
       --datadir="${DATA_DIR}"
       --socket="${SOCKET}"
       --init-file="${INIT_SCRIPT}"
+      {{- $extra := .Values.db.dbConfiguration.innodb.extraFlags -}}
+      {{- if $extra }}
+      {{- if kindIs "map" $extra }}
+      {{- range $flag, $value := $extra }}
+      --{{ $flag }}={{ $value }}
+      {{- end }}
+      {{- else }}
+      {{ $extra }}
+      {{- end }}
+      {{- end }}
     )
 
     if [[ ! -d "${DATA_DIR}/mysql" ]]; then

--- a/stable/pipelines-v2/values.yaml
+++ b/stable/pipelines-v2/values.yaml
@@ -237,6 +237,13 @@ db:
   dumpRestore:
     enabled: true   # enable to dump data from KFP 1.8 MySQL 5.6 to KFP 2.X MySQL version 8.4
 
+  dbConfiguration:
+    innodb:
+      extraFlags: {} # extra flags to pass to the mysql server start command, example:
+      # extraFlags:
+      #   innodb-use-native-aio: 0
+      # will be passed as --innodb-use-native-aio=0
+
 managedstorage:
   enabled: false
   gcsBucketName: ""


### PR DESCRIPTION
### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

`mysql-kf`'s `start-mysql.sh` entrypoint has a fixed, non-configurable `MYSQLD_OPTS` array — there was no way to override MySQL 8.4's InnoDB defaults (tuned for local SSD: `O_DIRECT` flush, `io_capacity=10000`, native AIO) for NFS-backed deployments without forking the entrypoint script. This adds `db.dbConfiguration.innodb.extraFlags`, mirroring the identical escape hatch already shipped on the `mlrun` chart's MySQL (`db-configmap.yaml`), adapted to this chart's bash-array `MYSQLD_OPTS` style instead of mlrun's backslash-continued command string. Accepts either a flag-name/value map or a raw string, same as mlrun's.

Defaults to `{}` — verified the rendered `mysql-kf` ConfigMap is byte-identical to before when unset, and that setting flags correctly appends them to the real entrypoint script's `MYSQLD_OPTS` array. Bumps `Chart.yaml` `0.13.3` -> `0.13.4` per repo convention.