### PR TITLE
[mlrun] Add extraVolumes and extraVolumeMounts for API deployments

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.11.26
+version: 0.11.27
 appVersion: 1.11.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -157,6 +157,9 @@ spec:
               subPath: {{ .subPath | default "" }}
               readOnly: {{ .readOnly }}
             {{- end }}
+            {{- with .Values.api.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         {{- if .Values.api.opa.enabled }}
         - name: {{ template "mlrun.name" . }}-{{ .Values.api.opa.name }}
           securityContext:
@@ -261,6 +264,9 @@ spec:
         - name: config
           secret:
             secretName: {{ template "mlrun.api.opa.fullname" . }}
+        {{- end }}
+        {{- with .Values.api.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.api.nodeSelector }}
       nodeSelector:

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -156,6 +156,9 @@ spec:
               subPath: {{ .subPath | default "" }}
               readOnly: {{ .readOnly }}
             {{- end }}
+            {{- with .Values.api.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         {{- if .Values.api.opa.enabled }}
         - name: {{ template "mlrun.name" . }}-{{ .Values.api.opa.name }}
           securityContext:
@@ -260,6 +263,9 @@ spec:
         - name: config
           secret:
             secretName: {{ template "mlrun.api.opa.fullname" . }}
+        {{- end }}
+        {{- with .Values.api.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.api.nodeSelector }}
       nodeSelector:

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -271,6 +271,15 @@ api:
     #   readOnly: true
     #   existingClaim: volume-claim
 
+  # Generic extra volumes/volumeMounts for the api container (chief + worker), e.g. an
+  # emptyDir scratch dir when readOnlyRootFilesystem leaves no writable tmp path.
+  extraVolumes: []
+    # - name: tmp
+    #   emptyDir: {}
+  extraVolumeMounts: []
+    # - name: tmp
+    #   mountPath: /tmp
+
   # Define extra initContainers for the api deployment
   extraInitContainers: []
 


### PR DESCRIPTION
### Checklist

- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

Adds configurable generic volumes and volume mounts for the MLRun API container on both chief and worker deployments. This complements the existing `extraPersistentVolumeMounts` (PVC-only) and allows operators to inject arbitrary Kubernetes volumes — for example, an `emptyDir` scratch directory at `/tmp` when `readOnlyRootFilesystem: true` is enabled and the container has no writable temp path.

### Changes Made

- **`stable/mlrun/values.yaml`**
  - Added `api.extraVolumes` and `api.extraVolumeMounts` (default: `[]`)
  - Documented example usage for an `emptyDir` `/tmp` mount

- **`stable/mlrun/templates/api-chief-deployment.yaml`**
  - Render `api.extraVolumeMounts` on the API container
  - Render `api.extraVolumes` in the pod spec

- **`stable/mlrun/templates/api-worker-deployment.yaml`**
  - Same volume/volumeMount support as chief deployment

**Breaking changes:** None. Defaults are empty arrays; existing deployments are unaffected.

### Testing

- [ ] `helm template` renders correctly with default values (no extra volumes)
- [ ] `helm template` with custom values injects volumes and mounts as expected:

  ```yaml
  api:
    extraVolumes:
      - name: tmp
        emptyDir: {}
    extraVolumeMounts:
      - name: tmp
        mountPath: /tmp
  ```

- [ ] Verify rendered manifests on both `api-chief-deployment` and `api-worker-deployment`
- [ ] Manual deploy test with `readOnlyRootFilesystem: true` and `/tmp` emptyDir mount (if applicable)

### Related Issues

<!-- Link related Jira/GitHub issues here, e.g. Fixes #123 -->

### Additional Notes

- **Deployment consideration:** When enabling `readOnlyRootFilesystem`, mount a writable path (e.g. `/tmp`) via these new values before rolling out.
- **Chart version:** Consider bumping `Chart.yaml` version (`0.11.26` → patch) before merge, per repo checklist.
- **Scope:** Volumes apply only to the main API container (chief + worker), not OPA or log-collector sidecars. Use sidecar-specific values for those if needed.
