### PR TITLE
[v3io-keycloak] Add startupProbe so first-time DB migration

### DIFF
--- a/stable/v3io-keycloak/Chart.yaml
+++ b/stable/v3io-keycloak/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: v3io-keycloak
-version: 0.2.5
+version: 0.2.6
 appVersion: 23.6.6
 description: Keycloak With V3IO MySQL Database
 maintainers:

--- a/stable/v3io-keycloak/values.yaml
+++ b/stable/v3io-keycloak/values.yaml
@@ -22,6 +22,27 @@ keycloak:
   postgresql:
     enabled: false
 
+  # A first-time install must run Keycloak's entire historical Liquibase changelog
+  # from scratch, which can take longer than livenessProbe's default 120s window on a
+  # loaded system - if that probe kills the container mid-migration, MySQL's
+  # non-transactional DDL leaves the schema permanently wedged (see IG-25046).
+  # A startupProbe defers liveness/readiness checks until Keycloak's HTTP port is
+  # actually up, so a slow first migration is never mistaken for a hung container.
+  startupProbe:
+    enabled: true
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 60 # ~10 minutes for the first-time migration to complete
+    successThreshold: 1
+
+  # Per Bitnami's own guidance: once startupProbe is enabled, liveness/readiness
+  # should not add their own extra initial delay on top of it.
+  livenessProbe:
+    initialDelaySeconds: 0
+
+  readinessProbe:
+    initialDelaySeconds: 0
+
   externalDatabase:
     host: v3io-keycloak-db
     port: 3306


### PR DESCRIPTION
A first-time install has to run Keycloak's entire historical Liquibase changelog from scratch, which can exceed the livenessProbe's fixed 120s window on a loaded system. Add a startupProbe so liveness/readiness don't start counting until Keycloak's HTTP port actually answers, giving the first migration a real ~10 minute budget instead of racing a fixed delay. See IG-25046.

Bump chart patch version for the values.yaml change.

### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

[Please add a description of the change request.]
