### PR TITLE
[MLRun] Disable service account automount for UI deployment

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.11.25
+version: 0.11.26
 appVersion: 1.11.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/ui-deployment.yaml
+++ b/stable/mlrun/templates/ui-deployment.yaml
@@ -14,6 +14,9 @@ spec:
       labels:
         {{- include "mlrun.ui.selectorLabels" . | nindent 8 }}
     spec:
+    {{- if kindIs "bool" .Values.ui.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.ui.automountServiceAccountToken }}
+    {{- end }}
     {{- with .Values.ui.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -687,6 +687,11 @@ ui:
 
   priorityClassName: ""
 
+  # The UI is a static frontend and does not talk to the Kubernetes API, so it
+  # has no need for a mounted ServiceAccount token. Set to null to omit the field
+  # (falling back to the ServiceAccount / cluster default).
+  automountServiceAccountToken: false
+
   podSecurityContext: {}
   # default UID & GID of unprivileged nginx image
   # https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-alpine.template


### PR DESCRIPTION
[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

This pull request updates the `mlrun` and introduces an option to control the mounting of the Kubernetes ServiceAccount token in the UI deployment. The main focus is on improving security by allowing users to disable automatic mounting of the ServiceAccount token for the UI, which does not require Kubernetes API access.
