### PR TITLE
[provazio] Add provctl ServiceAccount support and env-spec wiring

### DIFF
--- a/stable/provazio/Chart.yaml
+++ b/stable/provazio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Iguazio provisioner
 name: provazio
-version: 1.1.4
+version: 1.1.5
 appVersion: 0.24.37
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://iguazio.com

--- a/stable/provazio/Chart.yaml
+++ b/stable/provazio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Iguazio provisioner
 name: provazio
-version: 1.1.5
+version: 1.1.6
 appVersion: 0.24.37
 icon: https://github.com/nuclio/nuclio/raw/master/docs/assets/images/logo.png
 home: https://iguazio.com

--- a/stable/provazio/templates/_helpers.tpl
+++ b/stable/provazio/templates/_helpers.tpl
@@ -18,3 +18,21 @@
 {{- define "provazio.vault.name" -}}
 {{- printf "%s-vault" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "provazio.provctl.name" -}}
+{{- printf "%s-provctl" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+  SA name for provctl Job pods (dashboard env spec provisioning.service_account_name).
+  Precedence: useProvctlServiceAccount -> provctl.serviceAccountName -> legacy envSpec field -> omit (default SA).
+*/}}
+{{- define "provazio.provctl.jobServiceAccountName" -}}
+{{- if .Values.provctl.useProvctlServiceAccount -}}
+{{- include "provazio.provctl.name" . -}}
+{{- else if .Values.provctl.serviceAccountName -}}
+{{- .Values.provctl.serviceAccountName -}}
+{{- else if dig "provisioning" "service_account_name" "" .Values.dashboard.envSpec -}}
+{{- dig "provisioning" "service_account_name" "" .Values.dashboard.envSpec -}}
+{{- end -}}
+{{- end -}}

