### PR TITLE
[mlrun] Automount ServiceAccount token on API deployments

### DIFF
--- a/stable/mlrun/Chart.yaml
+++ b/stable/mlrun/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: mlrun
-version: 0.11.27
+version: 0.11.28
 appVersion: 1.11.0
 description: Machine Learning automation and tracking
 sources:

--- a/stable/mlrun/templates/api-chief-deployment.yaml
+++ b/stable/mlrun/templates/api-chief-deployment.yaml
@@ -30,6 +30,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: {{ template "mlrun.name" . }}-{{ .Values.api.name }}
     spec:
+    {{- if kindIs "bool" .Values.api.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.api.automountServiceAccountToken }}
+    {{- end }}
     {{- with .Values.api.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/stable/mlrun/templates/api-worker-deployment.yaml
+++ b/stable/mlrun/templates/api-worker-deployment.yaml
@@ -29,6 +29,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: {{ template "mlrun.name" . }}-{{ .Values.api.name }}
     spec:
+    {{- if kindIs "bool" .Values.api.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.api.automountServiceAccountToken }}
+    {{- end }}
     {{- with .Values.api.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/stable/mlrun/templates/ms-deployment.yaml
+++ b/stable/mlrun/templates/ms-deployment.yaml
@@ -29,6 +29,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: {{ template "mlrun.name" $ }}-{{ $.Values.api.name }}
     spec:
+    {{- if kindIs "bool" $.Values.api.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ $.Values.api.automountServiceAccountToken }}
+    {{- end }}
     {{- with $.Values.api.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/stable/mlrun/values.yaml
+++ b/stable/mlrun/values.yaml
@@ -217,6 +217,11 @@ api:
 
   priorityClassName: ""
 
+  # The API and its log-collector sidecar talk to the Kubernetes API, so they need a mounted ServiceAccount token.
+  # Applies to the chief, worker and microservices deployments.
+  # Set to null to omit the field, falling back to the ServiceAccount / cluster default.
+  automountServiceAccountToken: true
+
   podSecurityContext: {}
   # runAsUser: 1000
 


### PR DESCRIPTION
### Checklist

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)

### Description

The API and its `mlrun-log-collector` sidecar both talk to the Kubernetes API, so they need a ServiceAccount token mounted. On clusters where ServiceAccount token automounting is disabled by default, the log collector panics at startup with `open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory`, crashlooping `mlrun-api-chief` and `mlrun-api-worker` and leaving `mlrun-alerts` Not Ready.

- `values.yaml`: new `api.automountServiceAccountToken`, defaulting to `true`. This matches the Kubernetes default, so existing installs are unaffected.
- `api-chief-deployment.yaml`, `api-worker-deployment.yaml`, `ms-deployment.yaml`: emit `automountServiceAccountToken` on the pod spec, guarded by `kindIs "bool"` so setting the value to `null` omits the field entirely and falls back to the ServiceAccount / cluster default.
- The UI and DB deployments are deliberately untouched: the UI keeps its existing `ui.automountServiceAccountToken: false`, and the DB never sets the field.

Why a single key rather than a separate one under `api.microservices`: `ms-deployment.yaml` already sources every other pod-level setting (`serviceAccountName`, `podSecurityContext`, `resources`, `nodeSelector`) from `.Values.api.*`, and a shared key keeps the microservices from drifting away from the API setting — that drift is what left `mlrun-alerts` unhealthy.

Note for reviewers: the `kindIs "bool"` guard means a string-typed override (`--set-string api.automountServiceAccountToken=false`) is silently ignored rather than rejected, since only `null` is intended as the "omit" value. This mirrors the existing `ui.automountServiceAccountToken` template, so changing it would mean touching the UI deployment too.

Verified with `helm lint` (clean) and `helm template`: the chief, worker and `alerts` microservice render `true`, `mlrun-db` omits the field, `mlrun-ui` stays `false`, and `--set api.automountServiceAccountToken=null` omits it from all three API deployments.