### PR TITLE
[pipelines-v2] Disable Argo workflow-step log archiving by default

### DIFF
--- a/stable/pipelines-v2/Chart.yaml
+++ b/stable/pipelines-v2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: ">=2.16.0"
-version: 0.13.4
+version: 0.13.5
 name: pipelines-v2
 description: Kubeflow pipelines framework for machine learning
 home: https://www.kubeflow.org/

--- a/stable/pipelines-v2/README.md
+++ b/stable/pipelines-v2/README.md
@@ -35,7 +35,7 @@ $ helm install --name my-release -f values.yaml v3io-stable/pipelines
 - **`configurations.ui.replicas`**: Number of `ml-pipeline-ui` replicas to run. Default: `1`.
 - **`storageMode.archiveLogs`**: Whether Argo additionally archives each workflow
   step's own container logs into the artifact repository (separate from whatever
-  the step itself writes there). Default: `false`.
+  the step itself writes there). Default: `true`, for backward compatibility.
 
 ## TODOS:
 There are some unresolved issues in this project

--- a/stable/pipelines-v2/README.md
+++ b/stable/pipelines-v2/README.md
@@ -33,6 +33,9 @@ $ helm install --name my-release -f values.yaml v3io-stable/pipelines
 ### Common overrides
 
 - **`configurations.ui.replicas`**: Number of `ml-pipeline-ui` replicas to run. Default: `1`.
+- **`storageMode.archiveLogs`**: Whether Argo additionally archives each workflow
+  step's own container logs into the artifact repository (separate from whatever
+  the step itself writes there). Default: `false`.
 
 ## TODOS:
 There are some unresolved issues in this project

--- a/stable/pipelines-v2/templates/argo/workflow-controller-configmap.yaml
+++ b/stable/pipelines-v2/templates/argo/workflow-controller-configmap.yaml
@@ -16,7 +16,7 @@ data:
 
   # https://github.com/argoproj/argo-workflows/blob/v3.7.7/docs/workflow-controller-configmap.yaml
   artifactRepository: |
-    archiveLogs: {{ .Values.storageMode.archiveLogs | default false }}
+    archiveLogs: {{ if hasKey .Values.storageMode "archiveLogs" }}{{ .Values.storageMode.archiveLogs }}{{ else }}true{{ end }}
     s3:
       endpoint: {{ .Values.storageMode.minio.serviceHost }}:{{ .Values.storageMode.minio.servicePort }}
       bucket: {{ .Values.storageMode.minio.defaultBucket }}
@@ -55,7 +55,7 @@ data:
                   key: secretkey
               }
           },
-          archiveLogs: {{ .Values.storageMode.archiveLogs | default false }}
+          archiveLogs: {{ if hasKey .Values.storageMode "archiveLogs" }}{{ .Values.storageMode.archiveLogs }}{{ else }}true{{ end }}
       }
     }
   executor: |

--- a/stable/pipelines-v2/templates/argo/workflow-controller-configmap.yaml
+++ b/stable/pipelines-v2/templates/argo/workflow-controller-configmap.yaml
@@ -16,7 +16,7 @@ data:
 
   # https://github.com/argoproj/argo-workflows/blob/v3.7.7/docs/workflow-controller-configmap.yaml
   artifactRepository: |
-    archiveLogs: true
+    archiveLogs: {{ .Values.storageMode.archiveLogs | default false }}
     s3:
       endpoint: {{ .Values.storageMode.minio.serviceHost }}:{{ .Values.storageMode.minio.servicePort }}
       bucket: {{ .Values.storageMode.minio.defaultBucket }}
@@ -55,7 +55,7 @@ data:
                   key: secretkey
               }
           },
-          archiveLogs: true
+          archiveLogs: {{ .Values.storageMode.archiveLogs | default false }}
       }
     }
   executor: |

--- a/stable/pipelines-v2/values.yaml
+++ b/stable/pipelines-v2/values.yaml
@@ -189,6 +189,12 @@ storageMode:
   # default; set to "minio" to switch
   kind: v3io
   useTLS: false
+  # Whether Argo additionally archives each workflow step's own container logs
+  # into the artifact repository, separate from whatever the step itself writes
+  # there. MLRun already has its own job-log mechanism, so this is normally
+  # redundant, and archiving very large step logs has caused workflow failures.
+  # Default false; set true to restore the legacy Argo/KFP log-archiving behavior.
+  archiveLogs: false
   minio:
     serviceHost: minio.{{ .Release.Namespace }}.svc
     servicePort: 9000

--- a/stable/pipelines-v2/values.yaml
+++ b/stable/pipelines-v2/values.yaml
@@ -191,10 +191,11 @@ storageMode:
   useTLS: false
   # Whether Argo additionally archives each workflow step's own container logs
   # into the artifact repository, separate from whatever the step itself writes
-  # there. MLRun already has its own job-log mechanism, so this is normally
-  # redundant, and archiving very large step logs has caused workflow failures.
-  # Default false; set true to restore the legacy Argo/KFP log-archiving behavior.
-  archiveLogs: false
+  # there. Default true, for backward compatibility with the chart's legacy
+  # behavior. This can be redundant when the pipeline step already persists its
+  # own logs elsewhere, and archiving very large step logs has caused workflow
+  # failures — set false to disable it.
+  archiveLogs: true
   minio:
     serviceHost: minio.{{ .Release.Namespace }}.svc
     servicePort: 9000


### PR DESCRIPTION
### Checklist

[Place an '[x]' (no spaces) in all applicable fields. Please remove irrelevant fields.]

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

`archiveLogs` was hardcoded to `true` in both `storageMode` branches (`minio` and `v3io`) of the workflow-controller configmap, with no way to override it. This makes Argo additionally archive each workflow step's own container logs into the artifact repository, separate from whatever the step itself writes there — redundant when the pipeline step already persists its own logs elsewhere, and archiving very large step logs has been observed to cause workflow failures.

`storageMode.archiveLogs` is now an explicit, overridable value. It still **defaults to `true`** (no behavior change for existing installs); set `storageMode.archiveLogs: false` (or `--set storageMode.archiveLogs=false`) to disable it.

The template reads the value via a `hasKey` guard rather than Sprig's `default` filter, since `default` treats `false` as an "empty" value and would silently clobber an explicit `false` back to `true` — that would defeat the override entirely.

Verified with `helm lint` and `helm template` across both `storageMode.kind` values (`minio`/`v3io`), with no override, with an explicit `false` override, and with an explicit `true` override.