--- a/stable/provazio/templates/_helpers.tpl
+++ b/stable/provazio/templates/_helpers.tpl
@@ -23,10 +23,6 @@
 {{- printf "%s-provctl" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{/*
-  SA name for provctl Job pods (dashboard env spec provisioning.service_account_name).
-  When provctl.enabled, use {{ release }}-provctl; otherwise omit (namespace default SA).
-*/}}
 {{- define "provazio.provctl.jobServiceAccountName" -}}
 {{- if .Values.provctl.enabled -}}
 {{- include "provazio.provctl.name" . -}}

--- a/stable/provazio/templates/_helpers.tpl
+++ b/stable/provazio/templates/_helpers.tpl
@@ -25,14 +25,10 @@
 
 {{/*
   SA name for provctl Job pods (dashboard env spec provisioning.service_account_name).
-  Precedence: useProvctlServiceAccount -> provctl.serviceAccountName -> legacy envSpec field -> omit (default SA).
+  When provctl.enabled, use {{ release }}-provctl; otherwise omit (namespace default SA).
 */}}
 {{- define "provazio.provctl.jobServiceAccountName" -}}
-{{- if .Values.provctl.useProvctlServiceAccount -}}
+{{- if .Values.provctl.enabled -}}
 {{- include "provazio.provctl.name" . -}}
-{{- else if .Values.provctl.serviceAccountName -}}
-{{- .Values.provctl.serviceAccountName -}}
-{{- else if dig "provisioning" "service_account_name" "" .Values.dashboard.envSpec -}}
-{{- dig "provisioning" "service_account_name" "" .Values.dashboard.envSpec -}}
 {{- end -}}
 {{- end -}}

--- a/stable/provazio/templates/dashboard-env-spec-configmap.yaml
+++ b/stable/provazio/templates/dashboard-env-spec-configmap.yaml
@@ -1,4 +1,13 @@
 {{- if and .Values.dashboard.enabled }}
+{{- $envSpec := deepCopy .Values.dashboard.envSpec | default dict }}
+{{- $provisioning := dig "provisioning" dict $envSpec }}
+{{- $jobServiceAccountName := include "provazio.provctl.jobServiceAccountName" . | trim }}
+{{- if $jobServiceAccountName }}
+{{- $_ := set $provisioning "service_account_name" $jobServiceAccountName }}
+{{- else }}
+{{- $_ := unset $provisioning "service_account_name" }}
+{{- end }}
+{{- $_ := set $envSpec "provisioning" $provisioning }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,5 +20,5 @@ metadata:
     component: dashboard
 data:
   env.yaml: |
-{{ toYaml .Values.dashboard.envSpec | indent 4 }}
+{{ toYaml $envSpec | indent 4 }}
 {{- end }}

--- a/stable/provazio/templates/provctl-service-account.yaml
+++ b/stable/provazio/templates/provctl-service-account.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.provctl.enabled }}
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "provazio.provctl.name" . }}
+  labels:
+    app: {{ template "provazio.name" . }}
+    chart: {{ template "provazio.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: provctl
+  {{- with .Values.provctl.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+{{- end }}

--- a/stable/provazio/values.yaml
+++ b/stable/provazio/values.yaml
@@ -93,7 +93,7 @@ dashboard:
     #   terraform:
     #     bin_path: /usr/bin/terraform
     #     config_path: /etc/terraform/configs
-    #   (Job pod SA: see provctl.useProvctlServiceAccount / provctl.serviceAccountName)
+    #   (Job pod SA: see provctl.enabled)
 
   ## Node labels for pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -247,8 +247,9 @@ vault:
   priorityClassName: ""
 
 provctl:
-  # Create the dedicated provctl ServiceAccount (set IRSA annotations when on EKS).
-  # Required when useProvctlServiceAccount is true.
+  # When true, creates {{ release }}-provctl ServiceAccount (same pattern as dashboard/vault)
+  # and sets provisioning.service_account_name for kubernetes_job provctl pods.
+  # When false, provctl Job pods use the namespace default ServiceAccount.
   enabled: false
 
   serviceAccount:
@@ -256,15 +257,3 @@ provctl:
     # Example for IRSA:
     # annotations:
     #   eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/provazio-provisioning-role-shared
-  useProvctlServiceAccount: false
-  # Which ServiceAccount provctl Job pods run as (written to dashboard env spec by chart):
-  #
-  # useProvctlServiceAccount: true
-  #   -> Job pods use {{ release }}-provctl (e.g. provazio-provctl). Requires enabled: true.
-  #
-  # useProvctlServiceAccount: false (default) and serviceAccountName unset
-  #   -> Job pods use the namespace default ServiceAccount
-  #
-  # useProvctlServiceAccount: false and serviceAccountName: "my-sa"
-  #   -> Job pods use your custom SA (must exist in the namespace).
-  serviceAccountName: ""

--- a/stable/provazio/values.yaml
+++ b/stable/provazio/values.yaml
@@ -1,6 +1,7 @@
 # list of namespaces that the api will also get resources access to
 additionalManagedNamespaces: []
 
+
 dashboard:
   enabled: false
 
@@ -84,16 +85,15 @@ dashboard:
     #   username: 
 
     # provisioning:
-
     #   permitted_ingresses:
     #   - from_port: 0
     #     to_port: 0
     #     protocol: "-1"
     #     source_cidr_block: 10.0.0.1/32
-
     #   terraform:
     #     bin_path: /usr/bin/terraform
-    #     config_path: /etc/terraform/configs    
+    #     config_path: /etc/terraform/configs
+    #   (Job pod SA: see provctl.useProvctlServiceAccount / provctl.serviceAccountName)
 
   ## Node labels for pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -246,3 +246,25 @@ vault:
 
   priorityClassName: ""
 
+provctl:
+  # Create the dedicated provctl ServiceAccount (set IRSA annotations when on EKS).
+  # Required when useProvctlServiceAccount is true.
+  enabled: false
+
+  serviceAccount:
+    annotations: {}
+    # Example for IRSA:
+    # annotations:
+    #   eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/provazio-provisioning-role-shared
+  useProvctlServiceAccount: false
+  # Which ServiceAccount provctl Job pods run as (written to dashboard env spec by chart):
+  #
+  # useProvctlServiceAccount: true
+  #   -> Job pods use {{ release }}-provctl (e.g. provazio-provctl). Requires enabled: true.
+  #
+  # useProvctlServiceAccount: false (default) and serviceAccountName unset
+  #   -> Job pods use the namespace default ServiceAccount
+  #
+  # useProvctlServiceAccount: false and serviceAccountName: "my-sa"
+  #   -> Job pods use your custom SA (must exist in the namespace).
+  serviceAccountName: ""


### PR DESCRIPTION
### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

Adds **provctl ServiceAccount** support to the Provazio helm chart, complementing [iguazio/provazio#3389](https://github.com/iguazio/provazio/pull/3389) (dashboard reads `provisioning.service_account_name` for kubernetes_job pods).

Follows the same naming convention as dashboard (`{{ release }}-dashboard`) and vault (`{{ release }}-vault`):

| `provctl.enabled` | ServiceAccount created | Job pod identity |
|---|---|---|
| `false` (default) | none | namespace `default` |
| `true` | `{{ release }}-provctl` | `{{ release }}-provctl` |

Changes:

- New `provctl-service-account.yaml` template (optional SA with IRSA annotations)
- New `provctl` values block: `enabled`, `serviceAccount.annotations`
- Dashboard env-spec ConfigMap sets `provisioning.service_account_name` when `provctl.enabled` is true
- **Backward compatible**: default leaves provctl Job pods on the namespace default ServiceAccount

Follows the same IRSA annotation pattern as [v3io/helm-charts#1129](https://github.com/v3io/helm-charts/pull/1129) (dashboard/vault SA).

Example usage:

```yaml
provctl:
  enabled: true
  serviceAccount:
    annotations:
      eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/provazio-provisioning-role-shared
```

Chart version: **1.1.6**